### PR TITLE
refactor: Rename package from agent-toolkit to iowarp-agent-toolkit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "agent-toolkit"
+name = "iowarp-agent-toolkit"
 version = "0.4.0"
 description = "Agent Toolkit - MCP Servers, Clients, and Tools for AI Agents"
 readme = "README.md"


### PR DESCRIPTION
## Summary
- Rename root package from `agent-toolkit` to `iowarp-agent-toolkit` for better brand alignment

## Test plan
- [ ] Verify launcher still works: `uvx iowarp-agent-toolkit`
- [ ] Check package installation and discovery
- [ ] Confirm no breaking changes to existing MCP servers

🤖 Generated with [Claude Code](https://claude.com/claude-code)