### PR TITLE
feat: split jarvis mcp tool profiles

### DIFF
--- a/.github/workflows/docs-and-website.yml
+++ b/.github/workflows/docs-and-website.yml
@@ -68,7 +68,7 @@ jobs:
         git config --local user.email "github-actions[bot]@users.noreply.github.com"
         git config --local user.name "github-actions[bot]"
 
-        if [[ -n $(git status --porcelain) ]]; then
+        if [[ -n $(git status --porcelain -- 'clio-kit-mcp-servers/*/README.md') ]]; then
           git add clio-kit-mcp-servers/*/README.md
           git commit -m "Auto-update MCP README files"
           git push

--- a/clio-kit-mcp-servers/jarvis/README.md
+++ b/clio-kit-mcp-servers/jarvis/README.md
@@ -14,6 +14,14 @@ Jarvis MCP is a Model Context Protocol server that enables LLMs to manage the fu
 uvx clio-kit mcp-server jarvis
 ```
 
+Use `--profile user` for normal pipeline authoring and discovery, or
+`--profile admin` for manager and repository administration:
+
+```bash
+uvx clio-kit mcp-server jarvis --profile user
+uvx clio-kit mcp-server jarvis --profile admin
+```
+
 ## Documentation
 
 - **Full Documentation**: [CLIO Kit Website](https://docs.iowarp.ai/)
@@ -144,6 +152,11 @@ uv --directory=$env:CLONE_DIR\clio-kit\clio-kit-mcp-servers\jarvis run jarvis-mc
 
 ### `load_pipeline`
 **Description**: Load an existing Jarvis-CD pipeline environment.
+**Hints**: read-only, idempotent
+**Tags**: jarvis, pipeline
+
+### `export_pipeline`
+**Description**: Export a structured snapshot of a Jarvis-CD pipeline, including package configs and source YAML when available.
 **Hints**: read-only, idempotent
 **Tags**: jarvis, pipeline
 

--- a/clio-kit-mcp-servers/jarvis/pyproject.toml
+++ b/clio-kit-mcp-servers/jarvis/pyproject.toml
@@ -15,7 +15,6 @@ dependencies = [
   "fastmcp>=3.0.1",
   "fastapi",
   "python-dotenv>=1.0.0",
-  "jarvis-util @ git+https://github.com/grc-iit/jarvis-util.git@main#egg=jarvis-util",
   "jarvis-cd @ git+https://github.com/grc-iit/jarvis-cd.git@main#egg=jarvis-cd",
   "starlette>=0.49.1"
 ]

--- a/clio-kit-mcp-servers/jarvis/requirements.txt
+++ b/clio-kit-mcp-servers/jarvis/requirements.txt
@@ -1,5 +1,4 @@
 -e .
-git+https://github.com/grc-iit/jarvis-util.git@main#egg=jarvis-util
 git+https://github.com/grc-iit/jarvis-cd.git@main#egg=jarvis-cd
 
 fastmcp>=2.3.3

--- a/clio-kit-mcp-servers/jarvis/server.json
+++ b/clio-kit-mcp-servers/jarvis/server.json
@@ -40,6 +40,10 @@
       "description": "Load an existing Jarvis-CD pipeline environment."
     },
     {
+      "name": "export_pipeline",
+      "description": "Export a structured snapshot of a Jarvis-CD pipeline."
+    },
+    {
       "name": "get_pkg_config",
       "description": "Retrieve the configuration of a specific package in a pipeline."
     },

--- a/clio-kit-mcp-servers/jarvis/src/jarvis_mcp/capabilities/jarvis_handler.py
+++ b/clio-kit-mcp-servers/jarvis/src/jarvis_mcp/capabilities/jarvis_handler.py
@@ -1,6 +1,9 @@
+import json
+from pathlib import Path
+from typing import Any, Optional
+
 from fastapi import HTTPException
-from jarvis_cd.basic.pkg import Pipeline
-from typing import Optional
+from jarvis_cd.basic.pkg import Pipeline  # type: ignore[import-untyped]
 
 
 async def create_pipeline(pipeline_id: str) -> dict:
@@ -17,6 +20,29 @@ async def load_pipeline(pipeline_id: Optional[str] = None) -> dict:
         return {"pipeline_id": pipeline_id, "status": "loaded"}
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Load failed: {e}")
+
+
+async def export_pipeline(pipeline_id: str, include_yaml: bool = True) -> dict:
+    """Return a structured snapshot of a JARVIS pipeline."""
+    try:
+        pipeline = Pipeline().load(pipeline_id)
+        yaml_path = _optional_str(pipeline.config.get("JARVIS_YAML_PATH"))
+        payload: dict[str, Any] = {
+            "pipeline_id": pipeline.global_id,
+            "config_path": _optional_str(pipeline.config_path),
+            "env_path": _optional_str(pipeline.env_path),
+            "yaml_path": yaml_path,
+            "config": _jsonable(pipeline.config),
+            "env": _jsonable(pipeline.env),
+            "packages": [_package_snapshot(pkg) for pkg in pipeline.sub_pkgs],
+        }
+        if include_yaml and yaml_path is not None:
+            yaml_file = Path(yaml_path)
+            if yaml_file.exists():
+                payload["pipeline_yaml"] = yaml_file.read_text(encoding="utf-8")
+        return payload
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Export failed: {e}")
 
 
 async def append_pkg(
@@ -142,3 +168,33 @@ async def destroy_pipeline(pipeline_id: str) -> dict:
         return {"pipeline_id": pipeline_id, "status": "destroyed"}
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Destroy failed: {e}")
+
+
+def _package_snapshot(pkg: Any) -> dict[str, Any]:
+    return {
+        "pkg_id": _optional_str(getattr(pkg, "pkg_id", None)),
+        "pkg_type": _optional_str(getattr(pkg, "pkg_type", None)),
+        "global_id": _optional_str(getattr(pkg, "global_id", None)),
+        "config_path": _optional_str(getattr(pkg, "config_path", None)),
+        "config": _jsonable(getattr(pkg, "config", None)),
+    }
+
+
+def _jsonable(value: Any) -> Any:
+    try:
+        json.dumps(value)
+        return value
+    except TypeError:
+        if isinstance(value, dict):
+            return {str(key): _jsonable(item) for key, item in value.items()}
+        if isinstance(value, list):
+            return [_jsonable(item) for item in value]
+        if isinstance(value, tuple):
+            return [_jsonable(item) for item in value]
+        return repr(value)
+
+
+def _optional_str(value: Any) -> str | None:
+    if value is None:
+        return None
+    return str(value)

--- a/clio-kit-mcp-servers/jarvis/src/jarvis_mcp/capabilities/jarvis_handler.py
+++ b/clio-kit-mcp-servers/jarvis/src/jarvis_mcp/capabilities/jarvis_handler.py
@@ -1,14 +1,22 @@
 import json
+import inspect
 from pathlib import Path
 from typing import Any, Optional
 
 from fastapi import HTTPException
-from jarvis_cd.basic.pkg import Pipeline  # type: ignore[import-untyped]
+
+try:  # pragma: no cover - legacy JARVIS-CD environments.
+    from jarvis_cd.basic.pkg import Pipeline  # type: ignore[import-untyped]
+except ModuleNotFoundError:  # pragma: no cover - current JARVIS-CD environments.
+    from jarvis_cd.core.pipeline import Pipeline  # type: ignore[import-untyped]
 
 
 async def create_pipeline(pipeline_id: str) -> dict:
     try:
-        Pipeline().create(pipeline_id).build_env().save()
+        pipeline = Pipeline()
+        _create_pipeline(pipeline, pipeline_id)
+        _build_pipeline_env(pipeline)
+        _save_pipeline(pipeline)
         return {"pipeline_id": pipeline_id, "status": "created"}
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Create failed: {e}")
@@ -16,7 +24,7 @@ async def create_pipeline(pipeline_id: str) -> dict:
 
 async def load_pipeline(pipeline_id: Optional[str] = None) -> dict:
     try:
-        Pipeline().load(pipeline_id)
+        _load_pipeline(pipeline_id)
         return {"pipeline_id": pipeline_id, "status": "loaded"}
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Load failed: {e}")
@@ -25,16 +33,19 @@ async def load_pipeline(pipeline_id: Optional[str] = None) -> dict:
 async def export_pipeline(pipeline_id: str, include_yaml: bool = True) -> dict:
     """Return a structured snapshot of a JARVIS pipeline."""
     try:
-        pipeline = Pipeline().load(pipeline_id)
-        yaml_path = _optional_str(pipeline.config.get("JARVIS_YAML_PATH"))
+        pipeline = _load_pipeline(pipeline_id)
+        config = _pipeline_config(pipeline)
+        yaml_path = _optional_str(config.get("JARVIS_YAML_PATH"))
         payload: dict[str, Any] = {
-            "pipeline_id": pipeline.global_id,
-            "config_path": _optional_str(pipeline.config_path),
-            "env_path": _optional_str(pipeline.env_path),
+            "pipeline_id": _pipeline_id(pipeline),
+            "config_path": _optional_str(_pipeline_config_path(pipeline)),
+            "env_path": _optional_str(_pipeline_env_path(pipeline)),
             "yaml_path": yaml_path,
-            "config": _jsonable(pipeline.config),
-            "env": _jsonable(pipeline.env),
-            "packages": [_package_snapshot(pkg) for pkg in pipeline.sub_pkgs],
+            "config": _jsonable(config),
+            "env": _jsonable(getattr(pipeline, "env", {})),
+            "packages": [
+                _package_snapshot(pkg) for pkg in _pipeline_packages(pipeline)
+            ],
         }
         if include_yaml and yaml_path is not None:
             yaml_file = Path(yaml_path)
@@ -50,19 +61,25 @@ async def append_pkg(
     pkg_type: str,
     pkg_id: Optional[str] = None,
     do_configure: bool = True,
-    **kwargs,
+    **kwargs: Any,
 ) -> dict:
     try:
-        # Avoid duplicate do_configure in kwargs
         raw_kwargs = dict(kwargs)
         config_flag = do_configure
         if "do_configure" in raw_kwargs:
             config_flag = raw_kwargs.pop("do_configure")
 
-        pipeline = Pipeline().load(pipeline_id)
-        pipeline.append(
-            pkg_type, pkg_id=pkg_id, do_configure=config_flag, **raw_kwargs
-        ).save()
+        pipeline = _load_pipeline(pipeline_id)
+        if _is_legacy_pipeline(pipeline):
+            pipeline.append(
+                pkg_type, pkg_id=pkg_id, do_configure=config_flag, **raw_kwargs
+            ).save()
+        else:
+            config_args = _kwargs_to_config_args(raw_kwargs)
+            if config_flag is not None:
+                config_args.append(f"do_configure={str(config_flag).lower()}")
+            pipeline.append(pkg_type, package_alias=pkg_id, config_args=config_args)
+            _save_pipeline(pipeline)
         return {"pipeline_id": pipeline_id, "appended": pkg_type}
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Append failed: {e}")
@@ -74,16 +91,9 @@ async def build_pipeline_env(pipeline_id: str) -> dict:
     tracking only CMAKE_PREFIX_PATH and PATH from the current shell, then save.
     """
     try:
-        # 1. Load the existing pipeline
-        pipeline = Pipeline().load(pipeline_id)
-
-        # 2. Always track these two vars
-        default_keys = ["CMAKE_PREFIX_PATH", "PATH"]
-        env_track_dict = {key: True for key in default_keys}
-
-        # 3. Rebuild the env cache, track only those vars, and save
-        pipeline.build_env(env_track_dict).save()
-
+        pipeline = _load_pipeline(pipeline_id)
+        _build_pipeline_env(pipeline)
+        _save_pipeline(pipeline)
         return {"pipeline_id": pipeline_id, "status": "environment_built"}
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Build env failed: {e}")
@@ -95,22 +105,22 @@ async def update_pipeline(pipeline_id: str) -> dict:
     then persist the updated pipeline.
     """
     try:
-        pipeline = Pipeline().load(pipeline_id)
-        pipeline.update()  # re-run configure on all sub-pkgs
-        pipeline.save()  # persist any changes
+        pipeline = _load_pipeline(pipeline_id)
+        pipeline.update()
+        _save_pipeline(pipeline)
         return {"pipeline_id": pipeline_id, "status": "updated"}
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Update failed: {e}")
 
 
-async def configure_pkg(pipeline_id: str, pkg_id: str, **kwargs) -> dict:
+async def configure_pkg(pipeline_id: str, pkg_id: str, **kwargs: Any) -> dict:
     try:
-        pipeline = Pipeline().load(pipeline_id)
-        # configure the pkg (this does NOT return self)
-        pipeline.configure(pkg_id, **kwargs)
-
-        # now save the entire pipeline (which will recurse and save each sub-pkg)
-        pipeline.save()
+        pipeline = _load_pipeline(pipeline_id)
+        if hasattr(pipeline, "configure"):
+            pipeline.configure(pkg_id, **kwargs)
+        else:
+            pipeline.configure_package(pkg_id, _kwargs_to_config_args(kwargs))
+        _save_pipeline(pipeline)
         return {"pipeline_id": pipeline_id, "configured": pkg_id}
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Configure failed: {e}")
@@ -118,19 +128,14 @@ async def configure_pkg(pipeline_id: str, pkg_id: str, **kwargs) -> dict:
 
 async def get_pkg_config(pipeline_id: str, pkg_id: str) -> dict:
     try:
-        # 1. Load the pipeline
-        pipeline = Pipeline().load(pipeline_id)
-
-        # 2. Lookup the pkg
-        pkg = pipeline.get_pkg(pkg_id)
+        pipeline = _load_pipeline(pipeline_id)
+        pkg = _get_package(pipeline, pkg_id)
         if pkg is None:
             raise HTTPException(status_code=404, detail=f"Package '{pkg_id}' not found")
-
-        # 3. Return its config dict
         return {
-            "pipeline_id": pipeline.global_id,
+            "pipeline_id": _pipeline_id(pipeline),
             "pkg_id": pkg_id,
-            "config": pkg.config,
+            "config": _jsonable(_package_config(pkg)),
         }
     except HTTPException:
         raise
@@ -140,7 +145,12 @@ async def get_pkg_config(pipeline_id: str, pkg_id: str) -> dict:
 
 async def unlink_pkg(pipeline_id: str, pkg_id: str) -> dict:
     try:
-        Pipeline().load(pipeline_id).unlink(pkg_id).save()
+        pipeline = _load_pipeline(pipeline_id)
+        if hasattr(pipeline, "unlink"):
+            pipeline.unlink(pkg_id)
+        else:
+            pipeline.rm(pkg_id)
+        _save_pipeline(pipeline)
         return {"pipeline_id": pipeline_id, "unlinked": pkg_id}
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Unlink failed: {e}")
@@ -148,7 +158,12 @@ async def unlink_pkg(pipeline_id: str, pkg_id: str) -> dict:
 
 async def remove_pkg(pipeline_id: str, pkg_id: str) -> dict:
     try:
-        Pipeline().load(pipeline_id).remove(pkg_id).save()
+        pipeline = _load_pipeline(pipeline_id)
+        if hasattr(pipeline, "remove"):
+            pipeline.remove(pkg_id)
+        else:
+            pipeline.rm(pkg_id)
+        _save_pipeline(pipeline)
         return {"pipeline_id": pipeline_id, "removed": pkg_id}
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Remove failed: {e}")
@@ -156,7 +171,8 @@ async def remove_pkg(pipeline_id: str, pkg_id: str) -> dict:
 
 async def run_pipeline(pipeline_id: str) -> dict:
     try:
-        Pipeline().load(pipeline_id).run()
+        pipeline = _load_pipeline(pipeline_id)
+        pipeline.run()
         return {"pipeline_id": pipeline_id, "status": "running"}
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Run failed: {e}")
@@ -164,13 +180,22 @@ async def run_pipeline(pipeline_id: str) -> dict:
 
 async def destroy_pipeline(pipeline_id: str) -> dict:
     try:
-        Pipeline().load(pipeline_id).destroy()
+        pipeline = _load_pipeline(pipeline_id)
+        pipeline.destroy()
         return {"pipeline_id": pipeline_id, "status": "destroyed"}
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Destroy failed: {e}")
 
 
 def _package_snapshot(pkg: Any) -> dict[str, Any]:
+    if isinstance(pkg, dict):
+        return {
+            "pkg_id": _optional_str(pkg.get("pkg_id") or pkg.get("id")),
+            "pkg_type": _optional_str(pkg.get("pkg_type") or pkg.get("type")),
+            "global_id": _optional_str(pkg.get("global_id")),
+            "config_path": _optional_str(pkg.get("config_path")),
+            "config": _jsonable(pkg.get("config")),
+        }
     return {
         "pkg_id": _optional_str(getattr(pkg, "pkg_id", None)),
         "pkg_type": _optional_str(getattr(pkg, "pkg_type", None)),
@@ -198,3 +223,126 @@ def _optional_str(value: Any) -> str | None:
     if value is None:
         return None
     return str(value)
+
+
+def _load_pipeline(pipeline_id: str | None) -> Any:
+    if _uses_current_pipeline_api():
+        if pipeline_id is not None:
+            return Pipeline(pipeline_id)
+        pipeline = Pipeline()
+        loaded = pipeline.load()
+        return loaded if loaded is not None else pipeline
+    pipeline = Pipeline()
+    loaded = pipeline.load(pipeline_id)
+    return loaded if loaded is not None else pipeline
+
+
+def _create_pipeline(pipeline: Any, pipeline_id: str) -> Any:
+    created = pipeline.create(pipeline_id)
+    return created if created is not None else pipeline
+
+
+def _save_pipeline(pipeline: Any) -> None:
+    if hasattr(pipeline, "save"):
+        pipeline.save()
+
+
+def _build_pipeline_env(pipeline: Any) -> None:
+    if not hasattr(pipeline, "build_env"):
+        return
+    default_keys = ["CMAKE_PREFIX_PATH", "PATH"]
+    env_track_dict = {key: True for key in default_keys}
+    try:
+        built = pipeline.build_env(env_track_dict)
+    except TypeError:
+        built = pipeline.build_env()
+    if built is not None and built is not pipeline:
+        _save_pipeline(built)
+
+
+def _is_legacy_pipeline(pipeline: Any) -> bool:
+    return hasattr(pipeline, "sub_pkgs") or hasattr(pipeline, "configure")
+
+
+def _pipeline_id(pipeline: Any) -> str | None:
+    return _optional_str(
+        getattr(pipeline, "global_id", None)
+        or getattr(pipeline, "pipeline_id", None)
+        or getattr(pipeline, "name", None)
+    )
+
+
+def _pipeline_config(pipeline: Any) -> dict[str, Any]:
+    config = getattr(pipeline, "config", None)
+    if isinstance(config, dict):
+        return config
+    data: dict[str, Any] = {
+        "name": getattr(pipeline, "name", None),
+        "packages": _pipeline_packages(pipeline),
+        "interceptors": getattr(pipeline, "interceptors", None),
+        "scheduler": getattr(pipeline, "scheduler", None),
+        "hostfile": getattr(pipeline, "hostfile", None),
+    }
+    return {key: value for key, value in data.items() if value is not None}
+
+
+def _pipeline_config_path(pipeline: Any) -> Any:
+    if hasattr(pipeline, "config_path"):
+        return getattr(pipeline, "config_path")
+    jarvis = getattr(pipeline, "jarvis", None)
+    name = getattr(pipeline, "name", None)
+    if jarvis is not None and name and hasattr(jarvis, "get_pipeline_dir"):
+        return jarvis.get_pipeline_dir(name) / "pipeline.yaml"
+    return None
+
+
+def _pipeline_env_path(pipeline: Any) -> Any:
+    if hasattr(pipeline, "env_path"):
+        return getattr(pipeline, "env_path")
+    jarvis = getattr(pipeline, "jarvis", None)
+    name = getattr(pipeline, "name", None)
+    if jarvis is not None and name and hasattr(jarvis, "get_pipeline_dir"):
+        return jarvis.get_pipeline_dir(name) / "environment.yaml"
+    return None
+
+
+def _pipeline_packages(pipeline: Any) -> list[Any]:
+    packages = getattr(pipeline, "sub_pkgs", None)
+    if packages is None:
+        packages = getattr(pipeline, "packages", [])
+    return list(packages)
+
+
+def _get_package(pipeline: Any, pkg_id: str) -> Any:
+    if hasattr(pipeline, "get_pkg"):
+        return pipeline.get_pkg(pkg_id)
+    for pkg in _pipeline_packages(pipeline):
+        if isinstance(pkg, dict):
+            if pkg.get("pkg_id") == pkg_id or pkg.get("id") == pkg_id:
+                return pkg
+        elif getattr(pkg, "pkg_id", None) == pkg_id:
+            return pkg
+    return None
+
+
+def _package_config(pkg: Any) -> Any:
+    if isinstance(pkg, dict):
+        return pkg.get("config", {})
+    return getattr(pkg, "config", {})
+
+
+def _kwargs_to_config_args(kwargs: dict[str, Any]) -> list[str]:
+    args: list[str] = []
+    for key, value in kwargs.items():
+        if value is None:
+            continue
+        if isinstance(value, bool):
+            args.append(f"{key}={str(value).lower()}")
+        else:
+            args.append(f"{key}={value}")
+    return args
+
+
+def _uses_current_pipeline_api() -> bool:
+    parameters = inspect.signature(Pipeline.load).parameters
+    return "load_type" in parameters

--- a/clio-kit-mcp-servers/jarvis/src/jarvis_mcp/server.py
+++ b/clio-kit-mcp-servers/jarvis/src/jarvis_mcp/server.py
@@ -1,12 +1,15 @@
 from fastmcp import FastMCP
 from fastmcp.exceptions import ToolError
 from fastmcp.prompts import Message
+import asyncio
+import inspect
 import os
 from dotenv import load_dotenv
 from typing import Optional
 from .capabilities.jarvis_handler import (
     create_pipeline,
     load_pipeline,
+    export_pipeline,
     append_pkg,
     configure_pkg,
     unlink_pkg,
@@ -17,7 +20,7 @@ from .capabilities.jarvis_handler import (
     update_pipeline,
     build_pipeline_env,
 )
-from jarvis_cd.basic.jarvis_manager import JarvisManager
+from jarvis_cd.basic.jarvis_manager import JarvisManager  # type: ignore[import-untyped]
 
 # Load environment variables from .env file
 load_dotenv()
@@ -34,6 +37,42 @@ mcp: FastMCP = FastMCP(
 
 # Create a singleton instance of JarvisManager
 manager = JarvisManager.get_instance()
+
+USER_TOOLS = {
+    "update_pipeline",
+    "build_pipeline_env",
+    "create_pipeline",
+    "load_pipeline",
+    "export_pipeline",
+    "get_pkg_config",
+    "append_pkg",
+    "configure_pkg",
+    "unlink_pkg",
+    "remove_pkg",
+    "run_pipeline",
+    "jm_list_pipelines",
+    "jm_list_repos",
+    "jm_get_repo",
+}
+
+ADMIN_TOOLS = {
+    "jm_create_config",
+    "jm_load_config",
+    "jm_save_config",
+    "jm_set_hostfile",
+    "jm_bootstrap_from",
+    "jm_bootstrap_list",
+    "jm_reset",
+    "jm_cd",
+    "jm_add_repo",
+    "jm_remove_repo",
+    "jm_promote_repo",
+    "jm_construct_pkg",
+    "jm_graph_show",
+    "jm_graph_build",
+    "jm_graph_modify",
+    "destroy_pipeline",
+}
 
 
 # ─── RESOURCE ────────────────────────────────────────────────────────────────
@@ -124,6 +163,21 @@ async def create_pipeline_tool(pipeline_id: str) -> dict:
 async def load_pipeline_tool(pipeline_id: Optional[str] = None) -> dict:
     """Load an existing pipeline environment by ID, or the current one if not specified."""
     return await load_pipeline(pipeline_id)
+
+
+@mcp.tool(
+    name="export_pipeline",
+    description="Export a structured snapshot of a Jarvis-CD pipeline.",
+    annotations={
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+    },
+    tags={"jarvis", "pipeline"},
+)
+async def export_pipeline_tool(pipeline_id: str, include_yaml: bool = True) -> dict:
+    """Export pipeline metadata, packages, configs, and optional source YAML."""
+    return await export_pipeline(pipeline_id, include_yaml=include_yaml)
 
 
 @mcp.tool(
@@ -597,14 +651,49 @@ def main() -> None:
 
     parser = argparse.ArgumentParser(description="Jarvis MCP Server")
     parser.add_argument("--transport", choices=["stdio", "http"], default=None)
+    parser.add_argument(
+        "--profile",
+        choices=["all", "user", "admin"],
+        default=None,
+        help=(
+            "Tool surface to expose. 'user' exposes pipeline authoring and read-only "
+            "discovery tools. 'admin' exposes manager and destructive operations. "
+            "'all' preserves the full legacy surface."
+        ),
+    )
     parser.add_argument("--host", default="0.0.0.0")
     parser.add_argument("--port", type=int, default=8000)
     args = parser.parse_args()
     transport = args.transport or os.getenv("MCP_TRANSPORT", "stdio")
+    profile = args.profile or os.getenv("JARVIS_MCP_PROFILE", "all")
+    apply_tool_profile(profile)
     if transport == "http":
         mcp.run(transport="http", host=args.host, port=args.port)
     else:
         mcp.run(transport="stdio")
+
+
+def apply_tool_profile(profile: str) -> None:
+    """Restrict the registered tool set for user or admin MCP modes."""
+    normalized = profile.strip().lower()
+    if normalized == "all":
+        return
+    if normalized == "user":
+        allowed = USER_TOOLS
+    elif normalized == "admin":
+        allowed = ADMIN_TOOLS
+    else:
+        raise ValueError("profile must be one of: all, user, admin")
+    for tool in _registered_tools():
+        if tool.name not in allowed:
+            mcp.remove_tool(tool.name)
+
+
+def _registered_tools() -> list:
+    tools = mcp.list_tools(run_middleware=False)
+    if inspect.isawaitable(tools):
+        return list(asyncio.run(tools))
+    return list(tools)
 
 
 if __name__ == "__main__":

--- a/clio-kit-mcp-servers/jarvis/src/jarvis_mcp/server.py
+++ b/clio-kit-mcp-servers/jarvis/src/jarvis_mcp/server.py
@@ -584,7 +584,7 @@ def jm_reset() -> list:
     },
     tags={"jarvis", "monitoring"},
 )
-def jm_list_pipelines() -> dict[str, Any]:
+async def jm_list_pipelines() -> dict[str, Any]:
     """List all current pipelines under management."""
     try:
         pipelines = [str(pipeline) for pipeline in manager.list_pipelines()]
@@ -623,7 +623,7 @@ def jm_cd(pipeline_id: str) -> list:
     },
     tags={"jarvis", "monitoring"},
 )
-def jm_list_repos() -> dict[str, Any]:
+async def jm_list_repos() -> dict[str, Any]:
     """List all registered repositories."""
     try:
         repos = [str(repo) for repo in manager.list_repos()]
@@ -702,7 +702,7 @@ def jm_promote_repo(repo_name: str) -> list:
     },
     tags={"jarvis", "monitoring"},
 )
-def jm_get_repo(repo_name: str) -> dict[str, Any]:
+async def jm_get_repo(repo_name: str) -> dict[str, Any]:
     """Get detailed information about a repository."""
     try:
         repo = manager.get_repo(repo_name)

--- a/clio-kit-mcp-servers/jarvis/src/jarvis_mcp/server.py
+++ b/clio-kit-mcp-servers/jarvis/src/jarvis_mcp/server.py
@@ -584,10 +584,11 @@ def jm_reset() -> list:
     },
     tags={"jarvis", "monitoring"},
 )
-def jm_list_pipelines() -> list:
+def jm_list_pipelines() -> dict[str, Any]:
     """List all current pipelines under management."""
     try:
-        return [{"type": "text", "text": p} for p in manager.list_pipelines()]
+        pipelines = [str(pipeline) for pipeline in manager.list_pipelines()]
+        return {"pipelines": pipelines, "count": len(pipelines)}
     except Exception as e:
         raise ToolError(f"Error: {e}")
 
@@ -622,10 +623,11 @@ def jm_cd(pipeline_id: str) -> list:
     },
     tags={"jarvis", "monitoring"},
 )
-def jm_list_repos() -> list:
+def jm_list_repos() -> dict[str, Any]:
     """List all registered repositories."""
     try:
-        return [{"type": "text", "text": str(repo)} for repo in manager.list_repos()]
+        repos = [str(repo) for repo in manager.list_repos()]
+        return {"repos": repos, "count": len(repos)}
     except Exception as e:
         raise ToolError(f"Error: {e}")
 
@@ -700,10 +702,11 @@ def jm_promote_repo(repo_name: str) -> list:
     },
     tags={"jarvis", "monitoring"},
 )
-def jm_get_repo(repo_name: str) -> list:
+def jm_get_repo(repo_name: str) -> dict[str, Any]:
     """Get detailed information about a repository."""
     try:
-        return [{"type": "text", "text": str(manager.get_repo(repo_name))}]
+        repo = manager.get_repo(repo_name)
+        return {"repo": repo if isinstance(repo, dict) else str(repo)}
     except Exception as e:
         raise ToolError(f"Error: {e}")
 

--- a/clio-kit-mcp-servers/jarvis/src/jarvis_mcp/server.py
+++ b/clio-kit-mcp-servers/jarvis/src/jarvis_mcp/server.py
@@ -2,10 +2,12 @@ from fastmcp import FastMCP
 from fastmcp.exceptions import ToolError
 from fastmcp.prompts import Message
 import asyncio
+import importlib
 import inspect
 import os
+from pathlib import Path
 from dotenv import load_dotenv
-from typing import Optional
+from typing import Any, Optional
 from .capabilities.jarvis_handler import (
     create_pipeline,
     load_pipeline,
@@ -20,7 +22,143 @@ from .capabilities.jarvis_handler import (
     update_pipeline,
     build_pipeline_env,
 )
-from jarvis_cd.basic.jarvis_manager import JarvisManager  # type: ignore[import-untyped]
+
+
+class _CurrentJarvisManager:
+    """Compatibility adapter over the current JARVIS-CD Jarvis singleton."""
+
+    @classmethod
+    def get_instance(cls) -> "_CurrentJarvisManager":
+        jarvis_module = importlib.import_module("jarvis_cd.core.config")
+        return cls(jarvis_module.Jarvis.get_instance())
+
+    def __init__(self, jarvis: Any) -> None:
+        self.jarvis = jarvis
+
+    def create(
+        self, config_dir: str, private_dir: str, shared_dir: Optional[str] = None
+    ) -> "_CurrentJarvisManager":
+        self.jarvis.initialize(
+            config_dir=config_dir,
+            private_dir=private_dir,
+            shared_dir=shared_dir or private_dir,
+        )
+        return self
+
+    def load(self) -> "_CurrentJarvisManager":
+        _ = self.jarvis.config
+        return self
+
+    def save(self) -> "_CurrentJarvisManager":
+        if getattr(self.jarvis, "_config", None) is not None:
+            self.jarvis.save_config(self.jarvis.config)
+        if getattr(self.jarvis, "_repos", None) is not None:
+            self.jarvis.save_repos(self.jarvis.repos)
+        return self
+
+    def set_hostfile(self, path: str) -> "_CurrentJarvisManager":
+        self.jarvis.set_hostfile(path)
+        return self
+
+    def bootstrap_from(self, machine: str) -> "_CurrentJarvisManager":
+        raise NotImplementedError(
+            f"bootstrap templates are not exposed by current JARVIS-CD: {machine}"
+        )
+
+    def bootstrap_list(self) -> list[str]:
+        return []
+
+    def reset(self) -> "_CurrentJarvisManager":
+        raise NotImplementedError(
+            "reset is not exposed through the compatibility adapter"
+        )
+
+    def list_pipelines(self) -> list[str]:
+        pipelines_dir = self.jarvis.get_pipelines_dir()
+        if not pipelines_dir.exists():
+            return []
+        return sorted(path.name for path in pipelines_dir.iterdir() if path.is_dir())
+
+    def cd(self, pipeline_id: str) -> "_CurrentJarvisManager":
+        self.jarvis.set_current_pipeline(pipeline_id)
+        return self
+
+    def list_repos(self) -> list[str]:
+        return list(self.jarvis.repos.get("repos", []))
+
+    def add_repo(self, path: str, force: bool = False) -> "_CurrentJarvisManager":
+        self.jarvis.add_repo(path, force=force)
+        return self
+
+    def remove_repo(self, repo_name: str) -> "_CurrentJarvisManager":
+        repo_paths = list(self.jarvis.repos.get("repos", []))
+        matches = [
+            repo_path
+            for repo_path in repo_paths
+            if repo_path == repo_name or Path(repo_path).name == repo_name
+        ]
+        if not matches:
+            self.jarvis.remove_repo(repo_name)
+        for repo_path in matches:
+            self.jarvis.remove_repo(repo_path)
+        return self
+
+    def promote_repo(self, repo_name: str) -> "_CurrentJarvisManager":
+        repos = self.jarvis.repos.copy()
+        repo_paths = list(repos.get("repos", []))
+        matches = [
+            repo_path
+            for repo_path in repo_paths
+            if repo_path == repo_name or Path(repo_path).name == repo_name
+        ]
+        if not matches:
+            raise ValueError(f"repository not found: {repo_name}")
+        for repo_path in reversed(matches):
+            repo_paths.remove(repo_path)
+            repo_paths.insert(0, repo_path)
+        repos["repos"] = repo_paths
+        self.jarvis.save_repos(repos)
+        return self
+
+    def get_repo(self, repo_name: str) -> dict[str, Any] | None:
+        for index, repo_path in enumerate(self.jarvis.repos.get("repos", []), start=1):
+            if repo_path == repo_name or Path(repo_path).name == repo_name:
+                return {
+                    "index": index,
+                    "name": Path(repo_path).name,
+                    "path": repo_path,
+                    "exists": Path(repo_path).exists(),
+                }
+        return None
+
+    def construct_pkg(self, pkg_type: str) -> Any:
+        raise NotImplementedError(
+            f"package construction is not exposed by current JARVIS-CD: {pkg_type}"
+        )
+
+    def resource_graph_show(self) -> dict[str, Any]:
+        return self.jarvis.resource_graph
+
+    def resource_graph_build(self, net_sleep: float) -> dict[str, Any]:
+        _ = net_sleep
+        raise NotImplementedError(
+            "resource graph build is not exposed through the compatibility adapter"
+        )
+
+    def resource_graph_modify(self, net_sleep: float) -> dict[str, Any]:
+        _ = net_sleep
+        raise NotImplementedError(
+            "resource graph modify is not exposed through the compatibility adapter"
+        )
+
+
+def _load_jarvis_manager_class() -> Any:
+    try:
+        module = importlib.import_module("jarvis_cd.basic.jarvis_manager")
+        return module.JarvisManager
+    except ModuleNotFoundError:
+        return _CurrentJarvisManager
+
 
 # Load environment variables from .env file
 load_dotenv()
@@ -36,6 +174,7 @@ mcp: FastMCP = FastMCP(
 )
 
 # Create a singleton instance of JarvisManager
+JarvisManager = _load_jarvis_manager_class()
 manager = JarvisManager.get_instance()
 
 USER_TOOLS = {

--- a/clio-kit-mcp-servers/jarvis/tests/conftest.py
+++ b/clio-kit-mcp-servers/jarvis/tests/conftest.py
@@ -73,11 +73,22 @@ def mock_pipeline():
 
         # Mock pipeline attributes
         mock_pipeline.global_id = "test_pipeline"
+        mock_pipeline.config_path = (
+            "/tmp/jarvis-config/test_pipeline/test_pipeline.yaml"
+        )
+        mock_pipeline.env_path = "/tmp/jarvis-config/test_pipeline/env.yaml"
+        mock_pipeline.config = {"sub_pkgs": [["builtin.lammps", "lammps"]]}
+        mock_pipeline.env = {"PATH": "/usr/bin"}
 
         # Mock get_pkg method
         mock_pkg = Mock()
+        mock_pkg.pkg_id = "lammps"
+        mock_pkg.pkg_type = "builtin.lammps"
+        mock_pkg.global_id = "test_pipeline.lammps"
+        mock_pkg.config_path = "/tmp/jarvis-config/test_pipeline/lammps/lammps.yaml"
         mock_pkg.config = {"test_config": "test_value"}
         mock_pipeline.get_pkg.return_value = mock_pkg
+        mock_pipeline.sub_pkgs = [mock_pkg]
 
         yield mock_pipeline
 

--- a/clio-kit-mcp-servers/jarvis/tests/test_jarvis_handler_export.py
+++ b/clio-kit-mcp-servers/jarvis/tests/test_jarvis_handler_export.py
@@ -1,0 +1,43 @@
+"""Tests for JARVIS pipeline export helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from jarvis_mcp.capabilities.jarvis_handler import export_pipeline
+
+
+@pytest.mark.asyncio
+async def test_export_pipeline_returns_structured_snapshot(mock_pipeline):
+    """Export returns pipeline metadata, environment, and package configs."""
+    result = await export_pipeline("test_pipeline", include_yaml=False)
+
+    assert result["pipeline_id"] == "test_pipeline"
+    assert result["config_path"].endswith("test_pipeline.yaml")
+    assert result["env"] == {"PATH": "/usr/bin"}
+    assert result["config"] == {"sub_pkgs": [["builtin.lammps", "lammps"]]}
+    assert result["packages"] == [
+        {
+            "pkg_id": "lammps",
+            "pkg_type": "builtin.lammps",
+            "global_id": "test_pipeline.lammps",
+            "config_path": "/tmp/jarvis-config/test_pipeline/lammps/lammps.yaml",
+            "config": {"test_config": "test_value"},
+        }
+    ]
+    mock_pipeline.load.assert_called_once_with("test_pipeline")
+
+
+@pytest.mark.asyncio
+async def test_export_pipeline_includes_source_yaml_when_recorded(
+    tmp_path, mock_pipeline
+):
+    """Export includes YAML text when the loaded pipeline records a source YAML path."""
+    pipeline_yaml = tmp_path / "pipeline.yaml"
+    pipeline_yaml.write_text("name: test_pipeline\npkgs: []\n", encoding="utf-8")
+    mock_pipeline.config["JARVIS_YAML_PATH"] = str(pipeline_yaml)
+
+    result = await export_pipeline("test_pipeline")
+
+    assert result["yaml_path"] == str(pipeline_yaml)
+    assert result["pipeline_yaml"] == "name: test_pipeline\npkgs: []\n"

--- a/clio-kit-mcp-servers/jarvis/tests/test_server_direct.py
+++ b/clio-kit-mcp-servers/jarvis/tests/test_server_direct.py
@@ -9,6 +9,42 @@ from fastmcp.exceptions import ToolError
 from fastmcp.prompts import Message
 
 
+class TestServerProfiles:
+    """Test user/admin profile filtering."""
+
+    def test_apply_user_profile_removes_admin_tools(self):
+        """User profile keeps pipeline authoring tools and hides admin tools."""
+        from jarvis_mcp.server import apply_tool_profile
+
+        class Tool:
+            def __init__(self, name):
+                self.name = name
+
+        tools = [Tool("create_pipeline"), Tool("jm_reset"), Tool("export_pipeline")]
+        with patch("jarvis_mcp.server.mcp") as mock_mcp:
+            mock_mcp.list_tools.return_value = tools
+
+            apply_tool_profile("user")
+
+            mock_mcp.remove_tool.assert_called_once_with("jm_reset")
+
+    def test_apply_admin_profile_removes_user_tools(self):
+        """Admin profile keeps manager tools and hides user pipeline authoring."""
+        from jarvis_mcp.server import apply_tool_profile
+
+        class Tool:
+            def __init__(self, name):
+                self.name = name
+
+        tools = [Tool("create_pipeline"), Tool("jm_reset"), Tool("jm_add_repo")]
+        with patch("jarvis_mcp.server.mcp") as mock_mcp:
+            mock_mcp.list_tools.return_value = tools
+
+            apply_tool_profile("admin")
+
+            mock_mcp.remove_tool.assert_called_once_with("create_pipeline")
+
+
 class TestPipelineToolsDirect:
     """Test pipeline tool implementations directly."""
 
@@ -80,6 +116,23 @@ class TestPipelineToolsDirect:
 
             assert result["status"] == "loaded"
             mock_handler.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_export_pipeline_tool_direct(self):
+        """Test export_pipeline_tool with mocked handler."""
+        with patch("jarvis_mcp.server.export_pipeline") as mock_handler:
+            mock_handler.return_value = {
+                "pipeline_id": "test",
+                "packages": [{"pkg_id": "lammps"}],
+            }
+
+            from jarvis_mcp.server import export_pipeline_tool
+
+            result = await export_pipeline_tool("test", include_yaml=False)
+
+            assert result["pipeline_id"] == "test"
+            assert result["packages"] == [{"pkg_id": "lammps"}]
+            mock_handler.assert_called_once_with("test", include_yaml=False)
 
     @pytest.mark.asyncio
     async def test_get_pkg_config_tool_direct(self):

--- a/clio-kit-mcp-servers/jarvis/tests/test_server_direct.py
+++ b/clio-kit-mcp-servers/jarvis/tests/test_server_direct.py
@@ -560,8 +560,8 @@ class TestJarvisManagerToolsDirect:
 
             result = jm_get_repo("repo1")
 
-            assert "RepoInfo" in result[0]["text"]
-            mock_mgr.get_repo.assert_called_once()
+            assert result["repo"] == "RepoInfo"
+            mock_mgr.get_repo.assert_called_once_with("repo1")
 
     def test_jm_get_repo_error_direct(self):
         """Test jm_get_repo error handling."""

--- a/clio-kit-mcp-servers/jarvis/tests/test_server_direct.py
+++ b/clio-kit-mcp-servers/jarvis/tests/test_server_direct.py
@@ -413,19 +413,21 @@ class TestJarvisManagerToolsDirect:
             with pytest.raises(ToolError):
                 jm_reset()
 
-    def test_jm_list_pipelines_direct(self):
+    @pytest.mark.asyncio
+    async def test_jm_list_pipelines_direct(self):
         """Test jm_list_pipelines with mocked manager."""
         with patch("jarvis_mcp.server.manager") as mock_mgr:
             mock_mgr.list_pipelines.return_value = ["p1", "p2"]
 
             from jarvis_mcp.server import jm_list_pipelines
 
-            result = jm_list_pipelines()
+            result = await jm_list_pipelines()
 
-            assert len(result) == 2
+            assert result == {"pipelines": ["p1", "p2"], "count": 2}
             mock_mgr.list_pipelines.assert_called_once()
 
-    def test_jm_list_pipelines_error_direct(self):
+    @pytest.mark.asyncio
+    async def test_jm_list_pipelines_error_direct(self):
         """Test jm_list_pipelines error handling."""
         with patch("jarvis_mcp.server.manager") as mock_mgr:
             mock_mgr.list_pipelines.side_effect = Exception("List error")
@@ -433,7 +435,7 @@ class TestJarvisManagerToolsDirect:
             from jarvis_mcp.server import jm_list_pipelines
 
             with pytest.raises(ToolError):
-                jm_list_pipelines()
+                await jm_list_pipelines()
 
     def test_jm_cd_direct(self):
         """Test jm_cd with mocked manager."""
@@ -458,19 +460,21 @@ class TestJarvisManagerToolsDirect:
             with pytest.raises(ToolError):
                 jm_cd("pipe")
 
-    def test_jm_list_repos_direct(self):
+    @pytest.mark.asyncio
+    async def test_jm_list_repos_direct(self):
         """Test jm_list_repos with mocked manager."""
         with patch("jarvis_mcp.server.manager") as mock_mgr:
             mock_mgr.list_repos.return_value = ["repo1", "repo2"]
 
             from jarvis_mcp.server import jm_list_repos
 
-            result = jm_list_repos()
+            result = await jm_list_repos()
 
-            assert len(result) == 2
+            assert result == {"repos": ["repo1", "repo2"], "count": 2}
             mock_mgr.list_repos.assert_called_once()
 
-    def test_jm_list_repos_error_direct(self):
+    @pytest.mark.asyncio
+    async def test_jm_list_repos_error_direct(self):
         """Test jm_list_repos error handling."""
         with patch("jarvis_mcp.server.manager") as mock_mgr:
             mock_mgr.list_repos.side_effect = Exception("List error")
@@ -478,7 +482,7 @@ class TestJarvisManagerToolsDirect:
             from jarvis_mcp.server import jm_list_repos
 
             with pytest.raises(ToolError):
-                jm_list_repos()
+                await jm_list_repos()
 
     def test_jm_add_repo_direct(self):
         """Test jm_add_repo with mocked manager."""
@@ -549,7 +553,8 @@ class TestJarvisManagerToolsDirect:
             with pytest.raises(ToolError):
                 jm_promote_repo("repo")
 
-    def test_jm_get_repo_direct(self):
+    @pytest.mark.asyncio
+    async def test_jm_get_repo_direct(self):
         """Test jm_get_repo with mocked manager."""
         with patch("jarvis_mcp.server.manager") as mock_mgr:
             mock_repo = Mock()
@@ -558,12 +563,13 @@ class TestJarvisManagerToolsDirect:
 
             from jarvis_mcp.server import jm_get_repo
 
-            result = jm_get_repo("repo1")
+            result = await jm_get_repo("repo1")
 
             assert result["repo"] == "RepoInfo"
             mock_mgr.get_repo.assert_called_once_with("repo1")
 
-    def test_jm_get_repo_error_direct(self):
+    @pytest.mark.asyncio
+    async def test_jm_get_repo_error_direct(self):
         """Test jm_get_repo error handling."""
         with patch("jarvis_mcp.server.manager") as mock_mgr:
             mock_mgr.get_repo.side_effect = Exception("Get error")
@@ -571,7 +577,7 @@ class TestJarvisManagerToolsDirect:
             from jarvis_mcp.server import jm_get_repo
 
             with pytest.raises(ToolError):
-                jm_get_repo("repo")
+                await jm_get_repo("repo")
 
     def test_jm_construct_pkg_direct(self):
         """Test jm_construct_pkg with mocked manager."""

--- a/clio-kit-mcp-servers/jarvis/uv.lock
+++ b/clio-kit-mcp-servers/jarvis/uv.lock
@@ -120,14 +120,24 @@ sdist = { url = "https://files.pythonhosted.org/packages/92/88/b8527e1b00c1811db
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6a/80/ea4ead0c5d52a9828692e7df20f0eafe8d26e671ce4883a0a146bb91049e/caio-0.9.25-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:ca6c8ecda611478b6016cb94d23fd3eb7124852b985bdec7ecaad9f3116b9619", size = 36836, upload-time = "2025-12-26T15:22:04.662Z" },
     { url = "https://files.pythonhosted.org/packages/17/b9/36715c97c873649d1029001578f901b50250916295e3dddf20c865438865/caio-0.9.25-cp310-cp310-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:db9b5681e4af8176159f0d6598e73b2279bb661e718c7ac23342c550bd78c241", size = 79695, upload-time = "2025-12-26T15:22:18.818Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/ab/07080ecb1adb55a02cbd8ec0126aa8e43af343ffabb6a71125b42670e9a1/caio-0.9.25-cp310-cp310-manylinux_2_34_aarch64.whl", hash = "sha256:bf61d7d0c4fd10ffdd98ca47f7e8db4d7408e74649ffaf4bef40b029ada3c21b", size = 79457, upload-time = "2026-03-04T22:08:16.024Z" },
+    { url = "https://files.pythonhosted.org/packages/88/95/dd55757bb671eb4c376e006c04e83beb413486821f517792ea603ef216e9/caio-0.9.25-cp310-cp310-manylinux_2_34_x86_64.whl", hash = "sha256:ab52e5b643f8bbd64a0605d9412796cd3464cb8ca88593b13e95a0f0b10508ae", size = 77705, upload-time = "2026-03-04T22:08:17.202Z" },
     { url = "https://files.pythonhosted.org/packages/ec/90/543f556fcfcfa270713eef906b6352ab048e1e557afec12925c991dc93c2/caio-0.9.25-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:d6956d9e4a27021c8bd6c9677f3a59eb1d820cc32d0343cea7961a03b1371965", size = 36839, upload-time = "2025-12-26T15:21:40.267Z" },
     { url = "https://files.pythonhosted.org/packages/51/3b/36f3e8ec38dafe8de4831decd2e44c69303d2a3892d16ceda42afed44e1b/caio-0.9.25-cp311-cp311-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:bf84bfa039f25ad91f4f52944452a5f6f405e8afab4d445450978cd6241d1478", size = 80255, upload-time = "2025-12-26T15:22:20.271Z" },
+    { url = "https://files.pythonhosted.org/packages/df/ce/65e64867d928e6aff1b4f0e12dba0ef6d5bf412c240dc1df9d421ac10573/caio-0.9.25-cp311-cp311-manylinux_2_34_aarch64.whl", hash = "sha256:ae3d62587332bce600f861a8de6256b1014d6485cfd25d68c15caf1611dd1f7c", size = 80052, upload-time = "2026-03-04T22:08:20.402Z" },
+    { url = "https://files.pythonhosted.org/packages/46/90/e278863c47e14ec58309aa2e38a45882fbe67b4cc29ec9bc8f65852d3e45/caio-0.9.25-cp311-cp311-manylinux_2_34_x86_64.whl", hash = "sha256:fc220b8533dcf0f238a6b1a4a937f92024c71e7b10b5a2dfc1c73604a25709bc", size = 78273, upload-time = "2026-03-04T22:08:21.368Z" },
     { url = "https://files.pythonhosted.org/packages/d3/25/79c98ebe12df31548ba4eaf44db11b7cad6b3e7b4203718335620939083c/caio-0.9.25-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:fb7ff95af4c31ad3f03179149aab61097a71fd85e05f89b4786de0359dffd044", size = 36983, upload-time = "2025-12-26T15:21:36.075Z" },
     { url = "https://files.pythonhosted.org/packages/a3/2b/21288691f16d479945968a0a4f2856818c1c5be56881d51d4dac9b255d26/caio-0.9.25-cp312-cp312-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:97084e4e30dfa598449d874c4d8e0c8d5ea17d2f752ef5e48e150ff9d240cd64", size = 82012, upload-time = "2025-12-26T15:22:20.983Z" },
+    { url = "https://files.pythonhosted.org/packages/03/c4/8a1b580875303500a9c12b9e0af58cb82e47f5bcf888c2457742a138273c/caio-0.9.25-cp312-cp312-manylinux_2_34_aarch64.whl", hash = "sha256:4fa69eba47e0f041b9d4f336e2ad40740681c43e686b18b191b6c5f4c5544bfb", size = 81502, upload-time = "2026-03-04T22:08:22.381Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/1c/0fe770b8ffc8362c48134d1592d653a81a3d8748d764bec33864db36319d/caio-0.9.25-cp312-cp312-manylinux_2_34_x86_64.whl", hash = "sha256:6bebf6f079f1341d19f7386db9b8b1f07e8cc15ae13bfdaff573371ba0575d69", size = 80200, upload-time = "2026-03-04T22:08:23.382Z" },
     { url = "https://files.pythonhosted.org/packages/31/57/5e6ff127e6f62c9f15d989560435c642144aa4210882f9494204bc892305/caio-0.9.25-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d6c2a3411af97762a2b03840c3cec2f7f728921ff8adda53d7ea2315a8563451", size = 36979, upload-time = "2025-12-26T15:21:35.484Z" },
     { url = "https://files.pythonhosted.org/packages/a3/9f/f21af50e72117eb528c422d4276cbac11fb941b1b812b182e0a9c70d19c5/caio-0.9.25-cp313-cp313-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0998210a4d5cd5cb565b32ccfe4e53d67303f868a76f212e002a8554692870e6", size = 81900, upload-time = "2025-12-26T15:22:21.919Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/12/c39ae2a4037cb10ad5eb3578eb4d5f8c1a2575c62bba675f3406b7ef0824/caio-0.9.25-cp313-cp313-manylinux_2_34_aarch64.whl", hash = "sha256:1a177d4777141b96f175fe2c37a3d96dec7911ed9ad5f02bac38aaa1c936611f", size = 81523, upload-time = "2026-03-04T22:08:25.187Z" },
+    { url = "https://files.pythonhosted.org/packages/22/59/f8f2e950eb4f1a5a3883e198dca514b9d475415cb6cd7b78b9213a0dd45a/caio-0.9.25-cp313-cp313-manylinux_2_34_x86_64.whl", hash = "sha256:9ed3cfb28c0e99fec5e208c934e5c157d0866aa9c32aa4dc5e9b6034af6286b7", size = 80243, upload-time = "2026-03-04T22:08:26.449Z" },
     { url = "https://files.pythonhosted.org/packages/69/ca/a08fdc7efdcc24e6a6131a93c85be1f204d41c58f474c42b0670af8c016b/caio-0.9.25-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:fab6078b9348e883c80a5e14b382e6ad6aabbc4429ca034e76e730cf464269db", size = 36978, upload-time = "2025-12-26T15:21:41.055Z" },
     { url = "https://files.pythonhosted.org/packages/5e/6c/d4d24f65e690213c097174d26eda6831f45f4734d9d036d81790a27e7b78/caio-0.9.25-cp314-cp314-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:44a6b58e52d488c75cfaa5ecaa404b2b41cc965e6c417e03251e868ecd5b6d77", size = 81832, upload-time = "2025-12-26T15:22:22.757Z" },
+    { url = "https://files.pythonhosted.org/packages/87/a4/e534cf7d2d0e8d880e25dd61e8d921ffcfe15bd696734589826f5a2df727/caio-0.9.25-cp314-cp314-manylinux_2_34_aarch64.whl", hash = "sha256:628a630eb7fb22381dd8e3c8ab7f59e854b9c806639811fc3f4310c6bd711d79", size = 81565, upload-time = "2026-03-04T22:08:27.483Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/ed/bf81aeac1d290017e5e5ac3e880fd56ee15e50a6d0353986799d1bc5cfd5/caio-0.9.25-cp314-cp314-manylinux_2_34_x86_64.whl", hash = "sha256:0ba16aa605ccb174665357fc729cf500679c2d94d5f1458a6f0d5ca48f2060a7", size = 80071, upload-time = "2026-03-04T22:08:28.751Z" },
     { url = "https://files.pythonhosted.org/packages/86/93/1f76c8d1bafe3b0614e06b2195784a3765bbf7b0a067661af9e2dd47fc33/caio-0.9.25-py3-none-any.whl", hash = "sha256:06c0bb02d6b929119b1cfbe1ca403c768b2013a369e2db46bfa2a5761cf82e40", size = 19087, upload-time = "2025-12-26T15:22:00.221Z" },
 ]
 
@@ -667,7 +677,6 @@ dependencies = [
     { name = "fastapi" },
     { name = "fastmcp" },
     { name = "jarvis-cd" },
-    { name = "jarvis-util" },
     { name = "python-dotenv" },
     { name = "starlette" },
 ]
@@ -689,7 +698,6 @@ requires-dist = [
     { name = "fastapi" },
     { name = "fastmcp", specifier = ">=3.0.1" },
     { name = "jarvis-cd", git = "https://github.com/grc-iit/jarvis-cd.git?rev=main" },
-    { name = "jarvis-util", git = "https://github.com/grc-iit/jarvis-util.git?rev=main" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "starlette", specifier = ">=0.49.1" },
 ]
@@ -704,15 +712,6 @@ dev = [
     { name = "pytest-timeout", specifier = ">=2.4.0" },
     { name = "ruff", specifier = ">=0.12.5" },
     { name = "types-requests" },
-]
-
-[[package]]
-name = "jarvis-util"
-version = "0.0.1"
-source = { git = "https://github.com/grc-iit/jarvis-util.git?rev=main#c91bfdc9bba802e4b03bfb1babe614ffa3e09644" }
-dependencies = [
-    { name = "pyyaml" },
-    { name = "tabulate" },
 ]
 
 [[package]]
@@ -2012,15 +2011,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c4/68/79977123bb7be889ad680d79a40f339082c1978b5cfcf62c2d8d196873ac/starlette-0.52.1.tar.gz", hash = "sha256:834edd1b0a23167694292e94f597773bc3f89f362be6effee198165a35d62933", size = 2653702, upload-time = "2026-01-18T13:34:11.062Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/81/0d/13d1d239a25cbfb19e740db83143e95c772a1fe10202dda4b76792b114dd/starlette-0.52.1-py3-none-any.whl", hash = "sha256:0029d43eb3d273bc4f83a08720b4912ea4b071087a3b48db01b7c839f7954d74", size = 74272, upload-time = "2026-01-18T13:34:09.188Z" },
-]
-
-[[package]]
-name = "tabulate"
-version = "0.9.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ec/fe/802052aecb21e3797b8f7902564ab6ea0d60ff8ca23952079064155d1ae1/tabulate-0.9.0.tar.gz", hash = "sha256:0095b12bf5966de529c0feb1fa08671671b3368eec77d7ef7ab114be2c068b3c", size = 81090, upload-time = "2022-10-06T17:21:48.54Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/40/44/4a5f08c96eb108af5cb50b41f76142f0afa346dfa99d5296fe7202a11854/tabulate-0.9.0-py3-none-any.whl", hash = "sha256:024ca478df22e9340661486f85298cff5f6dcdba14f3813e8830015b9ed1948f", size = 35252, upload-time = "2022-10-06T17:21:44.262Z" },
 ]
 
 [[package]]

--- a/src/clio_kit/__init__.py
+++ b/src/clio_kit/__init__.py
@@ -229,7 +229,10 @@ def main(ctx):
         click.echo("  uvx clio-kit prompt <prompt-name>")
         click.echo("\nFor more help: uvx clio-kit <command> --help")
 
-@main.command("mcp-server")
+@main.command(
+    "mcp-server",
+    context_settings={"ignore_unknown_options": True, "allow_extra_args": True},
+)
 @click.argument('server', required=False)
 @click.option('-b', '--branch', help='Git branch to use (for development)')
 @click.argument('args', nargs=-1, type=click.UNPROCESSED)


### PR DESCRIPTION
﻿## Summary

Adds a safer user-facing JARVIS MCP surface and a structured pipeline export tool.

- adds `export_pipeline` to return pipeline metadata, package configs, environment, and source YAML when available
- adds `--profile user|admin|all` so normal agents can use a reduced pipeline-authoring surface while admin tools remain available intentionally
- keeps `all` as the default to preserve the existing MCP surface

## Why

clio-relay needs to route calls to a JARVIS MCP running on the target cluster. For that to work cleanly, agents need a normal user profile and a way to inspect/export a named remote pipeline before submitting it through the relay.

## Validation

From `clio-kit-mcp-servers/jarvis`:

- `uv run ruff format --check src tests`
- `uv run ruff check src tests`
- `uv run mypy src`
- `uv run pytest -q`
