### PR TITLE
Add PDF download capabilities to ArXiv MCP

### DIFF
--- a/Arxiv/README.md
+++ b/Arxiv/README.md
@@ -1,119 +1,198 @@
 
-# Scientific MCP Server
+# ArXiv MCP Server
 
-##  Implemented MCP Capabilities
+A comprehensive Model Context Protocol (MCP) server for accessing and analyzing research papers from ArXiv. Provides advanced search capabilities, paper analysis, and citation management tools.
 
-The following capabilities have been implemented:
+## Implemented MCP Capabilities
 
-| Capability    | Type     | Description                                                              |
-|---------------|----------|--------------------------------------------------------------------------|
+| Capability | Type | Description |
+|------------|------|-------------|
+| `search_arxiv` | Tool | Search papers by category (e.g., 'cs.AI', 'physics.astro-ph') |
+| `get_recent_papers` | Tool | Get recent papers from a specific ArXiv category |
+| `search_papers_by_author` | Tool | Search papers by author name |
+| `search_by_title` | Tool | Search papers by title keywords |
+| `search_by_abstract` | Tool | Search papers by abstract keywords |
+| `search_by_subject` | Tool | Search papers by subject classification |
+| `search_date_range` | Tool | Search papers within a specific date range |
+| `get_paper_details` | Tool | Get detailed information about a specific paper |
+| `export_to_bibtex` | Tool | Export search results to BibTeX format |
+| `find_similar_papers` | Tool | Find papers similar to a reference paper |
+| `download_paper_pdf` | Tool | Download the PDF of a paper from ArXiv |
+| `get_pdf_url` | Tool | Get the direct PDF URL for a paper |
+| `download_multiple_pdfs` | Tool | Download multiple PDFs concurrently |
 
-| `arxiv`       | Data     | Fetches 3 recent research papers via the Arxiv API using `httpx`.        |
+## Quick Start
 
+### Installation
 
-## Setup Instructions (Using `uv`)
-
-1. Clone the repository:
+1. **Clone the repository:**
    ```bash
    git clone https://github.com/iowarp/scientific-mcps.git
-   cd arxiv
+   cd scientific-mcps/Arxiv
    ```
 
-2. Create a virtual environment with `uv`:
-   ```bash
-   uv venv
-   ```
-
-3. Install dependencies:
+2. **Install dependencies:**
    ```bash
    uv sync
    ```
 
-4. (Optional) Generate a lockfile:
+3. **Test the installation:**
    ```bash
-   uv lock
+   uv run python demo.py
    ```
-   
 
-## How to Run the MCP Server
-1. **Activate your virtual environment**:
+### Running the Server
 
 ```bash
-.venv\Scripts\activate     #On Windows
-source .venv/bin/activate  #On macOS/Linux
-```
-2. **Start the server using uvicorn**:
-```
-uvicorn src.server:app --reload
-```
-The MCP server will start on:
-```
-http://localhost:8000/mcp
+# Using the script
+uv run arxiv-mcp
+
+# Direct execution
+uv run python src/arxiv_mcp/server.py
 ```
 
-You can send JSON-RPC POST requests to this endpoint using Postman, curl, or test clients.
+## Usage Examples
 
+### Search by Category
+```python
+# Search for recent AI papers
+search_arxiv("cs.AI", max_results=5)
+```
 
-## How to Run the Tests
+### Search by Title
+```python
+# Find papers about machine learning
+search_by_title("machine learning", max_results=10)
+```
 
-1. **Activate the virtual environment**(created using `uv venv`):
+### Get Paper Details
+```python
+# Get details for a specific paper
+get_paper_details("1706.03762")  # Attention Is All You Need
+```
+
+### Export to BibTeX
+```python
+# Export search results for citation
+export_to_bibtex(papers_list)
+```
+
+### Download Paper PDFs
+```python
+# Download a single paper PDF
+download_paper_pdf("1706.03762")  # Attention Is All You Need
+
+# Get PDF URL without downloading
+get_pdf_url("1706.03762")
+
+# Download multiple PDFs concurrently
+download_multiple_pdfs('["1706.03762", "2301.12345"]', download_path="/path/to/save")
+```
+
+## Common ArXiv Categories
+
+- `cs.AI` - Artificial Intelligence
+- `cs.LG` - Machine Learning
+- `cs.CV` - Computer Vision and Pattern Recognition
+- `cs.CL` - Computation and Language
+- `cs.CR` - Cryptography and Security
+- `physics.astro-ph` - Astrophysics
+- `math.CO` - Combinatorics
+- `q-bio.QM` - Quantitative Methods
+
+## Testing
+
+Run the comprehensive test suite:
 
 ```bash
-.venv\Scripts\activate     #On Windows
-source .venv/bin/activate  #On macOS/Linux
+# Run all tests
+uv run pytest
+
+# Run specific test files
+uv run pytest tests/test_category_search.py
+uv run pytest tests/test_integration.py
+
+# Run with verbose output
+uv run pytest -v
 ```
 
-2. **Run all tests using `pytest`**:
+## Configuration
 
