### PR TITLE
fix: authorize immutable release attestations

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -534,7 +534,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
     permissions:
       contents: write  # Mandatory for creating releases
-      attestations: read
+      attestations: write  # Immutable publication creates a release attestation
 
     steps:
     - name: Download all the dists

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -195,6 +195,12 @@ def test_pypi_verification_uses_pre_publish_immutable_copies() -> None:
 
 def test_final_release_requires_attestation_and_immutability() -> None:
     """Publishing remains gated by provenance, immutable state, and release verification."""
+    release_start = WORKFLOW.index("  github-release:")
+    release_steps = WORKFLOW.index("    steps:", release_start)
+    release_permissions = WORKFLOW[release_start:release_steps]
+    assert "contents: write" in release_permissions
+    assert "attestations: write" in release_permissions
+    assert "attestations: read" not in release_permissions
     assert "gh attestation verify" in WORKFLOW
     assert "--deny-self-hosted-runners" in WORKFLOW
     assert 'test "$(jq -r .immutable "$release_json")" = true' in WORKFLOW


### PR DESCRIPTION
## Summary
- grant the release job attestation write permission required when publishing an immutable release
- retain contents write and exact build-attestation verification
- enforce the permission boundary in the release-workflow contract tests

## Focused validation
- Ruff check/format
- exact release permission and draft identity tests: 2 passed
- `git diff --check`