### PR TITLE
Fix pytest-asyncio version constraint in compression-mcp

### DIFF
--- a/Compression/pyproject.toml
+++ b/Compression/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "pyarrow>=19.0.1",
     "pydantic>=2.11.3",
     "pytest>=8.3.5",
-    "pytest-asyncio==0.26.0",
+    "pytest-asyncio>=0.26.0",
     "requests>=2.32.3",
     "uvicorn>=0.34.1",
 ]


### PR DESCRIPTION
Change pytest-asyncio from ==0.26.0 to >=0.26.0 to resolve dependency conflict with arxiv-mcp which requires pytest-asyncio>=1.0.0