### PR TITLE
fix: retry draft release discovery

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -596,6 +596,26 @@ jobs:
           test "$(jq -r .immutable "$release_json")" = false || return 2
         }
 
+        wait_for_exact_draft_release() {
+          local attempt status
+          for attempt in {1..12}; do
+            if resolve_exact_draft_release; then
+              return 0
+            else
+              status="$?"
+            fi
+            if [ "$status" -ne 1 ]; then
+              return "$status"
+            fi
+            if [ "$attempt" -lt 12 ]; then
+              echo "draft release is not list-visible yet (attempt $attempt/12)" >&2
+              sleep 5
+            fi
+          done
+          echo "draft release did not become list-visible after 12 attempts" >&2
+          return 1
+        }
+
         load_and_verify_assets() {
           local allow_missing="$1" id name declared_digest downloaded
           local encoded_name http_status upload_json
@@ -681,7 +701,7 @@ jobs:
               --title "CLIO Kit $TAG_NAME" \
               --generate-notes \
               --draft
-            resolve_exact_draft_release
+            wait_for_exact_draft_release
           fi
         else
           cat "$release_error" >&2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -825,6 +825,7 @@ jobs:
 
           if python3 scripts/verify_mcp_registry_release.py \
             --manifest "$server_dir/server.json" \
+            --timeout 60 \
             --attempts 12 \
             --retry-delay 5; then
             if [ "$publish_result" = published ]; then

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -203,6 +203,7 @@ def test_registry_duplicate_versions_require_exact_live_verification() -> None:
     registry_block = WORKFLOW[WORKFLOW.index("  publish-to-mcp-registry:") :]
     assert "scripts/verify_mcp_registry_release.py" in registry_block
     assert '--manifest "$server_dir/server.json"' in registry_block
+    assert "--timeout 60" in registry_block
     assert "publish_result=duplicate" in registry_block
     duplicate_index = registry_block.index("publish_result=duplicate")
     verify_index = registry_block.index("scripts/verify_mcp_registry_release.py")

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -150,6 +150,27 @@ def test_draft_release_is_resolved_and_mutated_only_by_exact_id() -> None:
     assert publish_index < final_fetch_index
 
 
+def test_new_draft_release_waits_for_bounded_list_consistency() -> None:
+    """A newly created draft may take time to appear in the list endpoint."""
+    release_block = WORKFLOW[
+        WORKFLOW.index("  github-release:") : WORKFLOW.index(
+            "  publish-to-mcp-registry:"
+        )
+    ]
+    create_index = release_block.index('gh release create "$TAG_NAME"')
+    wait_index = release_block.index("wait_for_exact_draft_release", create_index)
+
+    assert "wait_for_exact_draft_release()" in release_block
+    assert "for attempt in {1..12}; do" in release_block
+    assert "if resolve_exact_draft_release; then" in release_block
+    assert 'else\n              status="$?"' in release_block
+    assert 'if [ "$status" -ne 1 ]; then' in release_block
+    assert "sleep 5" in release_block
+    assert "did not become list-visible after 12 attempts" in release_block
+    assert release_block.count('gh release create "$TAG_NAME"') == 1
+    assert create_index < wait_index
+
+
 def test_pypi_verification_uses_pre_publish_immutable_copies() -> None:
     """Publisher-generated sidecars must not contaminate exact-byte discovery."""
     publish_block = WORKFLOW[


### PR DESCRIPTION
## Summary

- retry exact draft-release discovery after creation while GitHub's list endpoint becomes consistent
- fail immediately on malformed or ambiguous draft state; retry only the exact not-found condition
- keep a single create operation and all subsequent asset upload/publication mutations bound to the recovered release ID
- allow 60 seconds for exact MCP Registry reads, matching the production endpoint's observed latency

## Live evidence

The v2.3.2 release created draft `353412371` with the correct tag, commit, title, and bot author, then failed because the immediately following paginated list call did not yet return it. Rerunning only the failed job recovered that same draft and published an immutable GitHub release.

Spack MCP 2.0.1 then published successfully, but the post-publish verifier's 20-second per-request timeout expired repeatedly. The official endpoint returned the exact active manifest in about 30 seconds, and the unchanged verifier passed with `--timeout 60`.

## Validation

- `20 passed` in `tests/test_release_workflow.py`
- Ruff check and format check
- actionlint 1.7.12
- exact local registry verification against Spack MCP 2.0.1 with a 60-second timeout
- `git diff --check`
