### PR TITLE
Add MCP implementations for HDF5, Slurm, and Node Hardware

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The capability is exposed through JSON-RPC 2.0 and can be accessed via:
   },
   "id": 1
 }
-
+```
 
 ## Implementation Details
 The implementation simulates HDF5 file operations without actually requiring real HDF5 files, making it suitable for testing and development.

--- a/hdf5_arman_behnam/README.md
+++ b/hdf5_arman_behnam/README.md
@@ -27,7 +27,7 @@ The capability is exposed through JSON-RPC 2.0 and can be accessed via:
   },
   "id": 1
 }
-
+```
 
 ## Implementation Details
-The implementation simulates HDF5 file operations without actually requiring real HDF5 files, making it suitable for testing and development.
+The implementation simulates HDF5 file operations without requiring real HDF5 files, making it suitable for testing and development.

--- a/hdf5_arman_behnam/pyproject.toml
+++ b/hdf5_arman_behnam/pyproject.toml
@@ -1,0 +1,25 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "mcp"
+version = "0.1.0"
+description = "Scientific MCP Server for connecting AI agents with scientific tools"
+requires-python = ">=3.10"
+dependencies = [
+    "fastapi>=0.104.0",
+    "uvicorn>=0.23.2",
+    "pytest>=7.4.0",
+    "httpx>=0.24.1",
+    "pytest-asyncio>=0.21.0"
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+python_files = "test_*.py"
+python_functions = "test_*"
+asyncio_mode = "auto"

--- a/hdf5_arman_behnam/src/capabilities/hdf5_handler.py
+++ b/hdf5_arman_behnam/src/capabilities/hdf5_handler.py
@@ -1,0 +1,27 @@
+import os
+import pathlib
+
+async def get_hdf5_data(params):
+    """Simulate HDF5 file access."""
+    path_pattern = params.get("path_pattern", "*.hdf5")
+    base_dir = params.get("base_dir", "/data")
+    
+    # Mock files for simulation
+    mock_files = [
+        f"{base_dir}/sim_run_123/output_00.hdf5",
+        f"{base_dir}/sim_run_123/output_01.hdf5",
+        f"{base_dir}/sim_run_124/output_00.hdf5"
+    ]
+    
+    # Filter based on pattern
+    matching_files = [f for f in mock_files if pathlib.Path(f).match(path_pattern)]
+    
+    return {
+        "resource_type": "hdf5",
+        "files": matching_files,
+        "count": len(matching_files),
+        "metadata": {
+            "base_dir": base_dir,
+            "pattern": path_pattern
+        }
+    }

--- a/hdf5_arman_behnam/src/mcp_handlers.py
+++ b/hdf5_arman_behnam/src/mcp_handlers.py
@@ -1,0 +1,114 @@
+from .capabilities import hdf5_handler, slurm_handler, node_hardware
+
+async def handle_list_resources(params):
+    """Handle mcp/listResources method."""
+    resources = [
+        {
+            "id": "hdf5",
+            "name": "HDF5 File Access",
+            "description": "Access to HDF5 scientific data files",
+            "type": "data_source"
+        }
+    ]
+    return {"resources": resources}
+
+async def handle_list_tools(params):
+    tools = [
+        {
+            "id": "slurm",
+            "name": "Slurm Job Scheduler",
+            "description": "Submit jobs to HPC cluster via Slurm",
+            "parameters": {
+                "script_path": {"type": "string", "description": "Path to job script"},
+                "cores": {"type": "integer", "description": "Number of CPU cores"}
+            }
+        },
+        {
+            "id": "node_hardware",
+            "name": "Node Hardware Info",
+            "description": "Get system hardware information",
+            "parameters": {}
+        }
+    ]
+    return {"tools": tools}
+
+
+async def handle_call_tool(params):
+    tool_id = params.get("tool_id")
+    tool_params = params.get("parameters", {})
+    
+    if tool_id == "slurm":
+        return await slurm_handler.submit_job(tool_params)
+    elif tool_id == "node_hardware":
+        return await node_hardware.get_system_info(tool_params)
+    else:
+        return {
+            "error": {
+                "code": -32602,
+                "message": f"Unknown tool: {tool_id}"
+            }
+        }
+
+async def handle_get_resource(params):
+    """Handle mcp/getResource method."""
+    resource_id = params.get("resource_id")
+    resource_params = params.get("parameters", {})
+    
+    if resource_id == "hdf5":
+        return await hdf5_handler.get_hdf5_data(resource_params)
+    else:
+        return {
+            "error": {
+                "code": -32602,
+                "message": f"Unknown resource: {resource_id}"
+            }
+        }
+
+MCP_METHODS = {
+    "mcp/listResources": handle_list_resources,
+    "mcp/callTool": handle_call_tool,
+    "mcp/listTools": handle_list_tools,
+    "mcp/getResource": handle_get_resource
+}
+
+async def handle_mcp_request(request):
+    """Handle MCP JSON-RPC 2.0 requests."""
+    if not all(k in request for k in ["jsonrpc", "method", "id"]):
+        return {
+            "jsonrpc": "2.0",
+            "error": {
+                "code": -32600,
+                "message": "Invalid Request"
+            },
+            "id": None
+        }
+    
+    if request["jsonrpc"] != "2.0":
+        return {
+            "jsonrpc": "2.0",
+            "error": {
+                "code": -32600,
+                "message": "Invalid Request: only JSON-RPC 2.0 supported"
+            },
+            "id": request.get("id")
+        }
+    
+    method = request["method"]
+    if method not in MCP_METHODS:
+        return {
+            "jsonrpc": "2.0",
+            "error": {
+                "code": -32601,
+                "message": f"Method '{method}' not found"
+            },
+            "id": request["id"]
+        }
+    
+    params = request.get("params", {})
+    result = await MCP_METHODS[method](params)
+    
+    return {
+        "jsonrpc": "2.0",
+        "result": result,
+        "id": request["id"]
+    }

--- a/hdf5_arman_behnam/src/server.py
+++ b/hdf5_arman_behnam/src/server.py
@@ -1,0 +1,28 @@
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+import uvicorn
+
+# Change absolute import to relative import
+from .mcp_handlers import handle_mcp_request
+
+app = FastAPI()
+
+@app.post("/mcp")
+async def mcp_endpoint(request: Request):
+    """Endpoint for MCP JSON-RPC 2.0 requests."""
+    try:
+        data = await request.json()
+        response = await handle_mcp_request(data)
+        return JSONResponse(content=response)
+    except Exception as e:
+        return JSONResponse(
+            content={
+                "jsonrpc": "2.0",
+                "error": {"code": -32603, "message": f"Internal error: {str(e)}"},
+                "id": None
+            },
+            status_code=500
+        )
+
+if __name__ == "__main__":
+    uvicorn.run("src.server:app", host="127.0.0.1", port=8000, reload=True)

--- a/hdf5_arman_behnam/tests/test_capabilities.py
+++ b/hdf5_arman_behnam/tests/test_capabilities.py
@@ -1,0 +1,51 @@
+import pytest
+from src.capabilities import hdf5_handler, slurm_handler, node_hardware
+@pytest.mark.asyncio
+async def test_hdf5_handler():
+    """Test HDF5 handler functionality."""
+    params = {"path_pattern": "*.hdf5"}
+    result = await hdf5_handler.get_hdf5_data(params)
+    
+    assert "resource_type" in result
+    assert result["resource_type"] == "hdf5"
+    assert "files" in result
+    assert isinstance(result["files"], list)
+    
+    params = {"path_pattern": "*_00.hdf5"}
+    result = await hdf5_handler.get_hdf5_data(params)
+    
+    assert all("_00.hdf5" in file for file in result["files"])
+
+@pytest.mark.asyncio
+async def test_slurm_handler():
+    """Test Slurm handler functionality."""
+    # Test successful job submission
+    params = {
+        "script_path": "/path/to/job.sh",
+        "cores": 4
+    }
+    result = await slurm_handler.submit_job(params)
+    
+    assert "tool" in result
+    assert result["tool"] == "slurm"
+    assert "job_id" in result
+    assert "status" in result
+    assert result["status"] == "submitted"
+    
+    params = {} # Missing required param
+    result = await slurm_handler.submit_job(params)
+    
+    assert "error" in result
+    assert "code" in result["error"]
+    assert "message" in result["error"]
+
+@pytest.mark.asyncio
+async def test_node_hardware():
+    """Test Node Hardware functionality."""
+    result = await node_hardware.get_system_info({})
+    
+    assert "tool" in result
+    assert result["tool"] == "node_hardware"
+    assert "cpu_cores" in result
+    assert isinstance(result["cpu_cores"], int)
+    assert "memory_gb" in result

--- a/node_hardware_arman_behnam/README.md
+++ b/node_hardware_arman_behnam/README.md
@@ -1,0 +1,26 @@
+# Node Hardware MCP Capability
+
+## Overview
+This MCP capability provides system information retrieval functionality, enabling AI agents to obtain hardware details of the host system.
+
+## Features
+- CPU cores count retrieval
+- System memory information
+- Platform details reporting
+
+## API
+- Tool ID: `node_hardware`
+- Method: `mcp/callTool`
+
+### Example Request
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "mcp/callTool",
+  "params": {
+    "tool_id": "node_hardware",
+    "parameters": {}
+  },
+  "id": 1
+}
+```

--- a/node_hardware_arman_behnam/pyproject.toml
+++ b/node_hardware_arman_behnam/pyproject.toml
@@ -1,0 +1,25 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "mcp"
+version = "0.1.0"
+description = "Scientific MCP Server for connecting AI agents with scientific tools"
+requires-python = ">=3.10"
+dependencies = [
+    "fastapi>=0.104.0",
+    "uvicorn>=0.23.2",
+    "pytest>=7.4.0",
+    "httpx>=0.24.1",
+    "pytest-asyncio>=0.21.0"
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+python_files = "test_*.py"
+python_functions = "test_*"
+asyncio_mode = "auto"

--- a/node_hardware_arman_behnam/src/capabilities/node_hardware.py
+++ b/node_hardware_arman_behnam/src/capabilities/node_hardware.py
@@ -1,0 +1,11 @@
+import os
+import psutil
+
+async def get_system_info(params):
+    """Get system hardware information."""
+    return {
+        "tool": "node_hardware",
+        "cpu_cores": os.cpu_count(),
+        "memory_gb": round(psutil.virtual_memory().total / (1024**3), 2),
+        "platform": os.name
+    }

--- a/node_hardware_arman_behnam/src/mcp_handlers.py
+++ b/node_hardware_arman_behnam/src/mcp_handlers.py
@@ -1,0 +1,114 @@
+from .capabilities import hdf5_handler, slurm_handler, node_hardware
+
+async def handle_list_resources(params):
+    """Handle mcp/listResources method."""
+    resources = [
+        {
+            "id": "hdf5",
+            "name": "HDF5 File Access",
+            "description": "Access to HDF5 scientific data files",
+            "type": "data_source"
+        }
+    ]
+    return {"resources": resources}
+
+async def handle_list_tools(params):
+    tools = [
+        {
+            "id": "slurm",
+            "name": "Slurm Job Scheduler",
+            "description": "Submit jobs to HPC cluster via Slurm",
+            "parameters": {
+                "script_path": {"type": "string", "description": "Path to job script"},
+                "cores": {"type": "integer", "description": "Number of CPU cores"}
+            }
+        },
+        {
+            "id": "node_hardware",
+            "name": "Node Hardware Info",
+            "description": "Get system hardware information",
+            "parameters": {}
+        }
+    ]
+    return {"tools": tools}
+
+
+async def handle_call_tool(params):
+    tool_id = params.get("tool_id")
+    tool_params = params.get("parameters", {})
+    
+    if tool_id == "slurm":
+        return await slurm_handler.submit_job(tool_params)
+    elif tool_id == "node_hardware":
+        return await node_hardware.get_system_info(tool_params)
+    else:
+        return {
+            "error": {
+                "code": -32602,
+                "message": f"Unknown tool: {tool_id}"
+            }
+        }
+
+async def handle_get_resource(params):
+    """Handle mcp/getResource method."""
+    resource_id = params.get("resource_id")
+    resource_params = params.get("parameters", {})
+    
+    if resource_id == "hdf5":
+        return await hdf5_handler.get_hdf5_data(resource_params)
+    else:
+        return {
+            "error": {
+                "code": -32602,
+                "message": f"Unknown resource: {resource_id}"
+            }
+        }
+
+MCP_METHODS = {
+    "mcp/listResources": handle_list_resources,
+    "mcp/callTool": handle_call_tool,
+    "mcp/listTools": handle_list_tools,
+    "mcp/getResource": handle_get_resource
+}
+
+async def handle_mcp_request(request):
+    """Handle MCP JSON-RPC 2.0 requests."""
+    if not all(k in request for k in ["jsonrpc", "method", "id"]):
+        return {
+            "jsonrpc": "2.0",
+            "error": {
+                "code": -32600,
+                "message": "Invalid Request"
+            },
+            "id": None
+        }
+    
+    if request["jsonrpc"] != "2.0":
+        return {
+            "jsonrpc": "2.0",
+            "error": {
+                "code": -32600,
+                "message": "Invalid Request: only JSON-RPC 2.0 supported"
+            },
+            "id": request.get("id")
+        }
+    
+    method = request["method"]
+    if method not in MCP_METHODS:
+        return {
+            "jsonrpc": "2.0",
+            "error": {
+                "code": -32601,
+                "message": f"Method '{method}' not found"
+            },
+            "id": request["id"]
+        }
+    
+    params = request.get("params", {})
+    result = await MCP_METHODS[method](params)
+    
+    return {
+        "jsonrpc": "2.0",
+        "result": result,
+        "id": request["id"]
+    }

--- a/node_hardware_arman_behnam/src/server.py
+++ b/node_hardware_arman_behnam/src/server.py
@@ -1,0 +1,28 @@
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+import uvicorn
+
+# Change absolute import to relative import
+from .mcp_handlers import handle_mcp_request
+
+app = FastAPI()
+
+@app.post("/mcp")
+async def mcp_endpoint(request: Request):
+    """Endpoint for MCP JSON-RPC 2.0 requests."""
+    try:
+        data = await request.json()
+        response = await handle_mcp_request(data)
+        return JSONResponse(content=response)
+    except Exception as e:
+        return JSONResponse(
+            content={
+                "jsonrpc": "2.0",
+                "error": {"code": -32603, "message": f"Internal error: {str(e)}"},
+                "id": None
+            },
+            status_code=500
+        )
+
+if __name__ == "__main__":
+    uvicorn.run("src.server:app", host="127.0.0.1", port=8000, reload=True)

--- a/node_hardware_arman_behnam/tests/test_capabilities.py
+++ b/node_hardware_arman_behnam/tests/test_capabilities.py
@@ -1,0 +1,51 @@
+import pytest
+from src.capabilities import hdf5_handler, slurm_handler, node_hardware
+@pytest.mark.asyncio
+async def test_hdf5_handler():
+    """Test HDF5 handler functionality."""
+    params = {"path_pattern": "*.hdf5"}
+    result = await hdf5_handler.get_hdf5_data(params)
+    
+    assert "resource_type" in result
+    assert result["resource_type"] == "hdf5"
+    assert "files" in result
+    assert isinstance(result["files"], list)
+    
+    params = {"path_pattern": "*_00.hdf5"}
+    result = await hdf5_handler.get_hdf5_data(params)
+    
+    assert all("_00.hdf5" in file for file in result["files"])
+
+@pytest.mark.asyncio
+async def test_slurm_handler():
+    """Test Slurm handler functionality."""
+    # Test successful job submission
+    params = {
+        "script_path": "/path/to/job.sh",
+        "cores": 4
+    }
+    result = await slurm_handler.submit_job(params)
+    
+    assert "tool" in result
+    assert result["tool"] == "slurm"
+    assert "job_id" in result
+    assert "status" in result
+    assert result["status"] == "submitted"
+    
+    params = {} # Missing required param
+    result = await slurm_handler.submit_job(params)
+    
+    assert "error" in result
+    assert "code" in result["error"]
+    assert "message" in result["error"]
+
+@pytest.mark.asyncio
+async def test_node_hardware():
+    """Test Node Hardware functionality."""
+    result = await node_hardware.get_system_info({})
+    
+    assert "tool" in result
+    assert result["tool"] == "node_hardware"
+    assert "cpu_cores" in result
+    assert isinstance(result["cpu_cores"], int)
+    assert "memory_gb" in result

--- a/slurm_arman_behnam/README.md
+++ b/slurm_arman_behnam/README.md
@@ -1,0 +1,33 @@
+# Slurm MCP Capability
+
+## Overview
+This MCP capability enables job submission to HPC clusters via Slurm, allowing AI agents to interact with high-performance computing resources.
+
+## Features
+- Job submission with script path and core count specification
+- Job ID generation and tracking
+- Job status monitoring and retrieval
+
+## API
+- Tool ID: `slurm`
+- Method: `mcp/callTool`
+
+### Example Request
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "mcp/callTool",
+  "params": {
+    "tool_id": "slurm",
+    "parameters": {
+      "script_path": "/path/to/script.sh",
+      "cores": 4
+    }
+  },
+  "id": 1
+}
+```
+
+
+## Implementation Details
+The implementation simulates Slurm job submission and management for testing and development.

