### PR TITLE
fix: repin JARVIS 1.3.5 runtime

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "CLIO Kit - MCP Servers for Scientific Computing and HPC",
-    "version": "2.4.7",
+    "version": "2.4.8",
     "pluginRoot": "./clio-kit-mcp-servers"
   },
   "plugins": [

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -339,8 +339,8 @@ jobs:
 
         from clio_kit import get_servers_path, locked_server_environment
 
-        expected_url = "https://github.com/grc-iit/jarvis-cd/releases/download/v1.3.4/jarvis_cd-1.3.4-py3-none-any.whl"
-        expected_digest = "960debefd73b7789a141b5d02e89776fa10317144c357d791e0b843d730e4275"
+        expected_url = "https://github.com/grc-iit/jarvis-cd/releases/download/v1.3.5/jarvis_cd-1.3.5-py3-none-any.whl"
+        expected_digest = "fd4ead8aa2d053527f9d2ebe85498ca952e99395b5975de50a696a9cc54a9e55"
         expected_requirement = f"jarvis-cd @ {expected_url}#sha256={expected_digest}"
         server = get_servers_path() / "jarvis"
         project = tomllib.loads(
@@ -353,7 +353,7 @@ jobs:
             for package in jarvis_lock["package"]
             if package["name"] == "jarvis-cd"
         )
-        assert jarvis_package["version"] == "1.3.4"
+        assert jarvis_package["version"] == "1.3.5"
         assert jarvis_package["source"] == {"url": expected_url}
         assert jarvis_package["wheels"] == [
             {"url": expected_url, "hash": f"sha256:{expected_digest}"}
@@ -374,9 +374,9 @@ jobs:
         from jarvis_cd.core.pkg import Pkg
         from jarvis_cd.core.pipeline import Pipeline
 
-        expected_url = "https://github.com/grc-iit/jarvis-cd/releases/download/v1.3.4/jarvis_cd-1.3.4-py3-none-any.whl"
+        expected_url = "https://github.com/grc-iit/jarvis-cd/releases/download/v1.3.5/jarvis_cd-1.3.5-py3-none-any.whl"
         installed = distribution("jarvis-cd")
-        assert installed.version == "1.3.4"
+        assert installed.version == "1.3.5"
         direct_url_text = installed.read_text("direct_url.json")
         assert direct_url_text is not None
         direct_url = json.loads(direct_url_text)
@@ -393,7 +393,7 @@ jobs:
                 str(root / "private"),
                 str(root / "shared"),
             )
-            legacy_builtin = root / "builtin"
+            legacy_builtin = Path.home() / ".ppi-jarvis" / "builtin"
             jarvis.save_repos({"repos": [str(legacy_builtin)]})
             rebound_builtin = Path(jarvis.repos["repos"][0])
             assert rebound_builtin != legacy_builtin
@@ -415,11 +415,12 @@ jobs:
                     "io_dump_interval": 25,
                     "io_lattice_size": 6,
                     "io_run_steps": 100,
-                    "out": str(root / "lammps output"),
+                    "out": ".",
                     "script": None,
                 }
             )
             lammps.shared_dir = root / "shared"
+            assert lammps._output_dir() == str(root / "shared")
             generated_input = lammps._generated_input_script()
             assert generated_input is not None
             generated_path = Path(generated_input)

--- a/clio-kit-mcp-servers/adios/server.json
+++ b/clio-kit-mcp-servers/adios/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.4.7",
+      "version": "2.4.8",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/arxiv/server.json
+++ b/clio-kit-mcp-servers/arxiv/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.4.7",
+      "version": "2.4.8",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/chronolog/server.json
+++ b/clio-kit-mcp-servers/chronolog/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.4.7",
+      "version": "2.4.8",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/compression/server.json
+++ b/clio-kit-mcp-servers/compression/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.4.7",
+      "version": "2.4.8",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/darshan/server.json
+++ b/clio-kit-mcp-servers/darshan/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.4.7",
+      "version": "2.4.8",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/geo/server.json
+++ b/clio-kit-mcp-servers/geo/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.4.7",
+      "version": "2.4.8",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/geojson/server.json
+++ b/clio-kit-mcp-servers/geojson/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.4.7",
+      "version": "2.4.8",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/hdf5/server.json
+++ b/clio-kit-mcp-servers/hdf5/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.4.7",
+      "version": "2.4.8",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/jarvis/pyproject.toml
+++ b/clio-kit-mcp-servers/jarvis/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
   "fastmcp>=3.2.0",
   "fastapi",
   "python-dotenv>=1.2.2",
