### PR TITLE
fix: isolate post-publish artifact verification

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "CLIO Kit - MCP Servers for Scientific Computing and HPC",
-    "version": "2.3.0",
+    "version": "2.3.1",
     "pluginRoot": "./clio-kit-mcp-servers"
   },
   "plugins": [

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -421,6 +421,21 @@ jobs:
         name: python-package-distributions
         path: dist/
 
+    - name: Stage immutable copies for post-publish verification
+      shell: bash
+      run: |
+        mkdir verification-dist
+        mapfile -t artifacts < <(
+          find dist -maxdepth 1 -type f \
+            \( -name '*.whl' -o -name '*.tar.gz' \) -print | sort
+        )
+        test "${#artifacts[@]}" -eq 2
+        cp -- "${artifacts[@]}" verification-dist/
+        for artifact in "${artifacts[@]}"; do
+          cmp --silent \
+            "$artifact" "verification-dist/$(basename "$artifact")"
+        done
+
     - name: Require fresh exact admin authorization at publication
       env:
         RELEASE_AUTHORIZATION: ${{ secrets.CLIO_KIT_RELEASE_AUTHORIZATION }}
@@ -448,7 +463,7 @@ jobs:
         python scripts/verify_pypi_release.py \
           --project clio-kit \
           --version "$RELEASE_VERSION" \
-          --dist-dir dist
+          --dist-dir verification-dist
 
   github-release:
     name: Create GitHub Release

--- a/clio-kit-mcp-servers/adios/server.json
+++ b/clio-kit-mcp-servers/adios/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/arxiv/server.json
+++ b/clio-kit-mcp-servers/arxiv/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/chronolog/server.json
+++ b/clio-kit-mcp-servers/chronolog/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/compression/server.json
+++ b/clio-kit-mcp-servers/compression/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/darshan/server.json
+++ b/clio-kit-mcp-servers/darshan/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/geo/server.json
+++ b/clio-kit-mcp-servers/geo/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/geojson/server.json
+++ b/clio-kit-mcp-servers/geojson/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/hdf5/server.json
+++ b/clio-kit-mcp-servers/hdf5/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/jarvis/server.json
+++ b/clio-kit-mcp-servers/jarvis/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/lmod/server.json
+++ b/clio-kit-mcp-servers/lmod/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/ndp/server.json
+++ b/clio-kit-mcp-servers/ndp/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/node-hardware/server.json
+++ b/clio-kit-mcp-servers/node-hardware/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/pandas/server.json
+++ b/clio-kit-mcp-servers/pandas/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/parallel-sort/server.json
+++ b/clio-kit-mcp-servers/parallel-sort/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/paraview/server.json
+++ b/clio-kit-mcp-servers/paraview/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/parquet/server.json
+++ b/clio-kit-mcp-servers/parquet/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/plot/server.json
+++ b/clio-kit-mcp-servers/plot/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/sac/server.json
+++ b/clio-kit-mcp-servers/sac/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/seismic/server.json
+++ b/clio-kit-mcp-servers/seismic/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/slurm/server.json
+++ b/clio-kit-mcp-servers/slurm/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/spack/server.json
+++ b/clio-kit-mcp-servers/spack/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/terrain/server.json
+++ b/clio-kit-mcp-servers/terrain/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "transport": {
         "type": "stdio"
       },

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "clio-kit",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "mcpServers": {
     "clio-adios": {
       "command": "clio-kit",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "clio-kit"
-version = "2.3.0"
+version = "2.3.1"
 description = "CLIO Kit - MCP Servers, Clients, and Tools for AI Agents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -115,6 +115,23 @@ def test_release_recovery_is_exact_byte_and_fail_closed() -> None:
     assert "--clobber" not in WORKFLOW
 
 
+def test_pypi_verification_uses_pre_publish_immutable_copies() -> None:
+    """Publisher-generated sidecars must not contaminate exact-byte discovery."""
+    publish_block = WORKFLOW[
+        WORKFLOW.index("  publish-to-pypi:") : WORKFLOW.index("  github-release:")
+    ]
+    stage_index = publish_block.index(
+        "Stage immutable copies for post-publish verification"
+    )
+    upload_index = publish_block.index("pypa/gh-action-pypi-publish@")
+    verify_index = publish_block.index("Verify exact published PyPI bytes")
+
+    assert stage_index < upload_index < verify_index
+    assert "mkdir verification-dist" in publish_block
+    assert "cmp --silent" in publish_block
+    assert "--dist-dir verification-dist" in publish_block
+
+
 def test_final_release_requires_attestation_and_immutability() -> None:
     """Publishing remains gated by provenance, immutable state, and release verification."""
     assert "gh attestation verify" in WORKFLOW

--- a/uv.lock
+++ b/uv.lock
@@ -61,7 +61,7 @@ wheels = [
 
 [[package]]
 name = "clio-kit"
-version = "2.3.0"
+version = "2.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- stage immutable wheel and sdist copies before the PyPI publisher creates PEP 740 sidecars
- verify published bytes against those untouched copies
- add a regression invariant and bump the corrective root release to 2.3.1
- regenerate every agent-runnable package coordinate for the 2.3.1 root wheel

## Validation
- 85 root tests passed with zero skips
- Ruff check and format passed
- strict MyPy passed
- uv lock check passed
- publish workflow YAML parsed
- exact v2.3.0 Actions artifacts were independently verified against PyPI, confirming the incident was local sidecar contamination

The v2.3.0 PyPI upload is byte-correct, but its workflow stopped before the GitHub Release and MCP Registry jobs. This patch intentionally leaves that tag immutable and makes v2.3.1 the complete corrective release.