### PR TITLE
fix: avoid release tag recreation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -758,7 +758,6 @@ jobs:
             gh release create "$TAG_NAME" \
               --repo "$REPOSITORY" \
               --verify-tag \
-              --target "$GITHUB_SHA" \
               --title "CLIO Kit $TAG_NAME" \
               --generate-notes \
               --draft

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -136,6 +136,7 @@ def test_draft_release_is_resolved_and_mutated_only_by_exact_id() -> None:
     assert "expected one draft release" in release_block
     assert "fetch_release_by_id()" in release_block
     assert '"repos/$REPOSITORY/releases/$release_id"' in release_block
+    assert '--target "$GITHUB_SHA"' not in release_block
     assert "verify_release_identity || return" in release_block
     assert (
         '"https://uploads.github.com/repos/$REPOSITORY/releases/'


### PR DESCRIPTION
## Summary
- stop passing a redundant target when creating a release for an already verified tag
- retain the existing remote-tag-to-`GITHUB_SHA` proof and `--verify-tag` guard
- prevent GitHub Actions from being forced through tag-creation authorization during release creation

## Focused validation
- Ruff check/format
- exact draft-release workflow tests: 2 passed
- `git diff --check`