-  "jarvis-cd @ https://github.com/grc-iit/jarvis-cd/releases/download/v1.3.4/jarvis_cd-1.3.4-py3-none-any.whl#sha256=960debefd73b7789a141b5d02e89776fa10317144c357d791e0b843d730e4275",
+  "jarvis-cd @ https://github.com/grc-iit/jarvis-cd/releases/download/v1.3.5/jarvis_cd-1.3.5-py3-none-any.whl#sha256=fd4ead8aa2d053527f9d2ebe85498ca952e99395b5975de50a696a9cc54a9e55",
   "starlette>=1.3.1",
   "authlib>=1.6.12",
   "cryptography>=48.0.1",

--- a/clio-kit-mcp-servers/jarvis/scripts/live_ares_semantic_mcp_probe.py
+++ b/clio-kit-mcp-servers/jarvis/scripts/live_ares_semantic_mcp_probe.py
@@ -18,13 +18,13 @@ from urllib.parse import urlsplit
 
 
 Json = dict[str, Any]
-EXPECTED_JARVIS_VERSION = "1.3.4"
+EXPECTED_JARVIS_VERSION = "1.3.5"
 EXPECTED_JARVIS_URL = (
-    "https://github.com/grc-iit/jarvis-cd/releases/download/v1.3.4/"
-    "jarvis_cd-1.3.4-py3-none-any.whl"
+    "https://github.com/grc-iit/jarvis-cd/releases/download/v1.3.5/"
+    "jarvis_cd-1.3.5-py3-none-any.whl"
 )
 EXPECTED_JARVIS_SHA256 = (
-    "960debefd73b7789a141b5d02e89776fa10317144c357d791e0b843d730e4275"
+    "fd4ead8aa2d053527f9d2ebe85498ca952e99395b5975de50a696a9cc54a9e55"
 )
 
 