--- a/slurm_arman_behnam/pyproject.toml
+++ b/slurm_arman_behnam/pyproject.toml
@@ -1,0 +1,25 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "mcp"
+version = "0.1.0"
+description = "Scientific MCP Server for connecting AI agents with scientific tools"
+requires-python = ">=3.10"
+dependencies = [
+    "fastapi>=0.104.0",
+    "uvicorn>=0.23.2",
+    "pytest>=7.4.0",
+    "httpx>=0.24.1",
+    "pytest-asyncio>=0.21.0"
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+python_files = "test_*.py"
+python_functions = "test_*"
+asyncio_mode = "auto"

--- a/slurm_arman_behnam/src/capabilities/slurm_handler.py
+++ b/slurm_arman_behnam/src/capabilities/slurm_handler.py
@@ -1,0 +1,38 @@
+import random
+
+async def submit_job(params):
+    """Simulate Slurm job submission."""
+    script_path = params.get("script_path", "")
+    cores = params.get("cores", 1)
+    
+    if not script_path:
+        return {
+            "error": {
+                "code": 400,
+                "message": "Missing required parameter: script_path"
+            }
+        }
+    
+    try:
+        cmd = f"sbatch --ntasks={cores} {script_path}"
+        print(f"Would execute: {cmd}")
+        
+        job_id = random.randint(10000, 99999)
+        
+        return {
+            "tool": "slurm",
+            "job_id": job_id,
+            "status": "submitted",
+            "metadata": {
+                "script": script_path,
+                "cores": cores,
+                "queue": "compute"
+            }
+        }
+    except Exception as e:
+        return {
+            "error": {
+                "code": 500,
+                "message": f"Job submission failed: {str(e)}"
+            }
+        }

--- a/slurm_arman_behnam/src/mcp_handlers.py
+++ b/slurm_arman_behnam/src/mcp_handlers.py
@@ -1,0 +1,114 @@
+from .capabilities import hdf5_handler, slurm_handler, node_hardware
+
+async def handle_list_resources(params):
+    """Handle mcp/listResources method."""
+    resources = [
+        {
+            "id": "hdf5",
+            "name": "HDF5 File Access",
+            "description": "Access to HDF5 scientific data files",
+            "type": "data_source"
+        }
+    ]
+    return {"resources": resources}
+
+async def handle_list_tools(params):
+    tools = [
+        {
+            "id": "slurm",
+            "name": "Slurm Job Scheduler",
+            "description": "Submit jobs to HPC cluster via Slurm",
+            "parameters": {
+                "script_path": {"type": "string", "description": "Path to job script"},
+                "cores": {"type": "integer", "description": "Number of CPU cores"}
+            }
+        },
+        {
+            "id": "node_hardware",
+            "name": "Node Hardware Info",
+            "description": "Get system hardware information",
+            "parameters": {}
+        }
+    ]
+    return {"tools": tools}
+
+
+async def handle_call_tool(params):
+    tool_id = params.get("tool_id")
+    tool_params = params.get("parameters", {})
+    
+    if tool_id == "slurm":
+        return await slurm_handler.submit_job(tool_params)
+    elif tool_id == "node_hardware":
+        return await node_hardware.get_system_info(tool_params)
+    else:
+        return {
+            "error": {
+                "code": -32602,
+                "message": f"Unknown tool: {tool_id}"
+            }
+        }
+
+async def handle_get_resource(params):
+    """Handle mcp/getResource method."""
+    resource_id = params.get("resource_id")
+    resource_params = params.get("parameters", {})
+    
+    if resource_id == "hdf5":
+        return await hdf5_handler.get_hdf5_data(resource_params)
+    else:
+        return {
+            "error": {
+                "code": -32602,
+                "message": f"Unknown resource: {resource_id}"
+            }
+        }
+
+MCP_METHODS = {
+    "mcp/listResources": handle_list_resources,
+    "mcp/callTool": handle_call_tool,
+    "mcp/listTools": handle_list_tools,
+    "mcp/getResource": handle_get_resource
+}
+
+async def handle_mcp_request(request):
+    """Handle MCP JSON-RPC 2.0 requests."""
+    if not all(k in request for k in ["jsonrpc", "method", "id"]):
+        return {
+            "jsonrpc": "2.0",
+            "error": {
+                "code": -32600,
+                "message": "Invalid Request"
+            },
+            "id": None
+        }
+    
+    if request["jsonrpc"] != "2.0":
+        return {
+            "jsonrpc": "2.0",
+            "error": {
+                "code": -32600,
+                "message": "Invalid Request: only JSON-RPC 2.0 supported"
+            },
+            "id": request.get("id")
+        }
+    
+    method = request["method"]
+    if method not in MCP_METHODS:
+        return {
+            "jsonrpc": "2.0",
+            "error": {
+                "code": -32601,
+                "message": f"Method '{method}' not found"
+            },
+            "id": request["id"]
+        }
+    
+    params = request.get("params", {})
+    result = await MCP_METHODS[method](params)
+    
+    return {
+        "jsonrpc": "2.0",
+        "result": result,
+        "id": request["id"]
+    }

--- a/slurm_arman_behnam/src/server.py
+++ b/slurm_arman_behnam/src/server.py
@@ -1,0 +1,28 @@
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+import uvicorn
+
+# Change absolute import to relative import
+from .mcp_handlers import handle_mcp_request
+
+app = FastAPI()
+
+@app.post("/mcp")
+async def mcp_endpoint(request: Request):
+    """Endpoint for MCP JSON-RPC 2.0 requests."""
+    try:
+        data = await request.json()
+        response = await handle_mcp_request(data)
+        return JSONResponse(content=response)
+    except Exception as e:
+        return JSONResponse(
+            content={
+                "jsonrpc": "2.0",
+                "error": {"code": -32603, "message": f"Internal error: {str(e)}"},
+                "id": None
+            },
+            status_code=500
+        )
+
+if __name__ == "__main__":
+    uvicorn.run("src.server:app", host="127.0.0.1", port=8000, reload=True)

--- a/slurm_arman_behnam/tests/test_capabilities.py
+++ b/slurm_arman_behnam/tests/test_capabilities.py
@@ -1,0 +1,51 @@
+import pytest
+from src.capabilities import hdf5_handler, slurm_handler, node_hardware
+@pytest.mark.asyncio
+async def test_hdf5_handler():
+    """Test HDF5 handler functionality."""
+    params = {"path_pattern": "*.hdf5"}
+    result = await hdf5_handler.get_hdf5_data(params)
+    
+    assert "resource_type" in result
+    assert result["resource_type"] == "hdf5"
+    assert "files" in result
+    assert isinstance(result["files"], list)
+    
+    params = {"path_pattern": "*_00.hdf5"}
+    result = await hdf5_handler.get_hdf5_data(params)
+    
+    assert all("_00.hdf5" in file for file in result["files"])
+
+@pytest.mark.asyncio
+async def test_slurm_handler():
+    """Test Slurm handler functionality."""
+    # Test successful job submission
+    params = {
+        "script_path": "/path/to/job.sh",
+        "cores": 4
+    }
+    result = await slurm_handler.submit_job(params)
+    
+    assert "tool" in result
+    assert result["tool"] == "slurm"
+    assert "job_id" in result
+    assert "status" in result
+    assert result["status"] == "submitted"
+    
+    params = {} # Missing required param
+    result = await slurm_handler.submit_job(params)
+    
+    assert "error" in result
+    assert "code" in result["error"]
+    assert "message" in result["error"]
+
+@pytest.mark.asyncio
+async def test_node_hardware():
+    """Test Node Hardware functionality."""
+    result = await node_hardware.get_system_info({})
+    
+    assert "tool" in result
+    assert result["tool"] == "node_hardware"
+    assert "cpu_cores" in result
+    assert isinstance(result["cpu_cores"], int)
+    assert "memory_gb" in result


### PR DESCRIPTION
# MCP Capability Implementations
This PR adds implementations for three Scientific MCP capabilities:

1. HDF5 (Data-focused): Provides file system interaction for HDF5 files with path pattern searching and metadata retrieval.
2. Slurm (Tool-focused): Enables job submission to HPC clusters with script path and core count specification, job tracking, and status reporting.
3. Node Hardware (Tool-focused): System information retrieval capability that reports CPU cores, memory information, and platform details.

All implementations include:

- JSON-RPC 2.0 API endpoints
- Unit tests
- Mock data capabilities for testing
- Basic error handling