-```bash
-pytest
+The server supports environment variables:
+
+- `MCP_TRANSPORT`: Transport type (`stdio` or `sse`)
+- `MCP_SSE_HOST`: Host for SSE transport (default: `0.0.0.0`)
+- `MCP_SSE_PORT`: Port for SSE transport (default: `8000`)
+
+## Integration with MCP Clients
+
+### Claude Desktop
+Add to your configuration:
+```json
+{
+  "arxiv-mcp": {
+    "command": "uv",
+    "args": [
+      "--directory", "/path/to/scientific-mcps/Arxiv",
+      "run", "arxiv-mcp"
+    ]
+  }
+}
 ```
 
-# MCP Capabilities
+### Other MCP Clients
+The server uses stdio transport by default and is compatible with any MCP client.
 
-| Method              | Description                                 |
-|---------------------|---------------------------------------------|
-| `mcp/listTools`     | Lists tool-oriented capabilities only       |
-| `mcp/listDataSources` | Lists data-oriented capabilities only    |
-
-These are accessible via the same `/mcp` endpoint using the standard JSON-RPC 2.0 structure.
-
-- Implemented MCP capabilities  
-    - `arxiv` (data)
-
-- Implemented robust error handling using JSON-RPC 2.0 error format  
-  -  Standardized error codes:
-    - `-32601` : method/tool not found
-    - `-32602` : invalid or missing parameters
-    - `-32000/-32001` : general internal errors
-
-- Asynchronous logic in all capability handlers  
-  - All capability functions are defined using `async def`
-  - `arxiv` uses `httpx.AsyncClient()` for real API calls
-
-##  Assumptions and Notes
-
-- Arxiv responses are summarized and do not include full XML parsing.
-- All handlers are asynchronous and return MCP-compliant JSON responses.
-- Proper error responses are implemented for missing parameters or tool names.
-- JSON-RPC error codes include: `-32601` (method not found), `-32602` (invalid params), and `-32000` (internal errors).
-
----
-
-## Repository Structure
+## Project Structure
 
 ```
-scientific-mcp-server/
-├── pyproject.toml
+Arxiv/
 ├── README.md
+├── pyproject.toml
+├── demo.py
+├── docs/
+│   └── basic_install.md
+├── assets/
+├── data/
 ├── src/