--- a/clio-kit-mcp-servers/jarvis/server.json
+++ b/clio-kit-mcp-servers/jarvis/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.4.7",
+      "version": "2.4.8",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/jarvis/uv.lock
+++ b/clio-kit-mcp-servers/jarvis/uv.lock
@@ -791,8 +791,8 @@ wheels = [
 
 [[package]]
 name = "jarvis-cd"
-version = "1.3.4"
-source = { url = "https://github.com/grc-iit/jarvis-cd/releases/download/v1.3.4/jarvis_cd-1.3.4-py3-none-any.whl" }
+version = "1.3.5"
+source = { url = "https://github.com/grc-iit/jarvis-cd/releases/download/v1.3.5/jarvis_cd-1.3.5-py3-none-any.whl" }
 dependencies = [
     { name = "pandas" },
     { name = "podman-compose" },
@@ -800,7 +800,7 @@ dependencies = [
     { name = "pyyaml" },
 ]
 wheels = [
-    { url = "https://github.com/grc-iit/jarvis-cd/releases/download/v1.3.4/jarvis_cd-1.3.4-py3-none-any.whl", hash = "sha256:960debefd73b7789a141b5d02e89776fa10317144c357d791e0b843d730e4275" },
+    { url = "https://github.com/grc-iit/jarvis-cd/releases/download/v1.3.5/jarvis_cd-1.3.5-py3-none-any.whl", hash = "sha256:fd4ead8aa2d053527f9d2ebe85498ca952e99395b5975de50a696a9cc54a9e55" },
 ]
 
 [package.metadata]
@@ -853,7 +853,7 @@ requires-dist = [
     { name = "fastapi" },
     { name = "fastmcp", specifier = ">=3.2.0" },
     { name = "idna", specifier = ">=3.15" },
-    { name = "jarvis-cd", url = "https://github.com/grc-iit/jarvis-cd/releases/download/v1.3.4/jarvis_cd-1.3.4-py3-none-any.whl" },
+    { name = "jarvis-cd", url = "https://github.com/grc-iit/jarvis-cd/releases/download/v1.3.5/jarvis_cd-1.3.5-py3-none-any.whl" },
     { name = "pydantic", specifier = ">=2.12.5" },
     { name = "pydantic-settings", specifier = ">=2.14.2" },
     { name = "pygments", specifier = ">=2.20.0" },

--- a/clio-kit-mcp-servers/lmod/server.json
+++ b/clio-kit-mcp-servers/lmod/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.4.7",
+      "version": "2.4.8",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/ndp/server.json
+++ b/clio-kit-mcp-servers/ndp/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.4.7",
+      "version": "2.4.8",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/node-hardware/server.json
+++ b/clio-kit-mcp-servers/node-hardware/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.4.7",
+      "version": "2.4.8",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/pandas/server.json
+++ b/clio-kit-mcp-servers/pandas/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.4.7",
+      "version": "2.4.8",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/parallel-sort/server.json
+++ b/clio-kit-mcp-servers/parallel-sort/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.4.7",
+      "version": "2.4.8",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/paraview/server.json
+++ b/clio-kit-mcp-servers/paraview/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.4.7",
+      "version": "2.4.8",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/parquet/server.json
+++ b/clio-kit-mcp-servers/parquet/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.4.7",
+      "version": "2.4.8",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/plot/server.json
+++ b/clio-kit-mcp-servers/plot/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.4.7",
+      "version": "2.4.8",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/sac/server.json
+++ b/clio-kit-mcp-servers/sac/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.4.7",
+      "version": "2.4.8",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/scientific-catalog/server.json
+++ b/clio-kit-mcp-servers/scientific-catalog/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.4.7",
+      "version": "2.4.8",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/seismic/server.json
+++ b/clio-kit-mcp-servers/seismic/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.4.7",
+      "version": "2.4.8",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/slurm/server.json
+++ b/clio-kit-mcp-servers/slurm/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.4.7",
+      "version": "2.4.8",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/spack/server.json
+++ b/clio-kit-mcp-servers/spack/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.4.7",
+      "version": "2.4.8",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/terrain/server.json
+++ b/clio-kit-mcp-servers/terrain/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.4.7",
+      "version": "2.4.8",
       "transport": {
         "type": "stdio"
       },

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "clio-kit",
-  "version": "2.4.7",
+  "version": "2.4.8",
   "mcpServers": {
     "clio-adios": {
       "command": "clio-kit",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "clio-kit"
-version = "2.4.7"
+version = "2.4.8"
 description = "CLIO Kit - MCP Servers, Clients, and Tools for AI Agents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -19,11 +19,11 @@ QUALITY_WORKFLOW = (
     REPOSITORY_ROOT / ".github" / "workflows" / "quality_control.yml"
 ).read_text(encoding="utf-8")
 EXPECTED_JARVIS_RELEASE_URL = (
-    "https://github.com/grc-iit/jarvis-cd/releases/download/v1.3.4/"
-    "jarvis_cd-1.3.4-py3-none-any.whl"
+    "https://github.com/grc-iit/jarvis-cd/releases/download/v1.3.5/"
+    "jarvis_cd-1.3.5-py3-none-any.whl"
 )
 EXPECTED_JARVIS_RELEASE_SHA256 = (
-    "960debefd73b7789a141b5d02e89776fa10317144c357d791e0b843d730e4275"
+    "fd4ead8aa2d053527f9d2ebe85498ca952e99395b5975de50a696a9cc54a9e55"
 )
 
 
@@ -251,6 +251,8 @@ def test_wheel_smoke_exercises_persistent_uv_tool_installation() -> None:
     assert 'test "$second_child_identity" = "$first_child_identity"' in smoke_block
     assert 'Pkg.load_standalone("builtin.lammps")' in smoke_block
     assert '"deploy_mode": "default"' in smoke_block
+    assert '"out": "."' in smoke_block
+    assert 'lammps._output_dir() == str(root / "shared")' in smoke_block
     assert "lammps._generated_input_script()" in smoke_block
     assert 'generated_path.name.startswith("generated_io_input-")' in smoke_block
     assert 'generated_content.endswith("run 100\\n")' in smoke_block
@@ -292,7 +294,7 @@ def test_ares_probe_exercises_persistent_uv_tool_installation() -> None:
     assert '"locked_jarvis": locked_jarvis' in probe
     assert 'assert "%" not in log_path.name' in probe
     assert "assert log_path.is_file()" in probe
-    assert probe_module["EXPECTED_JARVIS_VERSION"] == "1.3.4"
+    assert probe_module["EXPECTED_JARVIS_VERSION"] == "1.3.5"
     assert probe_module["EXPECTED_JARVIS_URL"] == EXPECTED_JARVIS_RELEASE_URL
     assert probe_module["EXPECTED_JARVIS_SHA256"] == EXPECTED_JARVIS_RELEASE_SHA256
     assert "uvx" not in probe
@@ -333,8 +335,8 @@ def test_wheel_smoke_binds_jarvis_artifacts_to_exact_release_wheel() -> None:
     )
     match = re.fullmatch(
         r"jarvis-cd @ "
-        r"(https://github\.com/grc-iit/jarvis-cd/releases/download/v1\.3\.4/"
-        r"jarvis_cd-1\.3\.4-py3-none-any\.whl)"
+        r"(https://github\.com/grc-iit/jarvis-cd/releases/download/v1\.3\.5/"
+        r"jarvis_cd-1\.3\.5-py3-none-any\.whl)"
         r"#sha256=([0-9a-f]{64})",
         dependency,
     )
@@ -348,7 +350,7 @@ def test_wheel_smoke_binds_jarvis_artifacts_to_exact_release_wheel() -> None:
     jarvis_package = next(
         package for package in jarvis_lock["package"] if package["name"] == "jarvis-cd"
     )
-    assert jarvis_package["version"] == "1.3.4"
+    assert jarvis_package["version"] == "1.3.5"
     assert jarvis_package["source"] == {"url": expected_url}
     assert jarvis_package["wheels"] == [
         {"url": expected_url, "hash": f"sha256:{expected_digest}"}
@@ -363,18 +365,19 @@ def test_wheel_smoke_binds_jarvis_artifacts_to_exact_release_wheel() -> None:
     assert '"jarvis_get_execution_artifacts"' not in smoke_block
     assert 'get_servers_path() / "jarvis"' in smoke_block
     assert 'distribution("jarvis-cd")' in smoke_block
-    assert 'installed.version == "1.3.4"' in smoke_block
+    assert 'installed.version == "1.3.5"' in smoke_block
     assert expected_url in smoke_block
     assert expected_digest in smoke_block
     assert "expected_requirement in project" in smoke_block
     assert 'package["name"] == "jarvis-cd"' in smoke_block
-    assert 'jarvis_package["version"] == "1.3.4"' in smoke_block
+    assert 'jarvis_package["version"] == "1.3.5"' in smoke_block
     assert 'jarvis_package["source"] == {"url": expected_url}' in smoke_block
     assert '"hash": f"sha256:{expected_digest}"' in smoke_block
     assert 'installed.read_text("direct_url.json")' in smoke_block
     assert 'direct_url["url"] == expected_url' in smoke_block
     assert 'getattr(Pipeline, "get_execution_artifacts", None)' in smoke_block
     assert "pipeline_source.is_relative_to(Path(sys.prefix).resolve())" in smoke_block
+    assert 'legacy_builtin = Path.home() / ".ppi-jarvis" / "builtin"' in smoke_block
     assert 'jarvis.save_repos({"repos": [str(legacy_builtin)]})' in smoke_block
     assert "rebound_builtin != legacy_builtin" in smoke_block
     assert '"builtin.paraview"' in smoke_block

--- a/uv.lock
+++ b/uv.lock
@@ -61,7 +61,7 @@ wheels = [
 
 [[package]]
 name = "clio-kit"
-version = "2.4.7"
+version = "2.4.8"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- release clio-kit 2.4.8 with the frozen JARVIS MCP project pinned to immutable JARVIS-CD v1.3.5
- bind the exact GitHub Release wheel URL and SHA-256 in the project, lock, live probe, and release smoke
- prove the 1.3.5 historical builtin migration and execution-owned portable LAMMPS output path in the installed-wheel gate
- regenerate only the root-wheel version mirrors in shipped manifests

## Validation

- downloaded JARVIS-CD v1.3.5 wheel: `fd4ead8aa2d053527f9d2ebe85498ca952e99395b5975de50a696a9cc54a9e55`
- `uv lock --check`
- `uv lock --check --directory clio-kit-mcp-servers/jarvis`
- focused Ruff check and format check
- focused Pyright: 0 errors, 0 warnings
- focused pytest: 25 passed
- locked JARVIS child portable LAMMPS smoke passed
- isolated `uv tool install` of the built clio-kit 2.4.8 wheel launched the JARVIS MCP and verified JARVIS-CD 1.3.5 provenance
- `git diff --check`