### PR TITLE
fix: repin JARVIS MCP runtime

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "CLIO Kit - MCP Servers for Scientific Computing and HPC",
-    "version": "2.4.5",
+    "version": "2.4.6",
     "pluginRoot": "./clio-kit-mcp-servers"
   },
   "plugins": [

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -339,8 +339,8 @@ jobs:
 
         from clio_kit import get_servers_path, locked_server_environment
 
-        expected_url = "https://github.com/grc-iit/jarvis-cd/releases/download/v1.3.2/jarvis_cd-1.3.2-py3-none-any.whl"
-        expected_digest = "2e5c994b1b21caf44eecb62c1d631c5ce3886d9282549589520c1d9b49961277"
+        expected_url = "https://github.com/grc-iit/jarvis-cd/releases/download/v1.3.3/jarvis_cd-1.3.3-py3-none-any.whl"
+        expected_digest = "f7235d7b0acf0ecd459839a83f9103038bca2c52ce5059a9d72e59f376004b32"
         expected_requirement = f"jarvis-cd @ {expected_url}#sha256={expected_digest}"
         server = get_servers_path() / "jarvis"
         project = tomllib.loads(
@@ -353,7 +353,7 @@ jobs:
             for package in jarvis_lock["package"]
             if package["name"] == "jarvis-cd"
         )
-        assert jarvis_package["version"] == "1.3.2"
+        assert jarvis_package["version"] == "1.3.3"
         assert jarvis_package["source"] == {"url": expected_url}
         assert jarvis_package["wheels"] == [
             {"url": expected_url, "hash": f"sha256:{expected_digest}"}
@@ -368,12 +368,15 @@ jobs:
         import sys
         from importlib.metadata import distribution
         from pathlib import Path
+        from tempfile import TemporaryDirectory
 
+        from jarvis_cd.core.config import Jarvis
+        from jarvis_cd.core.pkg import Pkg
         from jarvis_cd.core.pipeline import Pipeline
 
-        expected_url = "https://github.com/grc-iit/jarvis-cd/releases/download/v1.3.2/jarvis_cd-1.3.2-py3-none-any.whl"
+        expected_url = "https://github.com/grc-iit/jarvis-cd/releases/download/v1.3.3/jarvis_cd-1.3.3-py3-none-any.whl"
         installed = distribution("jarvis-cd")
-        assert installed.version == "1.3.2"
+        assert installed.version == "1.3.3"
         direct_url_text = installed.read_text("direct_url.json")
         assert direct_url_text is not None
         direct_url = json.loads(direct_url_text)
@@ -381,6 +384,30 @@ jobs:
         pipeline_source = Path(inspect.getfile(Pipeline)).resolve()
         assert pipeline_source.is_relative_to(Path(sys.prefix).resolve())
         assert callable(getattr(Pipeline, "get_execution_artifacts", None))
+        with TemporaryDirectory() as directory:
+            root = Path(directory)
+            Jarvis._instance = None
+            jarvis = Jarvis.get_instance(str(root))
+            jarvis.initialize(
+                str(root / "config"),
+                str(root / "private"),
+                str(root / "shared"),
+            )
+            legacy_builtin = root / "builtin"
+            jarvis.save_repos({"repos": [str(legacy_builtin)]})
+            rebound_builtin = Path(jarvis.repos["repos"][0])
+            assert rebound_builtin != legacy_builtin
+            assert rebound_builtin.is_relative_to(Path(sys.prefix).resolve())
+            paraview_menu = Pkg.load_standalone(
+                "builtin.paraview"
+            ).configure_menu()
+            pvpython = [
+                item for item in paraview_menu
+                if item.get("name") == "pvpython_bin"
+            ]
+            assert len(paraview_menu) == 30
+            assert len(pvpython) == 1
+            assert pvpython[0]["default"] == "pvpython"
         PY
         jarvis_admin_help="$("$clio_kit" \
           mcp-server jarvis -- --profile admin --help)"

--- a/clio-kit-mcp-servers/adios/server.json
+++ b/clio-kit-mcp-servers/adios/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.4.5",
+      "version": "2.4.6",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/arxiv/server.json
+++ b/clio-kit-mcp-servers/arxiv/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.4.5",
+      "version": "2.4.6",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/chronolog/server.json
+++ b/clio-kit-mcp-servers/chronolog/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.4.5",
+      "version": "2.4.6",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/compression/server.json
+++ b/clio-kit-mcp-servers/compression/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.4.5",
+      "version": "2.4.6",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/darshan/server.json
+++ b/clio-kit-mcp-servers/darshan/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.4.5",
+      "version": "2.4.6",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/geo/server.json
+++ b/clio-kit-mcp-servers/geo/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.4.5",
+      "version": "2.4.6",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/geojson/server.json
+++ b/clio-kit-mcp-servers/geojson/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.4.5",
+      "version": "2.4.6",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/hdf5/server.json
+++ b/clio-kit-mcp-servers/hdf5/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.4.5",
+      "version": "2.4.6",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/jarvis/pyproject.toml
+++ b/clio-kit-mcp-servers/jarvis/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
   "fastmcp>=3.2.0",
   "fastapi",
   "python-dotenv>=1.2.2",
-  "jarvis-cd @ https://github.com/grc-iit/jarvis-cd/releases/download/v1.3.2/jarvis_cd-1.3.2-py3-none-any.whl#sha256=2e5c994b1b21caf44eecb62c1d631c5ce3886d9282549589520c1d9b49961277",
+  "jarvis-cd @ https://github.com/grc-iit/jarvis-cd/releases/download/v1.3.3/jarvis_cd-1.3.3-py3-none-any.whl#sha256=f7235d7b0acf0ecd459839a83f9103038bca2c52ce5059a9d72e59f376004b32",
   "starlette>=1.3.1",
   "authlib>=1.6.12",
   "cryptography>=48.0.1",

--- a/clio-kit-mcp-servers/jarvis/scripts/live_ares_semantic_mcp_probe.py
+++ b/clio-kit-mcp-servers/jarvis/scripts/live_ares_semantic_mcp_probe.py
@@ -18,13 +18,13 @@ from urllib.parse import urlsplit
 
 
 Json = dict[str, Any]
-EXPECTED_JARVIS_VERSION = "1.3.2"
+EXPECTED_JARVIS_VERSION = "1.3.3"
 EXPECTED_JARVIS_URL = (
-    "https://github.com/grc-iit/jarvis-cd/releases/download/v1.3.2/"
-    "jarvis_cd-1.3.2-py3-none-any.whl"
+    "https://github.com/grc-iit/jarvis-cd/releases/download/v1.3.3/"
+    "jarvis_cd-1.3.3-py3-none-any.whl"
 )
 EXPECTED_JARVIS_SHA256 = (
-    "2e5c994b1b21caf44eecb62c1d631c5ce3886d9282549589520c1d9b49961277"
+    "f7235d7b0acf0ecd459839a83f9103038bca2c52ce5059a9d72e59f376004b32"
 )
 
 

--- a/clio-kit-mcp-servers/jarvis/server.json
+++ b/clio-kit-mcp-servers/jarvis/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.4.5",
+      "version": "2.4.6",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/jarvis/uv.lock
+++ b/clio-kit-mcp-servers/jarvis/uv.lock
@@ -791,8 +791,8 @@ wheels = [
 
 [[package]]
 name = "jarvis-cd"
-version = "1.3.2"
-source = { url = "https://github.com/grc-iit/jarvis-cd/releases/download/v1.3.2/jarvis_cd-1.3.2-py3-none-any.whl" }
+version = "1.3.3"
+source = { url = "https://github.com/grc-iit/jarvis-cd/releases/download/v1.3.3/jarvis_cd-1.3.3-py3-none-any.whl" }
 dependencies = [
     { name = "pandas" },
     { name = "podman-compose" },
@@ -800,7 +800,7 @@ dependencies = [
     { name = "pyyaml" },
 ]
 wheels = [
-    { url = "https://github.com/grc-iit/jarvis-cd/releases/download/v1.3.2/jarvis_cd-1.3.2-py3-none-any.whl", hash = "sha256:2e5c994b1b21caf44eecb62c1d631c5ce3886d9282549589520c1d9b49961277" },
+    { url = "https://github.com/grc-iit/jarvis-cd/releases/download/v1.3.3/jarvis_cd-1.3.3-py3-none-any.whl", hash = "sha256:f7235d7b0acf0ecd459839a83f9103038bca2c52ce5059a9d72e59f376004b32" },
 ]
 
 [package.metadata]
@@ -853,7 +853,7 @@ requires-dist = [
     { name = "fastapi" },
     { name = "fastmcp", specifier = ">=3.2.0" },
     { name = "idna", specifier = ">=3.15" },
-    { name = "jarvis-cd", url = "https://github.com/grc-iit/jarvis-cd/releases/download/v1.3.2/jarvis_cd-1.3.2-py3-none-any.whl" },
+    { name = "jarvis-cd", url = "https://github.com/grc-iit/jarvis-cd/releases/download/v1.3.3/jarvis_cd-1.3.3-py3-none-any.whl" },
     { name = "pydantic", specifier = ">=2.12.5" },
     { name = "pydantic-settings", specifier = ">=2.14.2" },
     { name = "pygments", specifier = ">=2.20.0" },

--- a/clio-kit-mcp-servers/lmod/server.json
+++ b/clio-kit-mcp-servers/lmod/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.4.5",
+      "version": "2.4.6",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/ndp/server.json
+++ b/clio-kit-mcp-servers/ndp/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.4.5",
+      "version": "2.4.6",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/node-hardware/server.json
+++ b/clio-kit-mcp-servers/node-hardware/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.4.5",
+      "version": "2.4.6",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/pandas/server.json
+++ b/clio-kit-mcp-servers/pandas/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.4.5",
+      "version": "2.4.6",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/parallel-sort/server.json
+++ b/clio-kit-mcp-servers/parallel-sort/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.4.5",
+      "version": "2.4.6",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/paraview/server.json
+++ b/clio-kit-mcp-servers/paraview/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.4.5",
+      "version": "2.4.6",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/parquet/server.json
+++ b/clio-kit-mcp-servers/parquet/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.4.5",
+      "version": "2.4.6",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/plot/server.json
+++ b/clio-kit-mcp-servers/plot/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.4.5",
+      "version": "2.4.6",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/sac/server.json
+++ b/clio-kit-mcp-servers/sac/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.4.5",
+      "version": "2.4.6",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/scientific-catalog/server.json
+++ b/clio-kit-mcp-servers/scientific-catalog/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.4.5",
+      "version": "2.4.6",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/seismic/server.json
+++ b/clio-kit-mcp-servers/seismic/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.4.5",
+      "version": "2.4.6",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/slurm/server.json
+++ b/clio-kit-mcp-servers/slurm/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.4.5",
+      "version": "2.4.6",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/spack/server.json
+++ b/clio-kit-mcp-servers/spack/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.4.5",
+      "version": "2.4.6",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/terrain/server.json
+++ b/clio-kit-mcp-servers/terrain/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.4.5",
+      "version": "2.4.6",
       "transport": {
         "type": "stdio"
       },

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "clio-kit",
-  "version": "2.4.5",
+  "version": "2.4.6",
   "mcpServers": {
     "clio-adios": {
       "command": "clio-kit",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "clio-kit"
-version = "2.4.5"
+version = "2.4.6"
 description = "CLIO Kit - MCP Servers, Clients, and Tools for AI Agents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -19,11 +19,11 @@ QUALITY_WORKFLOW = (
     REPOSITORY_ROOT / ".github" / "workflows" / "quality_control.yml"
 ).read_text(encoding="utf-8")
 EXPECTED_JARVIS_RELEASE_URL = (
-    "https://github.com/grc-iit/jarvis-cd/releases/download/v1.3.2/"
-    "jarvis_cd-1.3.2-py3-none-any.whl"
+    "https://github.com/grc-iit/jarvis-cd/releases/download/v1.3.3/"
+    "jarvis_cd-1.3.3-py3-none-any.whl"
 )
 EXPECTED_JARVIS_RELEASE_SHA256 = (
-    "2e5c994b1b21caf44eecb62c1d631c5ce3886d9282549589520c1d9b49961277"
+    "f7235d7b0acf0ecd459839a83f9103038bca2c52ce5059a9d72e59f376004b32"
 )
 
 
@@ -280,7 +280,7 @@ def test_ares_probe_exercises_persistent_uv_tool_installation() -> None:
     assert '"locked_jarvis": locked_jarvis' in probe
     assert 'assert "%" not in log_path.name' in probe
     assert "assert log_path.is_file()" in probe
-    assert probe_module["EXPECTED_JARVIS_VERSION"] == "1.3.2"
+    assert probe_module["EXPECTED_JARVIS_VERSION"] == "1.3.3"
     assert probe_module["EXPECTED_JARVIS_URL"] == EXPECTED_JARVIS_RELEASE_URL
     assert probe_module["EXPECTED_JARVIS_SHA256"] == EXPECTED_JARVIS_RELEASE_SHA256
     assert "uvx" not in probe
@@ -321,8 +321,8 @@ def test_wheel_smoke_binds_jarvis_artifacts_to_exact_release_wheel() -> None:
     )
     match = re.fullmatch(
         r"jarvis-cd @ "
-        r"(https://github\.com/grc-iit/jarvis-cd/releases/download/v1\.3\.2/"
-        r"jarvis_cd-1\.3\.2-py3-none-any\.whl)"
+        r"(https://github\.com/grc-iit/jarvis-cd/releases/download/v1\.3\.3/"
+        r"jarvis_cd-1\.3\.3-py3-none-any\.whl)"
         r"#sha256=([0-9a-f]{64})",
         dependency,
     )
@@ -336,7 +336,7 @@ def test_wheel_smoke_binds_jarvis_artifacts_to_exact_release_wheel() -> None:
     jarvis_package = next(
         package for package in jarvis_lock["package"] if package["name"] == "jarvis-cd"
     )
-    assert jarvis_package["version"] == "1.3.2"
+    assert jarvis_package["version"] == "1.3.3"
     assert jarvis_package["source"] == {"url": expected_url}
     assert jarvis_package["wheels"] == [
         {"url": expected_url, "hash": f"sha256:{expected_digest}"}
@@ -351,18 +351,24 @@ def test_wheel_smoke_binds_jarvis_artifacts_to_exact_release_wheel() -> None:
     assert '"jarvis_get_execution_artifacts"' not in smoke_block
     assert 'get_servers_path() / "jarvis"' in smoke_block
     assert 'distribution("jarvis-cd")' in smoke_block
-    assert 'installed.version == "1.3.2"' in smoke_block
+    assert 'installed.version == "1.3.3"' in smoke_block
     assert expected_url in smoke_block
     assert expected_digest in smoke_block
     assert "expected_requirement in project" in smoke_block
     assert 'package["name"] == "jarvis-cd"' in smoke_block
-    assert 'jarvis_package["version"] == "1.3.2"' in smoke_block
+    assert 'jarvis_package["version"] == "1.3.3"' in smoke_block
     assert 'jarvis_package["source"] == {"url": expected_url}' in smoke_block
     assert '"hash": f"sha256:{expected_digest}"' in smoke_block
     assert 'installed.read_text("direct_url.json")' in smoke_block
     assert 'direct_url["url"] == expected_url' in smoke_block
     assert 'getattr(Pipeline, "get_execution_artifacts", None)' in smoke_block
     assert "pipeline_source.is_relative_to(Path(sys.prefix).resolve())" in smoke_block
+    assert 'jarvis.save_repos({"repos": [str(legacy_builtin)]})' in smoke_block
+    assert "rebound_builtin != legacy_builtin" in smoke_block
+    assert '"builtin.paraview"' in smoke_block
+    assert 'item.get("name") == "pvpython_bin"' in smoke_block
+    assert "len(paraview_menu) == 30" in smoke_block
+    assert 'pvpython[0]["default"] == "pvpython"' in smoke_block
 
 
 def test_release_regenerates_and_smokes_shipped_user_contracts() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -61,7 +61,7 @@ wheels = [
 
 [[package]]
 name = "clio-kit"
-version = "2.4.5"
+version = "2.4.6"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## What changed

- bump the clio-kit distribution to 2.4.6 without changing the JARVIS MCP 3.1.1 agent-facing contract
- repin the frozen JARVIS MCP project from JARVIS-CD 1.3.2 to the immutable 1.3.3 wheel and exact SHA-256
- update release and Ares probes to verify the installed child runtime, not only the bootstrap environment
- add installed-wheel coverage for stale managed-builtin rebinding and the merged ParaView settings contract

## Why

Live Ares validation showed that clio-relay provisioned JARVIS-CD 1.3.3 but clio-kit 2.4.5 still launched JARVIS MCP from its separately frozen 1.3.2 environment. The remote call therefore succeeded while describing a stale `builtin.paraview` package without `pvpython_bin`.

The corrected installed-wheel contract has 30 settings: 18 package-specific ParaView settings plus 12 generic Application settings. `pvpython_bin` is present exactly once with default `pvpython`.

## Focused validation

- Ruff check/fix and format passed on changed Python files
- root and JARVIS locks pass `uv lock --check`
- 2 focused release pin/workflow tests passed
- 5 generator contract tests passed
- isolated `uv tool` installation from the built 2.4.6 wheel passed
- the installed frozen child loaded JARVIS-CD 1.3.3 from the exact release URL and successfully rebound a stale managed builtin repository
- `git diff --check` passed
