### PR TITLE
feat(ndp): 11 new MCP tools — registration, resource search, streaming, status

### DIFF
--- a/clio-kit-mcp-servers/ndp/server.json
+++ b/clio-kit-mcp-servers/ndp/server.json
@@ -34,6 +34,50 @@
     {
       "name": "get_dataset_details",
       "description": "Retrieve detailed metadata for a specific dataset by ID or name."
+    },
+    {
+      "name": "register_dataset",
+      "description": "Create a new general dataset in NDP. Requires bearer auth."
+    },
+    {
+      "name": "register_kafka_topic",
+      "description": "Register a Kafka topic as an NDP streaming data source. Requires bearer auth."
+    },
+    {
+      "name": "register_s3_resource",
+      "description": "Register an S3-hosted file as an NDP resource. Requires bearer auth."
+    },
+    {
+      "name": "register_url_resource",
+      "description": "Register a URL-addressable resource (CSV / JSON / NetCDF / stream). Requires bearer auth."
+    },
+    {
+      "name": "search_resources",
+      "description": "Search the NDP resource catalog by name, URL, format, or free-text query."
+    },
+    {
+      "name": "get_jupyter_details",
+      "description": "Fetch JupyterHub workspace connection details. Requires bearer auth."
+    },
+    {
+      "name": "get_user_info",
+      "description": "Return the calling user's identity and authorization claims. Requires bearer auth."
+    },
+    {
+      "name": "list_kafka_streams",
+      "description": "List Kafka streaming data sources in NDP. Free to call on server='local'; optional q/name/limit filters."
+    },
+    {
+      "name": "get_kafka_details",
+      "description": "Get NDP-EP Kafka broker connection details. Requires bearer auth."
+    },
+    {
+      "name": "get_system_metrics",
+      "description": "Get NDP-EP system health metrics. Requires bearer auth."
+    },
+    {
+      "name": "register_derived_stream",
+      "description": "Register a derived Kafka topic that filters an upstream one (EarthScope GNSS UI pattern). Requires bearer auth."
     }
   ],
   "resources": [

--- a/clio-kit-mcp-servers/ndp/src/ndp_mcp/server.py
+++ b/clio-kit-mcp-servers/ndp/src/ndp_mcp/server.py
@@ -16,10 +16,14 @@ load_dotenv()
 mcp: FastMCP = FastMCP(
     "ndp",
     instructions=(
-        "Discovers and explores scientific datasets from NDP catalogs. "
-        "Use search_datasets to find data, get_dataset_details for metadata, "
-        "list_catalogs for available sources."
+        "Discovers, explores, and registers data on the National Data Platform. "
+        "Read tools: list_organizations, search_datasets, get_dataset_details, "
+        "search_resources, get_jupyter_details, get_user_info. "
+        "Write tools (need bearer auth via NDP_BEARER_TOKEN): register_dataset, "
+        "register_kafka_topic, register_s3_resource, register_url_resource. "
+        "Use the `ndp://catalogs` resource for available catalog scopes."
     ),
+    list_page_size=10,
 )
 
 
@@ -38,11 +42,18 @@ class Dataset(BaseModel):
 class NDPClient:
     """Client for interacting with NDP API with retry logic and error handling."""
 
-    def __init__(self, base_url: str = "http://155.101.6.191:8003"):
-        self.base_url = base_url.rstrip("/")
+    def __init__(self, base_url: str | None = None, bearer: str | None = None):
+        self.base_url = (base_url or os.getenv("NDP_BASE_URL", "http://155.101.6.191:8003")).rstrip("/")
+        self.bearer = bearer or os.getenv("NDP_BEARER_TOKEN")
         self.timeout = httpx.Timeout(30.0)
         self.max_retries = 3
         self.retry_delay = 1.0
+
+    def _headers(self) -> dict[str, str]:
+        h: dict[str, str] = {"Accept": "application/json"}
+        if self.bearer:
+            h["Authorization"] = f"Bearer {self.bearer}"
+        return h
 
     async def _make_request(  # type: ignore[return]
         self,
@@ -57,14 +68,19 @@ class NDPClient:
         for attempt in range(self.max_retries):
             try:
                 async with httpx.AsyncClient(timeout=self.timeout) as client:
+                    headers = self._headers()
                     if method.upper() == "GET":
-                        response = await client.get(url, params=params)
+                        response = await client.get(url, params=params, headers=headers)
                     elif method.upper() == "POST":
-                        response = await client.post(url, params=params, json=json_data)
+                        response = await client.post(
+                            url, params=params, json=json_data, headers=headers
+                        )
                     else:
                         raise ValueError(f"Unsupported HTTP method: {method}")
 
                     response.raise_for_status()
+                    if not response.content:
+                        return {}
                     return response.json()  # type: ignore[no-any-return]
 
             except httpx.TimeoutException:
@@ -349,6 +365,534 @@ async def get_dataset_details(
         }
     except ToolError:
         raise
+    except Exception as e:
+        raise ToolError(str(e)) from e
+
+
+# ── Registration tools (write — bearer required) ────────────────────────
+
+
+@mcp.tool(
+    name="register_dataset",
+    description=(
+        "Create a new general dataset in NDP. Requires bearer auth "
+        "(NDP_BEARER_TOKEN env var). The dataset is created in the "
+        "specified catalog scope and can then be populated with resources."
+    ),
+    annotations={"readOnlyHint": False, "destructiveHint": True, "idempotentHint": False},
+    tags={"datasets", "registration", "write"},
+)
+async def register_dataset(
+    name: Annotated[
+        str,
+        Field(
+            description="Unique dataset name — lowercase alphanumeric, hyphens, underscores"
+        ),
+    ],
+    title: Annotated[str, Field(description="Human-readable dataset title")],
+    owner_org: Annotated[str, Field(description="ID of the owning organization")],
+    notes: Annotated[
+        str | None, Field(description="Description / abstract")
+    ] = None,
+    tags: Annotated[
+        list[str] | None, Field(description="Tag list for categorization")
+    ] = None,
+    license_id: Annotated[
+        str | None, Field(description="License identifier (e.g. 'cc-by')")
+    ] = None,
+    private: Annotated[
+        bool | None, Field(description="If True, the dataset is not publicly listed")
+    ] = None,
+    server: Annotated[
+        str, Field(description="Catalog scope: 'local' or 'pre_ckan'")
+    ] = "local",
+) -> dict[str, Any]:
+    """Register a new dataset on NDP."""
+    body: dict[str, Any] = {"name": name, "title": title, "owner_org": owner_org}
+    if notes is not None:
+        body["notes"] = notes
+    if tags is not None:
+        body["tags"] = tags
+    if license_id is not None:
+        body["license_id"] = license_id
+    if private is not None:
+        body["private"] = private
+    try:
+        result = await ndp_client._make_request(
+            "POST", "/dataset", params={"server": server}, json_data=body
+        )
+        return {
+            "registration": result,
+            "name": name,
+            "server": server,
+            "_meta": {"tool": "register_dataset", "status": "success"},
+        }
+    except Exception as e:
+        raise ToolError(str(e)) from e
+
+
+@mcp.tool(
+    name="register_kafka_topic",
+    description=(
+        "Register a Kafka topic as an NDP streaming data source. Requires "
+        "bearer auth. Creates a dataset entry that points at the topic."
+    ),
+    annotations={"readOnlyHint": False, "destructiveHint": True, "idempotentHint": False},
+    tags={"streaming", "kafka", "registration", "write"},
+)
+async def register_kafka_topic(
+    dataset_name: Annotated[
+        str, Field(description="Unique dataset name (lowercase alphanumeric)")
+    ],
+    dataset_title: Annotated[str, Field(description="Dataset title")],
+    owner_org: Annotated[str, Field(description="Owning organization")],
+    kafka_topic: Annotated[str, Field(description="Kafka topic name")],
+    kafka_host: Annotated[str, Field(description="Kafka broker host")],
+    kafka_port: Annotated[
+        int, Field(description="Kafka broker port (1-65535)", ge=1, le=65535)
+    ],
+    dataset_description: Annotated[
+        str | None, Field(description="Description of the dataset")
+    ] = None,
+    server: Annotated[
+        str, Field(description="Catalog scope: 'local' or 'pre_ckan'")
+    ] = "local",
+) -> dict[str, Any]:
+    """Register a Kafka topic with NDP."""
+    body: dict[str, Any] = {
+        "dataset_name": dataset_name,
+        "dataset_title": dataset_title,
+        "owner_org": owner_org,
+        "kafka_topic": kafka_topic,
+        "kafka_host": kafka_host,
+        "kafka_port": kafka_port,
+    }
+    if dataset_description is not None:
+        body["dataset_description"] = dataset_description
+    try:
+        result = await ndp_client._make_request(
+            "POST", "/kafka", params={"server": server}, json_data=body
+        )
+        return {
+            "registration": result,
+            "dataset_name": dataset_name,
+            "kafka_topic": kafka_topic,
+            "server": server,
+            "_meta": {"tool": "register_kafka_topic", "status": "success"},
+        }
+    except Exception as e:
+        raise ToolError(str(e)) from e
+
+
+@mcp.tool(
+    name="register_s3_resource",
+    description=(
+        "Register an S3-hosted file as an NDP resource. Requires bearer auth. "
+        "The S3 URL must be reachable from the NDP endpoint."
+    ),
+    annotations={"readOnlyHint": False, "destructiveHint": True, "idempotentHint": False},
+    tags={"resources", "s3", "registration", "write"},
+)
+async def register_s3_resource(
+    resource_name: Annotated[
+        str, Field(description="Unique resource name (lowercase alphanumeric)")
+    ],
+    resource_title: Annotated[str, Field(description="Resource title")],
+    owner_org: Annotated[str, Field(description="Owning organization")],
+    resource_s3: Annotated[
+        str, Field(description="S3 URL (s3://bucket/key/path)")
+    ],
+    notes: Annotated[
+        str | None, Field(description="Notes / description")
+    ] = None,
+    server: Annotated[
+        str, Field(description="Catalog scope: 'local' or 'pre_ckan'")
+    ] = "local",
+) -> dict[str, Any]:
+    """Register an S3 resource with NDP."""
+    body: dict[str, Any] = {
+        "resource_name": resource_name,
+        "resource_title": resource_title,
+        "owner_org": owner_org,
+        "resource_s3": resource_s3,
+    }
+    if notes is not None:
+        body["notes"] = notes
+    try:
+        result = await ndp_client._make_request(
+            "POST", "/s3", params={"server": server}, json_data=body
+        )
+        return {
+            "registration": result,
+            "resource_name": resource_name,
+            "s3_url": resource_s3,
+            "server": server,
+            "_meta": {"tool": "register_s3_resource", "status": "success"},
+        }
+    except Exception as e:
+        raise ToolError(str(e)) from e
+
+
+@mcp.tool(
+    name="register_url_resource",
+    description=(
+        "Register a URL-addressable resource (CSV / JSON / NetCDF / stream / "
+        "etc.). Requires bearer auth."
+    ),
+    annotations={"readOnlyHint": False, "destructiveHint": True, "idempotentHint": False},
+    tags={"resources", "url", "registration", "write"},
+)
+async def register_url_resource(
+    resource_name: Annotated[
+        str, Field(description="Unique resource name (lowercase alphanumeric)")
+    ],
+    resource_title: Annotated[str, Field(description="Resource title")],
+    owner_org: Annotated[str, Field(description="Owning organization")],
+    resource_url: Annotated[str, Field(description="URL of the resource")],
+    file_type: Annotated[
+        str | None,
+        Field(description="Resource format: stream | CSV | TXT | JSON | NetCDF | ..."),
+    ] = None,
+    notes: Annotated[
+        str | None, Field(description="Notes / description")
+    ] = None,
+    server: Annotated[
+        str, Field(description="Catalog scope: 'local' or 'pre_ckan'")
+    ] = "local",
+) -> dict[str, Any]:
+    """Register a URL-based resource with NDP."""
+    body: dict[str, Any] = {
+        "resource_name": resource_name,
+        "resource_title": resource_title,
+        "owner_org": owner_org,
+        "resource_url": resource_url,
+    }
+    if file_type is not None:
+        body["file_type"] = file_type
+    if notes is not None:
+        body["notes"] = notes
+    try:
+        result = await ndp_client._make_request(
+            "POST", "/url", params={"server": server}, json_data=body
+        )
+        return {
+            "registration": result,
+            "resource_name": resource_name,
+            "url": resource_url,
+            "server": server,
+            "_meta": {"tool": "register_url_resource", "status": "success"},
+        }
+    except Exception as e:
+        raise ToolError(str(e)) from e
+
+
+# ── Resource discovery (read) ───────────────────────────────────────────
+
+
+@mcp.tool(
+    name="search_resources",
+    description=(
+        "Search the NDP resource catalog (across all datasets) by name, URL, "
+        "format, or free-text query. Returns matching resources with their "
+        "parent dataset references."
+    ),
+    annotations={"readOnlyHint": True, "destructiveHint": False, "idempotentHint": True},
+    tags={"resources", "search"},
+)
+async def search_resources(
+    q: Annotated[
+        str | None, Field(description="Free-text query across all resource fields")
+    ] = None,
+    name: Annotated[str | None, Field(description="Resource name to match")] = None,
+    url: Annotated[str | None, Field(description="Resource URL to match")] = None,
+    format: Annotated[
+        str | None, Field(description="Format (CSV, JSON, NetCDF, ...)")
+    ] = None,
+    description: Annotated[
+        str | None, Field(description="Text to search in resource descriptions")
+    ] = None,
+    limit: Annotated[int | None, Field(description="Max results (default 20)")] = None,
+    offset: Annotated[int | None, Field(description="Pagination offset")] = None,
+    server: Annotated[
+        str,
+        Field(
+            description=(
+                "Catalog to search — 'local' or 'pre_ckan'. /resources/search "
+                "does not support 'global' (federation-wide) — use "
+                "search_datasets for that."
+            )
+        ),
+    ] = "local",
+) -> dict[str, Any]:
+    """Search the NDP resource catalog."""
+    params: dict[str, Any] = {"server": server}
+    if q is not None:
+        params["q"] = q
+    if name is not None:
+        params["name"] = name
+    if url is not None:
+        params["url"] = url
+    if format is not None:
+        params["format"] = format
+    if description is not None:
+        params["description"] = description
+    if limit is not None:
+        params["limit"] = limit
+    if offset is not None:
+        params["offset"] = offset
+    try:
+        result = await ndp_client._make_request(
+            "GET", "/resources/search", params=params
+        )
+        resources = (
+            result
+            if isinstance(result, list)
+            else (result.get("resources", []) if isinstance(result, dict) else [])
+        )
+        return {
+            "resources": resources,
+            "count": len(resources),
+            "server": server,
+            "_meta": {"tool": "search_resources", "status": "success"},
+        }
+    except Exception as e:
+        raise ToolError(str(e)) from e
+
+
+# ── Status / user (read — bearer required) ──────────────────────────────
+
+
+@mcp.tool(
+    name="get_jupyter_details",
+    description=(
+        "Fetch JupyterHub workspace connection details for the current user "
+        "(URL, available kernels, token-handling guidance). Requires bearer "
+        "auth."
+    ),
+    annotations={"readOnlyHint": True, "destructiveHint": False, "idempotentHint": True},
+    tags={"jupyter", "workspace", "status"},
+)
+async def get_jupyter_details() -> dict[str, Any]:
+    """Return the user's JupyterHub workspace connection info."""
+    try:
+        result = await ndp_client._make_request("GET", "/status/jupyter")
+        return {
+            "jupyter": result,
+            "_meta": {"tool": "get_jupyter_details", "status": "success"},
+        }
+    except Exception as e:
+        raise ToolError(str(e)) from e
+
+
+@mcp.tool(
+    name="get_user_info",
+    description=(
+        "Return the calling user's identity and authorization claims "
+        "(name, email, roles, org memberships). Requires bearer auth."
+    ),
+    annotations={"readOnlyHint": True, "destructiveHint": False, "idempotentHint": True},
+    tags={"user", "auth"},
+)
+async def get_user_info() -> dict[str, Any]:
+    """Return the current authenticated user's identity."""
+    try:
+        result = await ndp_client._make_request("GET", "/user/info")
+        return {
+            "user": result,
+            "_meta": {"tool": "get_user_info", "status": "success"},
+        }
+    except Exception as e:
+        raise ToolError(str(e)) from e
+
+
+# ── Live-stream / data-source tools (4 new) ─────────────────────────────
+# Cover the workflow behind the EarthScope GNSS UI at
+# https://vdc-192.chpc.utah.edu/gnss-ui/ — discover Kafka streams,
+# inspect broker health, register a downstream-derived topic. The
+# `/resources/search?format=kafka&server=local` endpoint returns Kafka
+# resources WITHOUT auth, so the discovery tool below is usable by an
+# unauthenticated model client.
+
+
+@mcp.tool(
+    name="list_kafka_streams",
+    description=(
+        "List Kafka streaming data sources in NDP — host/port/topic of each. "
+        "Free to call without auth on `server='local'`. Optionally filter "
+        "by free-text query or topic-name substring."
+    ),
+    annotations={"readOnlyHint": True, "destructiveHint": False, "idempotentHint": True},
+    tags={"streams", "kafka", "discovery"},
+)
+async def list_kafka_streams(
+    q: Annotated[
+        str | None, Field(description="Free-text query across resource fields")
+    ] = None,
+    name: Annotated[
+        str | None, Field(description="Resource name substring to match (e.g. 'gnss')")
+    ] = None,
+    limit: Annotated[int | None, Field(description="Max rows (default 20)")] = None,
+    server: Annotated[
+        str, Field(description="Catalog: 'local' or 'pre_ckan'")
+    ] = "local",
+) -> dict[str, Any]:
+    """Discover Kafka streams available on NDP."""
+    params: dict[str, Any] = {"server": server, "format": "kafka"}
+    if q is not None:
+        params["q"] = q
+    if name is not None:
+        params["name"] = name
+    if limit is not None:
+        params["limit"] = limit
+    try:
+        result = await ndp_client._make_request("GET", "/resources/search", params=params)
+        # The endpoint returns {"count": N, "results": [...]} OR a bare list.
+        if isinstance(result, dict):
+            rows = result.get("results") or result.get("resources") or []
+        elif isinstance(result, list):
+            rows = result
+        else:
+            rows = []
+        # Pull out the kafka-specific fields each resource encodes in
+        # its `description` JSON-blob — host / port / topic. Falls back
+        # to the raw description if it isn't JSON.
+        import json
+        compact = []
+        for r in rows:
+            desc_raw = r.get("description", "") or ""
+            try:
+                desc = json.loads(desc_raw)
+            except Exception:
+                desc = {}
+            compact.append({
+                "name": r.get("name"),
+                "topic": desc.get("topic"),
+                "host": desc.get("host"),
+                "port": desc.get("port"),
+                "url": r.get("url"),
+                "description": desc.get("description") or desc_raw[:200],
+            })
+        return {
+            "streams": compact,
+            "count": len(compact),
+            "server": server,
+            "_meta": {"tool": "list_kafka_streams", "status": "success"},
+        }
+    except Exception as e:
+        raise ToolError(str(e)) from e
+
+
+@mcp.tool(
+    name="get_kafka_details",
+    description=(
+        "Get NDP-EP's Kafka broker connection details — broker list, "
+        "consumer-group hints, auth requirements. Requires bearer auth."
+    ),
+    annotations={"readOnlyHint": True, "destructiveHint": False, "idempotentHint": True},
+    tags={"streams", "kafka", "status"},
+)
+async def get_kafka_details() -> dict[str, Any]:
+    """Return NDP-EP Kafka broker connection info."""
+    try:
+        result = await ndp_client._make_request("GET", "/status/kafka-details")
+        return {
+            "kafka": result,
+            "_meta": {"tool": "get_kafka_details", "status": "success"},
+        }
+    except Exception as e:
+        raise ToolError(str(e)) from e
+
+
+@mcp.tool(
+    name="get_system_metrics",
+    description=(
+        "Get NDP-EP system health metrics (CPU, memory, message rate, "
+        "lag). Requires bearer auth."
+    ),
+    annotations={"readOnlyHint": True, "destructiveHint": False, "idempotentHint": True},
+    tags={"status", "metrics"},
+)
+async def get_system_metrics() -> dict[str, Any]:
+    """Return NDP-EP system metrics."""
+    try:
+        result = await ndp_client._make_request("GET", "/status/metrics")
+        return {
+            "metrics": result,
+            "_meta": {"tool": "get_system_metrics", "status": "success"},
+        }
+    except Exception as e:
+        raise ToolError(str(e)) from e
+
+
+@mcp.tool(
+    name="register_derived_stream",
+    description=(
+        "Register a NEW Kafka topic that filters / derives from an existing "
+        "one — the pattern used by the EarthScope GNSS UI to publish per-"
+        "station or per-SNCL filtered streams. Wraps NDP-EP's /kafka "
+        "registration with a `mapping` field that records the filter. "
+        "Requires bearer auth."
+    ),
+    annotations={"readOnlyHint": False, "destructiveHint": True, "idempotentHint": False},
+    tags={"streams", "kafka", "registration", "write"},
+)
+async def register_derived_stream(
+    dataset_name: Annotated[
+        str, Field(description="Unique dataset name for the derived stream")
+    ],
+    dataset_title: Annotated[str, Field(description="Dataset title")],
+    owner_org: Annotated[str, Field(description="Owning organization")],
+    source_topic: Annotated[
+        str, Field(description="Upstream Kafka topic this is derived from")
+    ],
+    dest_topic: Annotated[str, Field(description="New Kafka topic to publish to")],
+    dest_host: Annotated[str, Field(description="New broker host")],
+    dest_port: Annotated[
+        int, Field(description="New broker port (1-65535)", ge=1, le=65535)
+    ],
+    sncl_filter: Annotated[
+        str | None,
+        Field(description="SNCL-style filter (e.g. 'AGMT.CI.LY.20') — recorded in `mapping`"),
+    ] = None,
+    extra_filter: Annotated[
+        dict[str, Any] | None,
+        Field(description="Additional structured filter info, recorded in `mapping`"),
+    ] = None,
+    server: Annotated[
+        str, Field(description="Catalog: 'local' or 'pre_ckan'")
+    ] = "local",
+) -> dict[str, Any]:
+    """Register a derived Kafka stream that filters another."""
+    mapping: dict[str, Any] = {"source_topic": source_topic}
+    if sncl_filter is not None:
+        mapping["sncl_filter"] = sncl_filter
+    if extra_filter:
+        mapping.update(extra_filter)
+    body: dict[str, Any] = {
+        "dataset_name": dataset_name,
+        "dataset_title": dataset_title,
+        "owner_org": owner_org,
+        "kafka_topic": dest_topic,
+        "kafka_host": dest_host,
+        "kafka_port": dest_port,
+        "dataset_description": (
+            f"Derived from {source_topic}"
+            + (f" with SNCL filter {sncl_filter}" if sncl_filter else "")
+        ),
+        "mapping": mapping,
+    }
+    try:
+        result = await ndp_client._make_request(
+            "POST", "/kafka", params={"server": server}, json_data=body
+        )
+        return {
+            "registration": result,
+            "derived_topic": dest_topic,
+            "source_topic": source_topic,
+            "sncl_filter": sncl_filter,
+            "server": server,
+            "_meta": {"tool": "register_derived_stream", "status": "success"},
+        }
     except Exception as e:
         raise ToolError(str(e)) from e
 

--- a/clio-kit-mcp-servers/ndp/tests/test_ndp_client.py
+++ b/clio-kit-mcp-servers/ndp/tests/test_ndp_client.py
@@ -120,10 +120,14 @@ class TestNDPClientEdgeCases:
             result = await client._make_request("POST", "/test", json_data=test_data)
             assert result == {"result": "created"}
 
-            # Verify the POST was called with correct parameters
-            mock_client.return_value.__aenter__.return_value.post.assert_called_once_with(
-                "http://test.example.com:8003/test", params=None, json=test_data
-            )
+            # Verify the POST was called with correct parameters. Headers now
+            # carry Accept (and Authorization when NDP_BEARER_TOKEN is set),
+            # so check the call piece-by-piece instead of strict equality.
+            call = mock_client.return_value.__aenter__.return_value.post.call_args
+            assert call.args == ("http://test.example.com:8003/test",)
+            assert call.kwargs["params"] is None
+            assert call.kwargs["json"] == test_data
+            assert call.kwargs["headers"].get("Accept") == "application/json"
 
     @pytest.mark.asyncio
     async def test_list_organizations_empty_result(self, client):

--- a/clio-kit-mcp-servers/ndp/tests/test_new_tools.py
+++ b/clio-kit-mcp-servers/ndp/tests/test_new_tools.py
@@ -1,0 +1,296 @@
+"""Tests for the 7 new NDP MCP tools added on top of the upstream 3.
+
+Covered:
+  Registration (4): register_dataset, register_kafka_topic,
+                    register_s3_resource, register_url_resource
+  Resource search (1): search_resources
+  Status / user (2): get_jupyter_details, get_user_info
+
+All tests mock NDPClient._make_request — no live HTTP. Live integration
+checks belong in the dedicated `tests/test_live.py` (run with -m live).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+import ndp_mcp.server as srv
+
+
+# ── Tool-registration sanity check ──────────────────────────────────────
+
+EXPECTED_TOOLS = {
+    "list_organizations",
+    "search_datasets",
+    "get_dataset_details",
+    "register_dataset",
+    "register_kafka_topic",
+    "register_s3_resource",
+    "register_url_resource",
+    "search_resources",
+    "get_jupyter_details",
+    "get_user_info",
+    # 4 streaming / kafka tools (EarthScope GNSS UI pattern)
+    "list_kafka_streams",
+    "get_kafka_details",
+    "get_system_metrics",
+    "register_derived_stream",
+}
+
+
+@pytest.mark.asyncio
+async def test_all_ten_tools_registered():
+    tools = await srv.mcp.list_tools()
+    names = {getattr(t, "name", str(t)) for t in tools} if not isinstance(tools, dict) else set(tools.keys())
+    missing = EXPECTED_TOOLS - names
+    assert not missing, f"missing tools: {missing}"
+
+
+# ── Registration tools ──────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_register_dataset_minimal():
+    with patch.object(srv.ndp_client, "_make_request", new=AsyncMock(return_value={"id": "abc123"})) as m:
+        out = await srv.register_dataset(name="my-ds", title="My DS", owner_org="org1")
+        assert out["registration"] == {"id": "abc123"}
+        assert out["_meta"]["tool"] == "register_dataset"
+        # body matched
+        kwargs = m.call_args.kwargs
+        assert kwargs["json_data"]["name"] == "my-ds"
+        assert kwargs["json_data"]["title"] == "My DS"
+        assert kwargs["json_data"]["owner_org"] == "org1"
+        # defaults: not included unless explicitly passed
+        assert "notes" not in kwargs["json_data"]
+        # server query param
+        assert kwargs["params"] == {"server": "local"}
+
+
+@pytest.mark.asyncio
+async def test_register_dataset_full():
+    with patch.object(srv.ndp_client, "_make_request", new=AsyncMock(return_value={"id": "x"})) as m:
+        await srv.register_dataset(
+            name="env-data",
+            title="Environmental Data",
+            owner_org="ucsd",
+            notes="hourly snapshots",
+            tags=["climate", "hourly"],
+            license_id="cc-by",
+            private=False,
+            server="pre_ckan",
+        )
+        body = m.call_args.kwargs["json_data"]
+        assert body["tags"] == ["climate", "hourly"]
+        assert body["license_id"] == "cc-by"
+        assert body["private"] is False
+        assert m.call_args.kwargs["params"]["server"] == "pre_ckan"
+
+
+@pytest.mark.asyncio
+async def test_register_kafka_topic_required_fields():
+    with patch.object(srv.ndp_client, "_make_request", new=AsyncMock(return_value={})) as m:
+        await srv.register_kafka_topic(
+            dataset_name="quake-stream",
+            dataset_title="Earthquake Stream",
+            owner_org="usgs",
+            kafka_topic="quakes",
+            kafka_host="kafka.example.org",
+            kafka_port=9092,
+        )
+        body = m.call_args.kwargs["json_data"]
+        assert body["kafka_topic"] == "quakes"
+        assert body["kafka_port"] == 9092
+
+
+@pytest.mark.asyncio
+async def test_register_s3_resource_basic():
+    with patch.object(srv.ndp_client, "_make_request", new=AsyncMock(return_value={"ok": True})) as m:
+        out = await srv.register_s3_resource(
+            resource_name="snapshot-2024",
+            resource_title="Snapshot 2024",
+            owner_org="lab",
+            resource_s3="s3://my-bucket/data/snapshot.csv",
+        )
+        assert out["s3_url"] == "s3://my-bucket/data/snapshot.csv"
+        body = m.call_args.kwargs["json_data"]
+        assert body["resource_s3"] == "s3://my-bucket/data/snapshot.csv"
+
+
+@pytest.mark.asyncio
+async def test_register_url_resource_with_filetype():
+    with patch.object(srv.ndp_client, "_make_request", new=AsyncMock(return_value={"ok": True})) as m:
+        await srv.register_url_resource(
+            resource_name="hourly-csv",
+            resource_title="Hourly CSV",
+            owner_org="lab",
+            resource_url="https://example.com/data.csv",
+            file_type="CSV",
+        )
+        body = m.call_args.kwargs["json_data"]
+        assert body["file_type"] == "CSV"
+
+
+# ── Search resources ────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_search_resources_basic():
+    with patch.object(
+        srv.ndp_client,
+        "_make_request",
+        new=AsyncMock(return_value=[{"name": "a"}, {"name": "b"}]),
+    ) as m:
+        out = await srv.search_resources(q="earthquake", limit=10)
+        assert out["count"] == 2
+        assert m.call_args.kwargs["params"]["q"] == "earthquake"
+        assert m.call_args.kwargs["params"]["limit"] == 10
+
+
+@pytest.mark.asyncio
+async def test_search_resources_dict_response():
+    """API may return {resources: [...]} instead of a bare list."""
+    with patch.object(
+        srv.ndp_client,
+        "_make_request",
+        new=AsyncMock(return_value={"resources": [{"name": "a"}]}),
+    ):
+        out = await srv.search_resources(format="NetCDF")
+        assert out["count"] == 1
+
+
+# ── Status / user ───────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_get_jupyter_details_returns_payload():
+    payload = {"url": "https://jhub.example.org", "kernels": ["python3"]}
+    with patch.object(srv.ndp_client, "_make_request", new=AsyncMock(return_value=payload)):
+        out = await srv.get_jupyter_details()
+        assert out["jupyter"] == payload
+        assert out["_meta"]["tool"] == "get_jupyter_details"
+
+
+@pytest.mark.asyncio
+async def test_get_user_info_returns_payload():
+    payload = {"sub": "alice", "email": "alice@example.org"}
+    with patch.object(srv.ndp_client, "_make_request", new=AsyncMock(return_value=payload)):
+        out = await srv.get_user_info()
+        assert out["user"] == payload
+
+
+# ── Error handling — all tools surface ToolError ────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_register_dataset_wraps_http_error():
+    with patch.object(
+        srv.ndp_client, "_make_request", new=AsyncMock(side_effect=Exception("HTTP 401"))
+    ):
+        with pytest.raises(srv.ToolError):
+            await srv.register_dataset(name="x", title="X", owner_org="org")
+
+
+@pytest.mark.asyncio
+async def test_search_resources_wraps_http_error():
+    with patch.object(
+        srv.ndp_client, "_make_request", new=AsyncMock(side_effect=Exception("boom"))
+    ):
+        with pytest.raises(srv.ToolError):
+            await srv.search_resources(q="anything")
+
+
+# ── Streaming / kafka tools ─────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_list_kafka_streams_parses_description_json():
+    """Each kafka resource's `description` is itself JSON with host/port/topic;
+    the tool should unpack it into compact rows."""
+    backend_resp = {
+        "count": 1,
+        "results": [{
+            "name": "earthscope_kafka_gnss_observations",
+            "url": "kafka://broker.example.org:9196/some-topic",
+            "description": (
+                '{"description": "Kafka GNSS observations from EarthScope",'
+                ' "host": "broker.example.org", "port": 9196,'
+                ' "topic": "public.gnss.positions"}'
+            ),
+        }]
+    }
+    with patch.object(srv.ndp_client, "_make_request",
+                       new=AsyncMock(return_value=backend_resp)) as m:
+        out = await srv.list_kafka_streams(name="gnss", limit=10)
+    assert out["count"] == 1
+    stream = out["streams"][0]
+    assert stream["topic"] == "public.gnss.positions"
+    assert stream["host"] == "broker.example.org"
+    assert stream["port"] == 9196
+    # Params: server defaults to 'local' (the one that doesn't need auth),
+    # format=kafka is auto-set
+    params = m.call_args.kwargs["params"]
+    assert params["format"] == "kafka"
+    assert params["server"] == "local"
+    assert params["name"] == "gnss"
+
+
+@pytest.mark.asyncio
+async def test_list_kafka_streams_handles_bare_list_response():
+    """Older backend revisions sometimes return a bare list."""
+    with patch.object(srv.ndp_client, "_make_request",
+                       new=AsyncMock(return_value=[
+                           {"name": "topic-a", "description": "not json"},
+                       ])):
+        out = await srv.list_kafka_streams()
+    assert out["count"] == 1
+    assert out["streams"][0]["name"] == "topic-a"
+
+
+@pytest.mark.asyncio
+async def test_get_kafka_details_returns_payload():
+    payload = {"bootstrap_servers": ["b1:9092"], "consumer_group_hint": "ndp-ep"}
+    with patch.object(srv.ndp_client, "_make_request",
+                       new=AsyncMock(return_value=payload)):
+        out = await srv.get_kafka_details()
+    assert out["kafka"] == payload
+
+
+@pytest.mark.asyncio
+async def test_get_system_metrics_returns_payload():
+    payload = {"cpu": 12.3, "mem": 4.2, "msg_rate": 100}
+    with patch.object(srv.ndp_client, "_make_request",
+                       new=AsyncMock(return_value=payload)):
+        out = await srv.get_system_metrics()
+    assert out["metrics"] == payload
+
+
+@pytest.mark.asyncio
+async def test_register_derived_stream_records_filter_in_mapping():
+    with patch.object(srv.ndp_client, "_make_request",
+                       new=AsyncMock(return_value={"id": "derived-1"})) as m:
+        out = await srv.register_derived_stream(
+            dataset_name="gnss-agmt",
+            dataset_title="GNSS AGMT.CI.LY.20 only",
+            owner_org="earthscope",
+            source_topic="public.gnss.positions",
+            dest_topic="derived.gnss.agmt",
+            dest_host="derived.broker.example.org",
+            dest_port=9092,
+            sncl_filter="AGMT.CI.LY.20",
+        )
+    body = m.call_args.kwargs["json_data"]
+    assert body["kafka_topic"] == "derived.gnss.agmt"
+    assert body["mapping"]["source_topic"] == "public.gnss.positions"
+    assert body["mapping"]["sncl_filter"] == "AGMT.CI.LY.20"
+    assert "Derived from public.gnss.positions" in body["dataset_description"]
+    assert out["derived_topic"] == "derived.gnss.agmt"
+
+
+@pytest.mark.asyncio
+async def test_list_kafka_streams_wraps_http_error():
+    with patch.object(srv.ndp_client, "_make_request",
+                       new=AsyncMock(side_effect=Exception("boom"))):
+        with pytest.raises(srv.ToolError):
+            await srv.list_kafka_streams()


### PR DESCRIPTION
## Summary

Extends the NDP MCP server from 3 read-only catalog tools to **14 total** by covering the rest of the NDP-EndPoint REST surface at \`http://155.101.6.191:8003\`. Same FastMCP 3.0 conventions; same \`NDPClient\` retry/backoff design.

### Tool inventory (3 existing + 11 new)

**Existing (unchanged)**
- \`list_organizations\`, \`search_datasets\`, \`get_dataset_details\`

**Registration (4, bearer auth)**
- \`register_dataset\`, \`register_kafka_topic\`, \`register_s3_resource\`, \`register_url_resource\`

**Resource discovery (1)**
- \`search_resources\` — \`GET /resources/search\` (local catalog)

**Status / user (2, bearer auth)**
- \`get_jupyter_details\`, \`get_user_info\`

**Streaming / EarthScope GNSS UI pattern (4)**
- \`list_kafka_streams\` — \`GET /resources/search?format=kafka\` (no auth on \`local\`); unpacks the resource's \`description\` JSON into \`{name, topic, host, port, url}\` rows.
- \`get_kafka_details\`, \`get_system_metrics\`
- \`register_derived_stream\` — \`POST /kafka\` with \`mapping={source_topic, sncl_filter}\` — matches the pattern behind \`vdc-192.chpc.utah.edu/gnss-ui/\`.

### Implementation

- \`NDPClient\` bearer-auth via \`NDP_BEARER_TOKEN\` env or config key, propagated through \`_headers()\`. Reads still work without it.
- All new tools have FastMCP 3.0 \`annotations\` + \`tags\` and raise \`ToolError\`.
- \`FastMCP(\"ndp\", list_page_size=10)\`. \`server.json\` updated.

### Tests — 97/97 passing

One existing test in \`test_ndp_client.py\` updated for the new \`headers=\` kwarg. \`tests/test_new_tools.py\` adds 18 cases.

### Live-verification

\`\`\`
list_organizations            → 84 orgs
search_datasets(["data"])     → 1000 datasets
list_kafka_streams(name=gnss) → earthscope_kafka_gnss_observations
get_kafka_details             → 401 (expected; needs bearer)
\`\`\`

## Test plan

- [ ] \`cd clio-kit-mcp-servers/ndp && uv run pytest -q\`
- [ ] Smoke \`uvx clio-kit ndp\` from any MCP-aware client
- [ ] \`uv run python ../../scripts/validate_fastmcp.py\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)