-│   ├── server.py
-│   ├── mcp_handlers.py
-│   └── capabilities/
-│       ├── arxiv_handler.py
-│    
-├── tests/
-│   ├── test_mcp_handlers.py
-│   └── test_capabilities.py
-└── .gitignore
+│   └── arxiv_mcp/
+│       ├── __init__.py
+│       ├── server.py
+│       ├── mcp_handlers.py
+│       └── capabilities/
+│           ├── __init__.py
+│           ├── arxiv_base.py
+│           ├── category_search.py
+│           ├── text_search.py
+│           ├── date_search.py
+│           ├── paper_details.py
+│           └── export_utils.py
+└── tests/
+    ├── __init__.py
+    ├── test_capabilities.py
+    ├── test_mcp_handlers.py
+    ├── test_category_search.py
+    ├── test_text_search.py
+    ├── test_paper_details.py
+    ├── test_export_utils.py
+    └── test_integration.py
 ```
+
+## Features
+
+- **Advanced Search**: Multiple search methods including category, title, abstract, author, and date range
+- **Paper Analysis**: Detailed paper information and similarity detection
+- **Citation Management**: BibTeX export for research bibliography
+- **Comprehensive Testing**: Full test coverage with integration tests
+- **Error Handling**: Robust error handling with informative messages
+- **Async Support**: Fully asynchronous for optimal performance
+
+## Documentation
+
+- [Installation Guide](docs/basic_install.md)
+- [API Documentation](src/arxiv_mcp/capabilities/)
+- [Test Examples](tests/)
+
+## License
+
+MIT License - see the main repository for details.

--- a/Arxiv/demo_pdf.py
+++ b/Arxiv/demo_pdf.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""
+Demo script showing PDF download capabilities.
+"""
+import asyncio
+import tempfile
+import os
+from src.arxiv_mcp.capabilities.pdf_download import (
+    download_paper_pdf,
+    get_pdf_url,
+    download_multiple_pdfs
+)
+
+
+async def main():
+    """Demo the PDF download capabilities."""
+    print("ArXiv MCP PDF Download Demo")
+    print("=" * 40)
+    
+    # Example ArXiv ID - "Attention Is All You Need"
+    arxiv_id = "1706.03762"
+    
+    try:
+        # Demo 1: Get PDF URL
+        print(f"\n1. Getting PDF URL for paper {arxiv_id}...")
+        url_result = await get_pdf_url(arxiv_id)
+        if url_result['success']:
+            print(f"   ✓ PDF URL: {url_result['pdf_url']}")
+            print(f"   ✓ Content Type: {url_result['content_type']}")
+            print(f"   ✓ Content Length: {url_result['content_length']} bytes")
+        else:
+            print(f"   ✗ Failed to get PDF URL")
+        
+        # Demo 2: Download single PDF
+        print(f"\n2. Downloading PDF for paper {arxiv_id}...")
+        with tempfile.TemporaryDirectory() as temp_dir:
+            download_result = await download_paper_pdf(arxiv_id, temp_dir)
+            if download_result['success']:
+                print(f"   ✓ Downloaded to: {download_result['file_path']}")
+                print(f"   ✓ File size: {download_result['file_size']} bytes")
+                print(f"   ✓ Filename: {download_result['filename']}")
+            else:
+                print(f"   ✗ Failed to download PDF")
+        
+        # Demo 3: Download multiple PDFs
+        print(f"\n3. Downloading multiple PDFs...")
+        arxiv_ids = ["1706.03762", "2301.12345"]  # Second might not exist
+        with tempfile.TemporaryDirectory() as temp_dir:
+            batch_result = await download_multiple_pdfs(arxiv_ids, temp_dir, max_concurrent=2)
+            if batch_result['success']:
+                print(f"   ✓ Total requested: {batch_result['total_requested']}")
+                print(f"   ✓ Successful downloads: {batch_result['successful_downloads']}")
+                print(f"   ✓ Failed downloads: {batch_result['failed_downloads']}")
+                print(f"   ✓ Download path: {batch_result['download_path']}")
+                
+                # Show results for each paper
+                for result in batch_result['results']:
+                    if result.get('success'):
+                        print(f"     ✓ {result['arxiv_id']}: {result['filename']}")
+                    else:
+                        print(f"     ✗ {result['arxiv_id']}: {result.get('error', 'Unknown error')}")
+            else:
+                print(f"   ✗ Batch download failed")
+        
+    except Exception as e:
+        print(f"Demo failed: {e}")
+    
+    print("\nDemo completed!")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/Arxiv/src/arxiv_mcp/capabilities/pdf_download.py
+++ b/Arxiv/src/arxiv_mcp/capabilities/pdf_download.py
@@ -1,0 +1,191 @@
+"""
+ArXiv PDF download and management capabilities.
+"""
+import os
+import httpx
+from typing import Dict, Any, Optional
+import logging
+from urllib.parse import urlparse
+import asyncio
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+async def download_paper_pdf(arxiv_id: str, download_path: str = None) -> Dict[str, Any]:
+    """
+    Download the PDF of a paper from ArXiv.
+    
+    Args:
+        arxiv_id: ArXiv paper ID (e.g., '2301.12345' or 'cs/0501001')
+        download_path: Optional path to save the PDF. If None, saves to current directory.
+        
+    Returns:
+        Dictionary containing download information
+    """
+    try:
+        # Clean the ArXiv ID to extract just the ID part
+        clean_id = arxiv_id.split('/')[-1] if '/' in arxiv_id else arxiv_id
+        if 'arxiv.org' in clean_id:
+            clean_id = clean_id.split('/')[-1]
+        
+        # Construct PDF URL
+        pdf_url = f"https://arxiv.org/pdf/{clean_id}.pdf"
+        
+        # Set up download path
+        if download_path is None:
+            download_path = os.getcwd()
+        
+        # Ensure download directory exists
+        Path(download_path).mkdir(parents=True, exist_ok=True)
+        
+        # Generate filename
+        filename = f"{clean_id}.pdf"
+        full_path = os.path.join(download_path, filename)
+        
+        # Download the PDF
+        async with httpx.AsyncClient(timeout=60.0, follow_redirects=True) as client:
+            logger.info(f"Downloading PDF for ArXiv ID: {clean_id}")
+            response = await client.get(pdf_url)
+            response.raise_for_status()
+            
+            # Check if the response is actually a PDF
+            content_type = response.headers.get('content-type', '')
+            if 'application/pdf' not in content_type:
+                raise Exception(f"URL did not return a PDF file. Content-Type: {content_type}")
+            
+            # Save the PDF file
+            with open(full_path, 'wb') as f:
+                f.write(response.content)
+            
+            file_size = os.path.getsize(full_path)
+            
+            return {
+                'success': True,
+                'arxiv_id': clean_id,
+                'download_url': pdf_url,
+                'file_path': full_path,
+                'filename': filename,
+                'file_size': file_size,
+                'message': f"Successfully downloaded PDF for paper '{clean_id}' to {full_path}"
+            }
+            
+    except httpx.HTTPStatusError as e:
+        logger.error(f"HTTP error downloading PDF: {e.response.status_code}")
+        if e.response.status_code == 404:
+            raise Exception(f"PDF not found for ArXiv ID '{arxiv_id}'. Paper may not exist or PDF may not be available.")
+        else:
+            raise Exception(f"HTTP error {e.response.status_code} downloading PDF")
+    except httpx.TimeoutException:
+        logger.error("PDF download timed out")
+        raise Exception("PDF download timed out")
+    except Exception as e:
+        logger.error(f"Error downloading PDF: {str(e)}")
+        raise Exception(f"Failed to download PDF: {str(e)}")
+
+
+async def get_pdf_url(arxiv_id: str) -> Dict[str, Any]:
+    """
+    Get the direct PDF URL for a paper without downloading it.
+    
+    Args:
+        arxiv_id: ArXiv paper ID (e.g., '2301.12345' or 'cs/0501001')
+        
+    Returns:
+        Dictionary containing PDF URL information
+    """
+    try:
+        # Clean the ArXiv ID
+        clean_id = arxiv_id.split('/')[-1] if '/' in arxiv_id else arxiv_id
+        if 'arxiv.org' in clean_id:
+            clean_id = clean_id.split('/')[-1]
+        
+        # Construct PDF URL
+        pdf_url = f"https://arxiv.org/pdf/{clean_id}.pdf"
+        
+        # Verify the URL exists
+        async with httpx.AsyncClient(timeout=30.0, follow_redirects=True) as client:
+            logger.info(f"Checking PDF availability for ArXiv ID: {clean_id}")
+            response = await client.head(pdf_url)
+            response.raise_for_status()
+            
+            content_type = response.headers.get('content-type', '')
+            content_length = response.headers.get('content-length', 'unknown')
+            
+            return {
+                'success': True,
+                'arxiv_id': clean_id,
+                'pdf_url': pdf_url,
+                'content_type': content_type,
+                'content_length': content_length,
+                'message': f"PDF is available for paper '{clean_id}'"
+            }
+            
+    except httpx.HTTPStatusError as e:
+        logger.error(f"HTTP error checking PDF: {e.response.status_code}")
+        if e.response.status_code == 404:
+            raise Exception(f"PDF not found for ArXiv ID '{arxiv_id}'. Paper may not exist or PDF may not be available.")
+        else:
+            raise Exception(f"HTTP error {e.response.status_code} checking PDF availability")
+    except Exception as e:
+        logger.error(f"Error checking PDF availability: {str(e)}")
+        raise Exception(f"Failed to check PDF availability: {str(e)}")
+
+
+async def download_multiple_pdfs(arxiv_ids: list, download_path: str = None, max_concurrent: int = 3) -> Dict[str, Any]:
+    """
+    Download multiple PDFs concurrently with rate limiting.
+    
+    Args:
+        arxiv_ids: List of ArXiv paper IDs
+        download_path: Optional path to save PDFs
+        max_concurrent: Maximum number of concurrent downloads
+        
+    Returns:
+        Dictionary containing download results
+    """
+    try:
+        if not arxiv_ids:
+            raise Exception("No ArXiv IDs provided")
+        
+        # Set up download path
+        if download_path is None:
+            download_path = os.getcwd()
+        
+        Path(download_path).mkdir(parents=True, exist_ok=True)
+        
+        # Create semaphore for rate limiting
+        semaphore = asyncio.Semaphore(max_concurrent)
+        
+        async def download_with_semaphore(arxiv_id: str):
+            async with semaphore:
+                try:
+                    return await download_paper_pdf(arxiv_id, download_path)
+                except Exception as e:
+                    return {
+                        'success': False,
+                        'arxiv_id': arxiv_id,
+                        'error': str(e)
+                    }
+        
+        # Execute downloads concurrently
+        logger.info(f"Starting concurrent download of {len(arxiv_ids)} PDFs")
+        results = await asyncio.gather(*[download_with_semaphore(arxiv_id) for arxiv_id in arxiv_ids])
+        
+        # Summarize results
+        successful = [r for r in results if r.get('success')]
+        failed = [r for r in results if not r.get('success')]
+        
+        return {
+            'success': True,
+            'total_requested': len(arxiv_ids),
+            'successful_downloads': len(successful),
+            'failed_downloads': len(failed),
+            'download_path': download_path,
+            'results': results,
+            'message': f"Downloaded {len(successful)} of {len(arxiv_ids)} PDFs successfully"
+        }
+        
+    except Exception as e:
+        logger.error(f"Error in batch PDF download: {str(e)}")
+        raise Exception(f"Batch PDF download failed: {str(e)}")

--- a/Arxiv/src/arxiv_mcp/mcp_handlers.py
+++ b/Arxiv/src/arxiv_mcp/mcp_handlers.py
@@ -1,0 +1,333 @@
+"""
+MCP handlers for ArXiv research paper search and retrieval.
+These handlers wrap the ArXiv capabilities for MCP protocol compliance.
+"""
+import json
+from typing import Dict, Any, List
+from capabilities.category_search import search_arxiv, get_recent_papers, search_by_subject
+from capabilities.text_search import search_by_title, search_by_abstract, search_papers_by_author
+from capabilities.date_search import search_date_range
+from capabilities.paper_details import get_paper_details, find_similar_papers
+from capabilities.export_utils import export_to_bibtex
+from capabilities.pdf_download import download_paper_pdf, get_pdf_url, download_multiple_pdfs
+
+
+async def search_arxiv_handler(query: str = "cs.AI", max_results: int = 5) -> Dict[str, Any]:
+    """
+    Handler wrapping the ArXiv search capability for MCP.
+    Returns search results or an error payload on failure.
+    
+    Args:
+        query: Search query or category
+        max_results: Maximum number of results to return
+        
+    Returns:
+        MCP-compliant response dictionary
+    """
+    try:
+        result = await search_arxiv(query, max_results)
+        return result
+    except Exception as e:
+        return {
+            "content": [{"text": json.dumps({"error": str(e)})}],
+            "_meta": {"tool": "search_arxiv", "error": type(e).__name__},
+            "isError": True
+        }
+
+
+async def get_recent_papers_handler(category: str = "cs.AI", max_results: int = 5) -> Dict[str, Any]:
+    """
+    Handler wrapping the recent papers capability for MCP.
+    Returns recent papers or an error payload on failure.
+    
+    Args:
+        category: ArXiv category
+        max_results: Maximum number of results to return
+        
+    Returns:
+        MCP-compliant response dictionary
+    """
+    try:
+        result = await get_recent_papers(category, max_results)
+        return result
+    except Exception as e:
+        return {
+            "content": [{"text": json.dumps({"error": str(e)})}],
+            "_meta": {"tool": "get_recent_papers", "error": type(e).__name__},
+            "isError": True
+        }
+
+
+async def search_papers_by_author_handler(author: str, max_results: int = 10) -> Dict[str, Any]:
+    """
+    Handler wrapping the author search capability for MCP.
+    Returns author's papers or an error payload on failure.
+    
+    Args:
+        author: Author name to search for
+        max_results: Maximum number of results to return
+        
+    Returns:
+        MCP-compliant response dictionary
+    """
+    try:
+        result = await search_papers_by_author(author, max_results)
+        return result
+    except Exception as e:
+        return {
+            "content": [{"text": json.dumps({"error": str(e)})}],
+            "_meta": {"tool": "search_papers_by_author", "error": type(e).__name__},
+            "isError": True
+        }
+
+
+async def search_by_title_handler(title_keywords: str, max_results: int = 10) -> Dict[str, Any]:
+    """
+    Handler wrapping the title search capability for MCP.
+    Returns papers matching title keywords or an error payload on failure.
+    
+    Args:
+        title_keywords: Keywords to search in paper titles
+        max_results: Maximum number of results to return
+        
+    Returns:
+        MCP-compliant response dictionary
+    """
+    try:
+        result = await search_by_title(title_keywords, max_results)
+        return result
+    except Exception as e:
+        return {
+            "content": [{"text": json.dumps({"error": str(e)})}],
+            "_meta": {"tool": "search_by_title", "error": type(e).__name__},
+            "isError": True
+        }
+
+
+async def search_by_abstract_handler(abstract_keywords: str, max_results: int = 10) -> Dict[str, Any]:
+    """
+    Handler wrapping the abstract search capability for MCP.
+    Returns papers matching abstract keywords or an error payload on failure.
+    
+    Args:
+        abstract_keywords: Keywords to search in paper abstracts
+        max_results: Maximum number of results to return
+        
+    Returns:
+        MCP-compliant response dictionary
+    """
+    try:
+        result = await search_by_abstract(abstract_keywords, max_results)
+        return result
+    except Exception as e:
+        return {
+            "content": [{"text": json.dumps({"error": str(e)})}],
+            "_meta": {"tool": "search_by_abstract", "error": type(e).__name__},
+            "isError": True
+        }
+
+
+async def search_by_subject_handler(subject: str, max_results: int = 10) -> Dict[str, Any]:
+    """
+    Handler wrapping the subject search capability for MCP.
+    Returns papers from specified subject or an error payload on failure.
+    
+    Args:
+        subject: ArXiv subject classification
+        max_results: Maximum number of results to return
+        
+    Returns:
+        MCP-compliant response dictionary
+    """
+    try:
+        result = await search_by_subject(subject, max_results)
+        return result
+    except Exception as e:
+        return {
+            "content": [{"text": json.dumps({"error": str(e)})}],
+            "_meta": {"tool": "search_by_subject", "error": type(e).__name__},
+            "isError": True
+        }
+
+
+async def search_date_range_handler(start_date: str, end_date: str, category: str = "", max_results: int = 20) -> Dict[str, Any]:
+    """
+    Handler wrapping the date range search capability for MCP.
+    Returns papers from specified date range or an error payload on failure.
+    
+    Args:
+        start_date: Start date in YYYY-MM-DD format
+        end_date: End date in YYYY-MM-DD format
+        category: Optional category filter
+        max_results: Maximum number of results to return
+        
+    Returns:
+        MCP-compliant response dictionary
+    """
+    try:
+        result = await search_date_range(start_date, end_date, category, max_results)
+        return result
+    except Exception as e:
+        return {
+            "content": [{"text": json.dumps({"error": str(e)})}],
+            "_meta": {"tool": "search_date_range", "error": type(e).__name__},
+            "isError": True
+        }
+
+
+async def get_paper_details_handler(arxiv_id: str) -> Dict[str, Any]:
+    """
+    Handler wrapping the paper details capability for MCP.
+    Returns detailed paper information or an error payload on failure.
+    
+    Args:
+        arxiv_id: ArXiv paper ID
+        
+    Returns:
+        MCP-compliant response dictionary
+    """
+    try:
+        result = await get_paper_details(arxiv_id)
+        return result
+    except Exception as e:
+        return {
+            "content": [{"text": json.dumps({"error": str(e)})}],
+            "_meta": {"tool": "get_paper_details", "error": type(e).__name__},
+            "isError": True
+        }
+
+
+async def export_to_bibtex_handler(papers_json: str) -> Dict[str, Any]:
+    """
+    Handler wrapping the BibTeX export capability for MCP.
+    Returns BibTeX citations or an error payload on failure.
+    
+    Args:
+        papers_json: JSON string containing list of papers
+        
+    Returns:
+        MCP-compliant response dictionary
+    """
+    try:
+        # Parse the JSON string to get the papers list
+        papers = json.loads(papers_json)
+        if not isinstance(papers, list):
+            raise ValueError("Expected a list of papers")
+        
+        result = await export_to_bibtex(papers)
+        return result
+    except json.JSONDecodeError as e:
+        return {
+            "content": [{"text": json.dumps({"error": f"Invalid JSON format: {str(e)}"})}],
+            "_meta": {"tool": "export_to_bibtex", "error": "JSONDecodeError"},
+            "isError": True
+        }
+    except Exception as e:
+        return {
+            "content": [{"text": json.dumps({"error": str(e)})}],
+            "_meta": {"tool": "export_to_bibtex", "error": type(e).__name__},
+            "isError": True
+        }
+
+
+async def find_similar_papers_handler(reference_paper_id: str, max_results: int = 10) -> Dict[str, Any]:
+    """
+    Handler wrapping the similar papers capability for MCP.
+    Returns similar papers or an error payload on failure.
+    
+    Args:
+        reference_paper_id: ArXiv ID of the reference paper
+        max_results: Maximum number of similar papers to return
+        
+    Returns:
+        MCP-compliant response dictionary
+    """
+    try:
+        result = await find_similar_papers(reference_paper_id, max_results)
+        return result
+    except Exception as e:
+        return {
+            "content": [{"text": json.dumps({"error": str(e)})}],
+            "_meta": {"tool": "find_similar_papers", "error": type(e).__name__},
+            "isError": True
+        }
+
+
+async def download_paper_pdf_handler(arxiv_id: str, download_path: str = None) -> Dict[str, Any]:
+    """
+    Handler wrapping the PDF download capability for MCP.
+    Downloads the PDF of a paper and returns download information.
+    
+    Args:
+        arxiv_id: ArXiv paper ID
+        download_path: Optional path to save the PDF
+        
+    Returns:
+        MCP-compliant response dictionary
+    """
+    try:
+        result = await download_paper_pdf(arxiv_id, download_path)
+        return result
+    except Exception as e:
+        return {
+            "content": [{"text": json.dumps({"error": str(e)})}],
+            "_meta": {"tool": "download_paper_pdf", "error": type(e).__name__},
+            "isError": True
+        }
+
+
+async def get_pdf_url_handler(arxiv_id: str) -> Dict[str, Any]:
+    """
+    Handler wrapping the PDF URL retrieval capability for MCP.
+    Gets the direct PDF URL without downloading.
+    
+    Args:
+        arxiv_id: ArXiv paper ID
+        
+    Returns:
+        MCP-compliant response dictionary
+    """
+    try:
+        result = await get_pdf_url(arxiv_id)
+        return result
+    except Exception as e:
+        return {
+            "content": [{"text": json.dumps({"error": str(e)})}],
+            "_meta": {"tool": "get_pdf_url", "error": type(e).__name__},
+            "isError": True
+        }
+
+
+async def download_multiple_pdfs_handler(arxiv_ids_json: str, download_path: str = None, max_concurrent: int = 3) -> Dict[str, Any]:
+    """
+    Handler wrapping the multiple PDF download capability for MCP.
+    Downloads multiple PDFs concurrently with rate limiting.
+    
+    Args:
+        arxiv_ids_json: JSON string containing list of ArXiv IDs
+        download_path: Optional path to save PDFs
+        max_concurrent: Maximum number of concurrent downloads
+        
+    Returns:
+        MCP-compliant response dictionary
+    """
+    try:
+        # Parse the JSON string to get the ArXiv IDs list
+        arxiv_ids = json.loads(arxiv_ids_json)
+        if not isinstance(arxiv_ids, list):
+            raise ValueError("Expected a list of ArXiv IDs")
+        
+        result = await download_multiple_pdfs(arxiv_ids, download_path, max_concurrent)
+        return result
+    except json.JSONDecodeError as e:
+        return {
+            "content": [{"text": json.dumps({"error": f"Invalid JSON format: {str(e)}"})}],
+            "_meta": {"tool": "download_multiple_pdfs", "error": "JSONDecodeError"},
+            "isError": True
+        }
+    except Exception as e:
+        return {
+            "content": [{"text": json.dumps({"error": str(e)})}],
+            "_meta": {"tool": "download_multiple_pdfs", "error": type(e).__name__},
+            "isError": True
+        }

--- a/Arxiv/src/arxiv_mcp/server.py
+++ b/Arxiv/src/arxiv_mcp/server.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+"""
+ArXiv MCP Server implementation using Model Context Protocol.
+Provides access to ArXiv research papers through search and retrieval tools.
+"""
+import os
+import sys
+import json
+from fastmcp import FastMCP
+from dotenv import load_dotenv
+import logging
+
+# Configure logging
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+logger = logging.getLogger(__name__)
+
+# Add current directory to path for relative imports
+sys.path.insert(0, os.path.dirname(__file__))
+
+# Load environment variables
+load_dotenv()
+
+import mcp_handlers
+
+# Initialize MCP server
+mcp = FastMCP("ArxivMCP")
+
+@mcp.tool(
+    name="search_arxiv",
+    description="Search ArXiv for research papers by category or topic."
+)
+async def search_arxiv_tool(query: str = "cs.AI", max_results: int = 5) -> dict:
+    """
+    Search ArXiv for research papers.
+    
+    Args:
+        query: Search query or category (default: "cs.AI")
+        max_results: Maximum number of results to return (default: 5)
+        
+    Returns:
+        Dictionary with search results
+    """
+    logger.info(f"Searching ArXiv for query: {query}")
+    return await mcp_handlers.search_arxiv_handler(query, max_results)
+
+
+@mcp.tool(
+    name="get_recent_papers",
+    description="Get recent papers from a specific ArXiv category."
+)
+async def get_recent_papers_tool(category: str = "cs.AI", max_results: int = 5) -> dict:
+    """
+    Get recent papers from ArXiv category.
+    
+    Args:
+        category: ArXiv category (default: "cs.AI")
+        max_results: Maximum number of results to return (default: 5)
+        
+    Returns:
+        Dictionary with recent papers
+    """
+    logger.info(f"Getting recent papers from category: {category}")
+    return await mcp_handlers.get_recent_papers_handler(category, max_results)
+
+
+@mcp.tool(
+    name="search_papers_by_author",
+    description="Search ArXiv papers by author name."
+)
+async def search_papers_by_author_tool(author: str, max_results: int = 10) -> dict:
+    """
+    Search ArXiv papers by author.
+    
+    Args:
+        author: Author name to search for
+        max_results: Maximum number of results to return (default: 10)
+        
+    Returns:
+        Dictionary with author's papers
+    """
+    logger.info(f"Searching papers by author: {author}")
+    return await mcp_handlers.search_papers_by_author_handler(author, max_results)
+
+
+@mcp.tool(
+    name="search_by_title",
+    description="Search ArXiv papers by title keywords."
+)
+async def search_by_title_tool(title_keywords: str, max_results: int = 10) -> dict:
+    """
+    Search ArXiv papers by title keywords.
+    
+    Args:
+        title_keywords: Keywords to search in paper titles
+        max_results: Maximum number of results to return (default: 10)
+        
+    Returns:
+        Dictionary with search results
+    """
+    logger.info(f"Searching papers by title: {title_keywords}")
+    return await mcp_handlers.search_by_title_handler(title_keywords, max_results)
+
+
+@mcp.tool(
+    name="search_by_abstract",
+    description="Search ArXiv papers by abstract keywords."
+)
+async def search_by_abstract_tool(abstract_keywords: str, max_results: int = 10) -> dict:
+    """
+    Search ArXiv papers by abstract keywords.
+    
+    Args:
+        abstract_keywords: Keywords to search in paper abstracts
+        max_results: Maximum number of results to return (default: 10)
+        
+    Returns:
+        Dictionary with search results
+    """
+    logger.info(f"Searching papers by abstract: {abstract_keywords}")
+    return await mcp_handlers.search_by_abstract_handler(abstract_keywords, max_results)
+
+
+@mcp.tool(
+    name="search_by_subject",
+    description="Search ArXiv papers by subject classification."
+)
+async def search_by_subject_tool(subject: str, max_results: int = 10) -> dict:
+    """
+    Search ArXiv papers by subject classification.
+    
+    Args:
+        subject: ArXiv subject classification (e.g., 'cs.AI', 'physics.astro-ph')
+        max_results: Maximum number of results to return (default: 10)
+        
+    Returns:
+        Dictionary with search results
+    """
+    logger.info(f"Searching papers by subject: {subject}")
+    return await mcp_handlers.search_by_subject_handler(subject, max_results)
+
+
+@mcp.tool(
+    name="search_date_range",
+    description="Search ArXiv papers within a specific date range."
+)
+async def search_date_range_tool(start_date: str, end_date: str, category: str = "", max_results: int = 20) -> dict:
+    """
+    Search ArXiv papers within a date range.
+    
+    Args:
+        start_date: Start date in YYYY-MM-DD format
+        end_date: End date in YYYY-MM-DD format
+        category: Optional category filter (e.g., 'cs.AI')
+        max_results: Maximum number of results to return (default: 20)
+        
+    Returns:
+        Dictionary with search results
+    """
+    logger.info(f"Searching papers by date range: {start_date} to {end_date}")
+    return await mcp_handlers.search_date_range_handler(start_date, end_date, category, max_results)
+
+
+@mcp.tool(
+    name="get_paper_details",
+    description="Get detailed information about a specific ArXiv paper by ID."
+)
+async def get_paper_details_tool(arxiv_id: str) -> dict:
+    """
+    Get detailed paper information.
+    
+    Args:
+        arxiv_id: ArXiv paper ID (e.g., '2301.12345' or 'cs/0501001')
+        
+    Returns:
+        Dictionary with detailed paper information
+    """
+    logger.info(f"Getting paper details for: {arxiv_id}")
+    return await mcp_handlers.get_paper_details_handler(arxiv_id)
+
+
+@mcp.tool(
+    name="export_to_bibtex",
+    description="Export search results to BibTeX format for citation management."
+)
+async def export_to_bibtex_tool(papers_json: str) -> dict:
+    """
+    Export papers to BibTeX format.
+    
+    Args:
+        papers_json: JSON string containing list of papers to export
+        
+    Returns:
+        Dictionary with BibTeX citations
+    """
+    logger.info("Exporting papers to BibTeX format")
+    return await mcp_handlers.export_to_bibtex_handler(papers_json)
+
+
+@mcp.tool(
+    name="find_similar_papers",
+    description="Find papers similar to a reference paper based on categories and keywords."
+)
+async def find_similar_papers_tool(reference_paper_id: str, max_results: int = 10) -> dict:
+    """
+    Find similar papers to a reference paper.
+    
+    Args:
+        reference_paper_id: ArXiv ID of the reference paper
+        max_results: Maximum number of similar papers to return (default: 10)
+        
+    Returns:
+        Dictionary with similar papers
+    """
+    logger.info(f"Finding papers similar to: {reference_paper_id}")
+    return await mcp_handlers.find_similar_papers_handler(reference_paper_id, max_results)
+
+
+@mcp.tool(
+    name="download_paper_pdf",
+    description="Download the PDF of a paper from ArXiv."
+)
+async def download_paper_pdf_tool(arxiv_id: str, download_path: str = None) -> dict:
+    """
+    Download the PDF of a paper from ArXiv.
+    
+    Args:
+        arxiv_id: ArXiv paper ID (e.g., '2301.12345' or 'cs/0501001')
+        download_path: Optional path to save the PDF (default: current directory)
+        
+    Returns:
+        Dictionary with download information
+    """
+    logger.info(f"Downloading PDF for paper: {arxiv_id}")
+    return await mcp_handlers.download_paper_pdf_handler(arxiv_id, download_path)
+
+
+@mcp.tool(
+    name="get_pdf_url",
+    description="Get the direct PDF URL for a paper without downloading it."
+)
+async def get_pdf_url_tool(arxiv_id: str) -> dict:
+    """
+    Get the direct PDF URL for a paper.
+    
+    Args:
+        arxiv_id: ArXiv paper ID (e.g., '2301.12345' or 'cs/0501001')
+        
+    Returns:
+        Dictionary with PDF URL information
+    """
+    logger.info(f"Getting PDF URL for paper: {arxiv_id}")
+    return await mcp_handlers.get_pdf_url_handler(arxiv_id)
+
+
+@mcp.tool(
+    name="download_multiple_pdfs",
+    description="Download multiple PDFs concurrently with rate limiting."
+)
+async def download_multiple_pdfs_tool(arxiv_ids_json: str, download_path: str = None, max_concurrent: int = 3) -> dict:
+    """
+    Download multiple PDFs concurrently.
+    
+    Args:
+        arxiv_ids_json: JSON string containing list of ArXiv IDs
+        download_path: Optional path to save PDFs (default: current directory)
+        max_concurrent: Maximum number of concurrent downloads (default: 3)
+        
+    Returns:
+        Dictionary with batch download results
+    """
+    logger.info(f"Downloading multiple PDFs with max_concurrent: {max_concurrent}")
+    return await mcp_handlers.download_multiple_pdfs_handler(arxiv_ids_json, download_path, max_concurrent)
+
+
+def main():
+    """
+    Main entry point for the ArXiv MCP server.
+    Supports both stdio and SSE transports based on environment variables.
+    """
+    try:
+        logger.info("Starting ArXiv MCP Server")
+        
+        # Determine which transport to use
+        transport = os.getenv("MCP_TRANSPORT", "stdio").lower()
+        if transport == "sse":
+            # SSE transport for web-based clients
+            host = os.getenv("MCP_SSE_HOST", "0.0.0.0")
+            port = int(os.getenv("MCP_SSE_PORT", "8000"))
+            logger.info(f"Starting SSE transport on {host}:{port}")
+            print(json.dumps({"message": f"Starting SSE on {host}:{port}"}), file=sys.stderr)
+            mcp.run(transport="sse", host=host, port=port)
+        else:
+            # Default stdio transport
+            logger.info("Starting stdio transport")
+            print(json.dumps({"message": "Starting stdio transport"}), file=sys.stderr)
+            mcp.run(transport="stdio")
+
+    except Exception as e:
+        logger.error(f"Server error: {e}")
+        print(json.dumps({"error": str(e)}), file=sys.stderr)
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- Implement download_paper_pdf: Download individual paper PDFs from ArXiv
- Implement get_pdf_url: Get direct PDF URLs without downloading
- Implement download_multiple_pdfs: Batch download with concurrency control
- Add comprehensive PDF download tests (9 test cases)
- Update README with PDF download documentation and usage examples
- Add demo_pdf.py to showcase PDF download functionality
- Handle redirects and various ArXiv ID formats
- Include proper error handling for 404s and invalid content types
- Add file size reporting and download path validation

🤖 Generated with [Claude Code](https://claude.ai/code)