### PR TITLE
fix: preserve structured JARVIS package config

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "CLIO Kit - MCP Servers for Scientific Computing and HPC",
-    "version": "2.4.2",
+    "version": "2.4.3",
     "pluginRoot": "./clio-kit-mcp-servers"
   },
   "plugins": [
@@ -125,7 +125,7 @@
       "name": "clio-jarvis",
       "source": "./clio-kit-mcp-servers/jarvis",
       "description": "JARVIS-CD MCP with a compact user pipeline contract and explicit admin compatibility profiles",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "category": "development",
       "keywords": [
         "pipeline-management",

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -339,8 +339,8 @@ jobs:
 
         from clio_kit import get_servers_path, locked_server_environment
 
-        expected_url = "https://github.com/grc-iit/jarvis-cd/releases/download/v1.3.1/jarvis_cd-1.3.1-py3-none-any.whl"
-        expected_digest = "08411d49f8d457ec8a1a73ad9eacc71416a17919733682acee7e28e0011d8cea"
+        expected_url = "https://github.com/grc-iit/jarvis-cd/releases/download/v1.3.2/jarvis_cd-1.3.2-py3-none-any.whl"
+        expected_digest = "2e5c994b1b21caf44eecb62c1d631c5ce3886d9282549589520c1d9b49961277"
         expected_requirement = f"jarvis-cd @ {expected_url}#sha256={expected_digest}"
         server = get_servers_path() / "jarvis"
         project = tomllib.loads(
@@ -353,7 +353,7 @@ jobs:
             for package in jarvis_lock["package"]
             if package["name"] == "jarvis-cd"
         )
-        assert jarvis_package["version"] == "1.3.1"
+        assert jarvis_package["version"] == "1.3.2"
         assert jarvis_package["source"] == {"url": expected_url}
         assert jarvis_package["wheels"] == [
             {"url": expected_url, "hash": f"sha256:{expected_digest}"}
@@ -371,9 +371,9 @@ jobs:
 
         from jarvis_cd.core.pipeline import Pipeline
 
-        expected_url = "https://github.com/grc-iit/jarvis-cd/releases/download/v1.3.1/jarvis_cd-1.3.1-py3-none-any.whl"
+        expected_url = "https://github.com/grc-iit/jarvis-cd/releases/download/v1.3.2/jarvis_cd-1.3.2-py3-none-any.whl"
         installed = distribution("jarvis-cd")
-        assert installed.version == "1.3.1"
+        assert installed.version == "1.3.2"
         direct_url_text = installed.read_text("direct_url.json")
         assert direct_url_text is not None
         direct_url = json.loads(direct_url_text)

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ CLIO Kit is part of the IoWarp platform's comprehensive tooling ecosystem for AI
 
 ```bash
 # Install the released CLI into its own persistent tool environment
-uv tool install 'clio-kit==2.4.2'
+uv tool install 'clio-kit==2.4.3'
 # If uv reports that its executable directory is not on PATH:
 uv tool update-shell
 
@@ -104,7 +104,7 @@ clio-kit prompt code-coverage-prompt # Use a prompt
 ```
 
 `uv tool install` keeps CLIO Kit in a persistent, isolated tool environment.
-Use `uvx --from 'clio-kit==2.4.2' clio-kit ...` only for a temporary, one-shot
+Use `uvx --from 'clio-kit==2.4.3' clio-kit ...` only for a temporary, one-shot
 invocation.
 
 Released `clio-kit` wheels execute each embedded MCP server from that server's
@@ -247,7 +247,7 @@ Agents should discover first, install only when needed, then pass the exact
 | **`geo`** | 2.2.3 | Geospatial | Render GeoJSON vector layers with basemaps | `clio-kit mcp-server geo` |
 | **`geojson`** | 2.2.3 | Geospatial | Inspect, validate, and summarize GeoJSON | `clio-kit mcp-server geojson` |
 | **`hdf5`** | 2.2.3 | Data I/O | HPC-optimized scientific data with 27 tools, AI insights, caching, streaming | `clio-kit mcp-server hdf5` |
-| **`jarvis`** | 3.1.0 | Workflow | Durable pipeline, progress, artifact, and service-runtime management | `clio-kit mcp-server jarvis` |
+| **`jarvis`** | 3.1.1 | Workflow | Durable pipeline, progress, artifact, and service-runtime management | `clio-kit mcp-server jarvis` |
 | **`lmod`** | 2.2.3 | Environment | Environment module management | `clio-kit mcp-server lmod` |
 | **`ndp`** | 2.2.3 | Data Protocol | Search and discover datasets across CKAN instances | `clio-kit mcp-server ndp` |
 | **`node-hardware`** | 2.2.3 | System | System hardware information | `clio-kit mcp-server node-hardware` |
@@ -388,7 +388,7 @@ pip install uv
 Then install CLIO Kit persistently and expose uv's tool directory:
 
 ```bash
-uv tool install 'clio-kit==2.4.2'
+uv tool install 'clio-kit==2.4.3'
 uv tool update-shell
 ```
 

--- a/clio-kit-mcp-servers/adios/server.json
+++ b/clio-kit-mcp-servers/adios/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.4.2",
+      "version": "2.4.3",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/arxiv/server.json
+++ b/clio-kit-mcp-servers/arxiv/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.4.2",
+      "version": "2.4.3",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/chronolog/server.json
+++ b/clio-kit-mcp-servers/chronolog/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.4.2",
+      "version": "2.4.3",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/compression/server.json
+++ b/clio-kit-mcp-servers/compression/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.4.2",
+      "version": "2.4.3",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/darshan/server.json
+++ b/clio-kit-mcp-servers/darshan/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.4.2",
+      "version": "2.4.3",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/geo/server.json
+++ b/clio-kit-mcp-servers/geo/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.4.2",
+      "version": "2.4.3",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/geojson/server.json
+++ b/clio-kit-mcp-servers/geojson/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.4.2",
+      "version": "2.4.3",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/hdf5/server.json
+++ b/clio-kit-mcp-servers/hdf5/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.4.2",
+      "version": "2.4.3",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/jarvis/.claude-plugin/plugin.json
+++ b/clio-kit-mcp-servers/jarvis/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "clio-jarvis",
   "description": "JARVIS-CD MCP with a compact user pipeline contract and explicit admin compatibility profiles",
-  "version": "3.1.0"
+  "version": "3.1.1"
 }

--- a/clio-kit-mcp-servers/jarvis/pyproject.toml
+++ b/clio-kit-mcp-servers/jarvis/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jarvis-mcp"
-version = "3.1.0"
+version = "3.1.1"
 description = "JARVIS-CD MCP with a compact user pipeline contract and explicit admin compatibility profiles"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -15,7 +15,7 @@ dependencies = [
   "fastmcp>=3.2.0",
   "fastapi",
   "python-dotenv>=1.2.2",
-  "jarvis-cd @ https://github.com/grc-iit/jarvis-cd/releases/download/v1.3.1/jarvis_cd-1.3.1-py3-none-any.whl#sha256=08411d49f8d457ec8a1a73ad9eacc71416a17919733682acee7e28e0011d8cea",
+  "jarvis-cd @ https://github.com/grc-iit/jarvis-cd/releases/download/v1.3.2/jarvis_cd-1.3.2-py3-none-any.whl#sha256=2e5c994b1b21caf44eecb62c1d631c5ce3886d9282549589520c1d9b49961277",
   "starlette>=1.3.1",
   "authlib>=1.6.12",
   "cryptography>=48.0.1",

--- a/clio-kit-mcp-servers/jarvis/scripts/live_ares_semantic_mcp_probe.py
+++ b/clio-kit-mcp-servers/jarvis/scripts/live_ares_semantic_mcp_probe.py
@@ -18,13 +18,13 @@ from urllib.parse import urlsplit
 
 
 Json = dict[str, Any]
-EXPECTED_JARVIS_VERSION = "1.3.1"
+EXPECTED_JARVIS_VERSION = "1.3.2"
 EXPECTED_JARVIS_URL = (
-    "https://github.com/grc-iit/jarvis-cd/releases/download/v1.3.1/"
-    "jarvis_cd-1.3.1-py3-none-any.whl"
+    "https://github.com/grc-iit/jarvis-cd/releases/download/v1.3.2/"
+    "jarvis_cd-1.3.2-py3-none-any.whl"
 )
 EXPECTED_JARVIS_SHA256 = (
-    "08411d49f8d457ec8a1a73ad9eacc71416a17919733682acee7e28e0011d8cea"
+    "2e5c994b1b21caf44eecb62c1d631c5ce3886d9282549589520c1d9b49961277"
 )
 
 

--- a/clio-kit-mcp-servers/jarvis/server.json
+++ b/clio-kit-mcp-servers/jarvis/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.iowarp/jarvis-mcp",
   "title": "CLIO Jarvis",
   "description": "JARVIS-CD MCP with a compact user pipeline contract and explicit admin compatibility profiles",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "repository": {
     "url": "https://github.com/iowarp/clio-kit",
     "source": "github"
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.4.2",
+      "version": "2.4.3",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/jarvis/src/jarvis_mcp/capabilities/jarvis_handler.py
+++ b/clio-kit-mcp-servers/jarvis/src/jarvis_mcp/capabilities/jarvis_handler.py
@@ -695,6 +695,7 @@ async def run_pipeline(
                 raise ValueError(
                     "scheduler mode requires a configured pipeline scheduler"
                 )
+        assert pipeline is not None
         resolved_pipeline_id = _pipeline_id(pipeline) or pipeline_id
         if normalized == "scheduler" or (normalized == "auto" and has_scheduler):
             _require_execution_parameters(
@@ -1614,12 +1615,15 @@ def _open_spack_path_descriptor(path: Path, *, nonblocking: bool = False) -> int
         open_osfhandle = getattr(msvcrt, "open_osfhandle", None)
         if not callable(open_osfhandle):
             raise RuntimeError("Windows descriptor conversion APIs are unavailable")
-        return int(
-            open_osfhandle(
-                int(handle),
-                os.O_RDONLY | getattr(os, "O_BINARY", 0),
-            )
+        descriptor = open_osfhandle(
+            int(cast(Any, handle)),
+            os.O_RDONLY | getattr(os, "O_BINARY", 0),
         )
+        if not isinstance(descriptor, int):
+            raise RuntimeError(
+                "Windows descriptor conversion returned an invalid value"
+            )
+        return descriptor
     except BaseException:
         kernel32.CloseHandle(handle)
         raise
@@ -3224,7 +3228,7 @@ def _normalize_package_config_request(
             + ", ".join(null_names)
         )
 
-    parser = get_argparse()
+    parser = cast(Any, get_argparse())
     try:
         parser.parse(["configure", *_kwargs_to_config_args(kwargs)])
     except SystemExit as exc:
@@ -3268,9 +3272,23 @@ def _kwargs_to_config_args(kwargs: dict[str, Any]) -> list[str]:
         if value is None:
             continue
         if isinstance(value, bool):
-            args.append(f"{key}={str(value).lower()}")
+            rendered = str(value).lower()
+        elif isinstance(value, (dict, list)):
+            try:
+                rendered = json.dumps(
+                    value,
+                    allow_nan=False,
+                    ensure_ascii=False,
+                    separators=(",", ":"),
+                    sort_keys=True,
+                )
+            except (TypeError, ValueError) as exc:
+                raise ValueError(
+                    f"Package setting '{key}' must contain JSON-compatible values"
+                ) from exc
         else:
-            args.append(f"{key}={value}")
+            rendered = str(value)
+        args.append(f"{key}={rendered}")
     return args
 
 

--- a/clio-kit-mcp-servers/jarvis/tests/test_jarvis_handler.py
+++ b/clio-kit-mcp-servers/jarvis/tests/test_jarvis_handler.py
@@ -2,6 +2,7 @@
 Tests for the jarvis_handler module that contains pipeline operation logic.
 """
 
+import hashlib
 import json
 import os
 import subprocess
@@ -297,7 +298,7 @@ class TestHandlerHelpers:
     """Test helper branches used by the semantic MCP contract."""
 
     def test_jsonable_and_config_arg_helpers(self):
-        """Non-JSON values are normalized and config args preserve bool spelling."""
+        """Structured config args use deterministic, standards-compliant JSON."""
         from jarvis_mcp.capabilities.jarvis_handler import (
             _jsonable,
             _kwargs_to_config_args,
@@ -308,8 +309,73 @@ class TestHandlerHelpers:
             "items": [repr(Path("/tmp/y"))],
         }
         assert _kwargs_to_config_args(
-            {"enabled": True, "disabled": False, "skip": None, "count": 2}
-        ) == ["enabled=true", "disabled=false", "count=2"]
+            {
+                "enabled": True,
+                "disabled": False,
+                "skip": None,
+                "count": 2,
+                "options": {"z": [1, True, None], "a": "value"},
+                "members": ["first", 2],
+            }
+        ) == [
+            "enabled=true",
+            "disabled=false",
+            "count=2",
+            'options={"a":"value","z":[1,true,null]}',
+            'members=["first",2]',
+        ]
+
+        with pytest.raises(ValueError, match="JSON-compatible"):
+            _kwargs_to_config_args({"options": {"bad": float("nan")}})
+
+    def test_catalog_descriptor_config_is_valid_jarvis_json(self):
+        """A catalog descriptor object survives the JARVIS package-argument bridge."""
+        from jarvis_cd.service_runtime.schema import DatasetDescriptor
+        from jarvis_mcp.capabilities.jarvis_handler import _kwargs_to_config_args
+
+        intrinsic = {
+            "schema_version": "jarvis.dataset-descriptor.v1",
+            "dataset_id": "asteroid-first-five",
+            "kind": "temporal-volume",
+            "format": "vti",
+            "members": [
+                {
+                    "index": 0,
+                    "location": "/datasets/asteroid/frame-0000.vti",
+                    "timestep": 0.0,
+                },
+                {
+                    "index": 1,
+                    "location": "/datasets/asteroid/frame-0001.vti",
+                    "timestep": 1.0,
+                },
+            ],
+            "arrays": [{"name": "prs", "association": "point", "components": 1}],
+            "bounds": [-1.0, 1.0, -2.0, 2.0, -3.0, 3.0],
+            "source_artifact": None,
+        }
+        digest = hashlib.sha256(
+            json.dumps(
+                intrinsic,
+                allow_nan=False,
+                ensure_ascii=False,
+                separators=(",", ":"),
+                sort_keys=True,
+            ).encode("utf-8")
+        ).hexdigest()
+        descriptor = {
+            **intrinsic,
+            "fingerprint": {"algorithm": "sha256", "digest": digest},
+        }
+
+        [argument] = _kwargs_to_config_args({"dataset_descriptor": descriptor})
+        key, payload = argument.split("=", 1)
+        parsed = DatasetDescriptor.from_json(payload)
+
+        assert key == "dataset_descriptor"
+        assert json.loads(payload) == descriptor
+        assert parsed.dataset_id == descriptor["dataset_id"]
+        assert parsed.fingerprint == digest
 
     def test_pipeline_snapshot_helpers_fallback_to_current_api_fields(self, tmp_path):
         """Current Pipeline objects expose config, package, and path fallbacks."""

--- a/clio-kit-mcp-servers/jarvis/uv.lock
+++ b/clio-kit-mcp-servers/jarvis/uv.lock
@@ -791,8 +791,8 @@ wheels = [
 
 [[package]]
 name = "jarvis-cd"
-version = "1.3.1"
-source = { url = "https://github.com/grc-iit/jarvis-cd/releases/download/v1.3.1/jarvis_cd-1.3.1-py3-none-any.whl" }
+version = "1.3.2"
+source = { url = "https://github.com/grc-iit/jarvis-cd/releases/download/v1.3.2/jarvis_cd-1.3.2-py3-none-any.whl" }
 dependencies = [
     { name = "pandas" },
     { name = "podman-compose" },
@@ -800,7 +800,7 @@ dependencies = [
     { name = "pyyaml" },
 ]
 wheels = [
-    { url = "https://github.com/grc-iit/jarvis-cd/releases/download/v1.3.1/jarvis_cd-1.3.1-py3-none-any.whl", hash = "sha256:08411d49f8d457ec8a1a73ad9eacc71416a17919733682acee7e28e0011d8cea" },
+    { url = "https://github.com/grc-iit/jarvis-cd/releases/download/v1.3.2/jarvis_cd-1.3.2-py3-none-any.whl", hash = "sha256:2e5c994b1b21caf44eecb62c1d631c5ce3886d9282549589520c1d9b49961277" },
 ]
 
 [package.metadata]
@@ -813,7 +813,7 @@ requires-dist = [
 
 [[package]]
 name = "jarvis-mcp"
-version = "3.1.0"
+version = "3.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "authlib" },
@@ -853,7 +853,7 @@ requires-dist = [
     { name = "fastapi" },
     { name = "fastmcp", specifier = ">=3.2.0" },
     { name = "idna", specifier = ">=3.15" },
-    { name = "jarvis-cd", url = "https://github.com/grc-iit/jarvis-cd/releases/download/v1.3.1/jarvis_cd-1.3.1-py3-none-any.whl" },
+    { name = "jarvis-cd", url = "https://github.com/grc-iit/jarvis-cd/releases/download/v1.3.2/jarvis_cd-1.3.2-py3-none-any.whl" },
     { name = "pydantic", specifier = ">=2.12.5" },
     { name = "pydantic-settings", specifier = ">=2.14.2" },
     { name = "pygments", specifier = ">=2.20.0" },

--- a/clio-kit-mcp-servers/lmod/server.json
+++ b/clio-kit-mcp-servers/lmod/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.4.2",
+      "version": "2.4.3",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/ndp/server.json
+++ b/clio-kit-mcp-servers/ndp/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.4.2",
+      "version": "2.4.3",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/node-hardware/server.json
+++ b/clio-kit-mcp-servers/node-hardware/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.4.2",
+      "version": "2.4.3",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/pandas/server.json
+++ b/clio-kit-mcp-servers/pandas/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.4.2",
+      "version": "2.4.3",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/parallel-sort/server.json
+++ b/clio-kit-mcp-servers/parallel-sort/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.4.2",
+      "version": "2.4.3",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/paraview/server.json
+++ b/clio-kit-mcp-servers/paraview/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.4.2",
+      "version": "2.4.3",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/parquet/server.json
+++ b/clio-kit-mcp-servers/parquet/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.4.2",
+      "version": "2.4.3",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/plot/server.json
+++ b/clio-kit-mcp-servers/plot/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.4.2",
+      "version": "2.4.3",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/sac/server.json
+++ b/clio-kit-mcp-servers/sac/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.4.2",
+      "version": "2.4.3",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/scientific-catalog/server.json
+++ b/clio-kit-mcp-servers/scientific-catalog/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.4.2",
+      "version": "2.4.3",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/seismic/server.json
+++ b/clio-kit-mcp-servers/seismic/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.4.2",
+      "version": "2.4.3",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/slurm/server.json
+++ b/clio-kit-mcp-servers/slurm/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.4.2",
+      "version": "2.4.3",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/spack/server.json
+++ b/clio-kit-mcp-servers/spack/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.4.2",
+      "version": "2.4.3",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/terrain/server.json
+++ b/clio-kit-mcp-servers/terrain/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.4.2",
+      "version": "2.4.3",
       "transport": {
         "type": "stdio"
       },

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "clio-kit",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "mcpServers": {
     "clio-adios": {
       "command": "clio-kit",

--- a/mcp-server-versions.toml
+++ b/mcp-server-versions.toml
@@ -4,7 +4,7 @@ schema-version = 1
 # Existing Registry versions are immutable and must not be republished merely
 # because a newer clio-kit wheel also contains their unchanged implementation.
 [mcp-registry-release]
-publish = ["scientific-catalog"]
+publish = ["jarvis"]
 
 # Generated website metadata must not depend on the wall clock. Advance this
 # date intentionally whenever current contract metadata is regenerated.
@@ -23,7 +23,7 @@ darshan = "2.2.3"
 geo = "2.2.3"
 geojson = "2.2.3"
 hdf5 = "2.2.3"
-jarvis = "3.1.0"
+jarvis = "3.1.1"
 lmod = "2.2.3"
 ndp = "2.2.3"
 node-hardware = "2.2.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "clio-kit"
-version = "2.4.2"
+version = "2.4.3"
 description = "CLIO Kit - MCP Servers, Clients, and Tools for AI Agents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_generate_server_json_contract.py
+++ b/tests/test_generate_server_json_contract.py
@@ -97,7 +97,7 @@ def test_every_committed_server_has_an_agent_runnable_package_coordinate() -> No
     assert manifests == [project / "server.json" for project in projects]
     assert list(expected_server_versions) == sorted(expected_server_versions)
     assert set(expected_server_versions) == {project.name for project in projects}
-    assert publish_servers == ("scientific-catalog",)
+    assert publish_servers == ("jarvis",)
     assert marketplace["metadata"]["version"] == expected_version
     assert set(marketplace_plugins) == set(expected_server_versions)
     assert gemini_extension["version"] == expected_version

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -19,11 +19,11 @@ QUALITY_WORKFLOW = (
     REPOSITORY_ROOT / ".github" / "workflows" / "quality_control.yml"
 ).read_text(encoding="utf-8")
 EXPECTED_JARVIS_RELEASE_URL = (
-    "https://github.com/grc-iit/jarvis-cd/releases/download/v1.3.1/"
-    "jarvis_cd-1.3.1-py3-none-any.whl"
+    "https://github.com/grc-iit/jarvis-cd/releases/download/v1.3.2/"
+    "jarvis_cd-1.3.2-py3-none-any.whl"
 )
 EXPECTED_JARVIS_RELEASE_SHA256 = (
-    "08411d49f8d457ec8a1a73ad9eacc71416a17919733682acee7e28e0011d8cea"
+    "2e5c994b1b21caf44eecb62c1d631c5ce3886d9282549589520c1d9b49961277"
 )
 
 
@@ -280,7 +280,7 @@ def test_ares_probe_exercises_persistent_uv_tool_installation() -> None:
     assert '"locked_jarvis": locked_jarvis' in probe
     assert 'assert "%" not in log_path.name' in probe
     assert "assert log_path.is_file()" in probe
-    assert probe_module["EXPECTED_JARVIS_VERSION"] == "1.3.1"
+    assert probe_module["EXPECTED_JARVIS_VERSION"] == "1.3.2"
     assert probe_module["EXPECTED_JARVIS_URL"] == EXPECTED_JARVIS_RELEASE_URL
     assert probe_module["EXPECTED_JARVIS_SHA256"] == EXPECTED_JARVIS_RELEASE_SHA256
     assert "uvx" not in probe
@@ -321,8 +321,8 @@ def test_wheel_smoke_binds_jarvis_artifacts_to_exact_release_wheel() -> None:
     )
     match = re.fullmatch(
         r"jarvis-cd @ "
-        r"(https://github\.com/grc-iit/jarvis-cd/releases/download/v1\.3\.1/"
-        r"jarvis_cd-1\.3\.1-py3-none-any\.whl)"
+        r"(https://github\.com/grc-iit/jarvis-cd/releases/download/v1\.3\.2/"
+        r"jarvis_cd-1\.3\.2-py3-none-any\.whl)"
         r"#sha256=([0-9a-f]{64})",
         dependency,
     )
@@ -336,7 +336,7 @@ def test_wheel_smoke_binds_jarvis_artifacts_to_exact_release_wheel() -> None:
     jarvis_package = next(
         package for package in jarvis_lock["package"] if package["name"] == "jarvis-cd"
     )
-    assert jarvis_package["version"] == "1.3.1"
+    assert jarvis_package["version"] == "1.3.2"
     assert jarvis_package["source"] == {"url": expected_url}
     assert jarvis_package["wheels"] == [
         {"url": expected_url, "hash": f"sha256:{expected_digest}"}
@@ -351,12 +351,12 @@ def test_wheel_smoke_binds_jarvis_artifacts_to_exact_release_wheel() -> None:
     assert '"jarvis_get_execution_artifacts"' not in smoke_block
     assert 'get_servers_path() / "jarvis"' in smoke_block
     assert 'distribution("jarvis-cd")' in smoke_block
-    assert 'installed.version == "1.3.1"' in smoke_block
+    assert 'installed.version == "1.3.2"' in smoke_block
     assert expected_url in smoke_block
     assert expected_digest in smoke_block
     assert "expected_requirement in project" in smoke_block
     assert 'package["name"] == "jarvis-cd"' in smoke_block
-    assert 'jarvis_package["version"] == "1.3.1"' in smoke_block
+    assert 'jarvis_package["version"] == "1.3.2"' in smoke_block
     assert 'jarvis_package["source"] == {"url": expected_url}' in smoke_block
     assert '"hash": f"sha256:{expected_digest}"' in smoke_block
     assert 'installed.read_text("direct_url.json")' in smoke_block

--- a/uv.lock
+++ b/uv.lock
@@ -61,7 +61,7 @@ wheels = [
 
 [[package]]
 name = "clio-kit"
-version = "2.4.2"
+version = "2.4.3"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- canonical-JSON encode mapping and list package settings instead of Python repr
- prove a scientific-catalog dataset descriptor crosses into JARVIS 1.3.2 and parses through DatasetDescriptor
- pin the nested JARVIS MCP runtime to the exact released JARVIS-CD 1.3.2 wheel and SHA
- prepare clio-kit 2.4.3 and publish only the changed JARVIS MCP contract as 3.1.1

## Focused verification
- 2 nested JARVIS handler/descriptor tests
- 3 root release/manifest invariant tests
- Ruff clean and formatted
- targeted Pyright: 0 errors, 0 warnings
- root and nested uv lock checks
- installed child direct_url/version verification

The untracked local paraview-mcp-capabilities.md file is not part of this PR.