### PR TITLE
fix(jarvis): separate direct and scheduler lifecycle

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "CLIO Kit - MCP Servers for Scientific Computing and HPC",
-    "version": "2.5.0",
+    "version": "2.5.1",
     "pluginRoot": "./clio-kit-mcp-servers"
   },
   "plugins": [

--- a/clio-kit-mcp-servers/adios/server.json
+++ b/clio-kit-mcp-servers/adios/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.0",
+      "version": "2.5.1",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/arxiv/server.json
+++ b/clio-kit-mcp-servers/arxiv/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.0",
+      "version": "2.5.1",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/chronolog/server.json
+++ b/clio-kit-mcp-servers/chronolog/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.0",
+      "version": "2.5.1",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/compression/server.json
+++ b/clio-kit-mcp-servers/compression/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.0",
+      "version": "2.5.1",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/darshan/server.json
+++ b/clio-kit-mcp-servers/darshan/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.0",
+      "version": "2.5.1",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/geo/server.json
+++ b/clio-kit-mcp-servers/geo/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.0",
+      "version": "2.5.1",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/geojson/server.json
+++ b/clio-kit-mcp-servers/geojson/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.0",
+      "version": "2.5.1",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/hdf5/server.json
+++ b/clio-kit-mcp-servers/hdf5/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.0",
+      "version": "2.5.1",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/jarvis/server.json
+++ b/clio-kit-mcp-servers/jarvis/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.0",
+      "version": "2.5.1",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/jarvis/src/jarvis_mcp/capabilities/jarvis_handler.py
+++ b/clio-kit-mcp-servers/jarvis/src/jarvis_mcp/capabilities/jarvis_handler.py
@@ -2739,6 +2739,12 @@ def _runtime_metadata_from_documents(
     scheduler_provider = cast(str | None, handle_document["scheduler_provider"])
     scheduler_native_id = cast(str | None, handle_document["scheduler_native_id"])
     cluster = cast(str | None, handle_document["cluster"])
+    scheduler_owned = (
+        handle_document["mode"] == "scheduler"
+        and scheduler_provider is not None
+        and scheduler_native_id is not None
+        and record_document["submitted"] is True
+    )
     return {
         "schema_version": RUNTIME_METADATA_SCHEMA,
         "source": "jarvis_mcp",
@@ -2752,7 +2758,7 @@ def _runtime_metadata_from_documents(
         # above remain authoritative and are never recovered from stdout.
         "scheduler_type": scheduler_provider,
         "scheduler_job_id": scheduler_native_id,
-        "scheduler_phase": record_document["state"],
+        "scheduler_phase": record_document["state"] if scheduler_owned else None,
         "script_path": script_path,
         "hostfile_path": (
             _native_optional_text(

--- a/clio-kit-mcp-servers/jarvis/tests/test_jarvis_handler.py
+++ b/clio-kit-mcp-servers/jarvis/tests/test_jarvis_handler.py
@@ -1190,7 +1190,13 @@ class TestPipelineExecutionOperations:
             "cluster": None,
         }
         assert result["progress"]["schema_version"] == ("jarvis.execution.progress.v1")
-        assert result["runtime_metadata"]["terminal"]["terminal"] is True
+        runtime_metadata = result["runtime_metadata"]
+        assert runtime_metadata["scheduler_provider"] is None
+        assert runtime_metadata["scheduler_native_id"] is None
+        assert runtime_metadata["cluster"] is None
+        assert runtime_metadata["scheduler_phase"] is None
+        assert runtime_metadata["terminal"]["state"] == "completed"
+        assert runtime_metadata["terminal"]["terminal"] is True
 
     @pytest.mark.asyncio
     async def test_run_pipeline_failure(self, mock_pipeline):
@@ -1249,6 +1255,8 @@ class TestPipelineExecutionOperations:
         assert result["runtime_metadata"]["scheduler_native_id"] == "24680"
         assert result["runtime_metadata"]["cluster"] == "ares"
         assert result["runtime_metadata"]["scheduler_job_id"] == "24680"
+        assert result["runtime_metadata"]["scheduler_phase"] == "completed"
+        assert result["runtime_metadata"]["terminal"]["state"] == "completed"
         assert result["runtime_metadata"]["terminal"]["terminal"] is True
         assert (
             result["runtime_metadata"]["details"]["scheduler_submission"]
@@ -1556,6 +1564,8 @@ class TestPipelineExecutionOperations:
         assert result["mode"] == "scheduler"
         assert ModernPipeline.instances[-1].submitted is False
         assert result["runtime_metadata"]["scheduler_job_id"] is None
+        assert result["runtime_metadata"]["scheduler_phase"] is None
+        assert result["runtime_metadata"]["terminal"]["state"] == "scripted"
 
     @pytest.mark.asyncio
     async def test_script_only_run_rejects_unsubmitted_scheduler_identity(self):

--- a/clio-kit-mcp-servers/lmod/server.json
+++ b/clio-kit-mcp-servers/lmod/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.0",
+      "version": "2.5.1",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/ndp/server.json
+++ b/clio-kit-mcp-servers/ndp/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.0",
+      "version": "2.5.1",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/node-hardware/server.json
+++ b/clio-kit-mcp-servers/node-hardware/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.0",
+      "version": "2.5.1",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/pandas/server.json
+++ b/clio-kit-mcp-servers/pandas/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.0",
+      "version": "2.5.1",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/parallel-sort/server.json
+++ b/clio-kit-mcp-servers/parallel-sort/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.0",
+      "version": "2.5.1",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/paraview/server.json
+++ b/clio-kit-mcp-servers/paraview/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.0",
+      "version": "2.5.1",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/parquet/server.json
+++ b/clio-kit-mcp-servers/parquet/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.0",
+      "version": "2.5.1",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/plot/server.json
+++ b/clio-kit-mcp-servers/plot/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.0",
+      "version": "2.5.1",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/sac/server.json
+++ b/clio-kit-mcp-servers/sac/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.0",
+      "version": "2.5.1",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/scientific-catalog/server.json
+++ b/clio-kit-mcp-servers/scientific-catalog/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.0",
+      "version": "2.5.1",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/seismic/server.json
+++ b/clio-kit-mcp-servers/seismic/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.0",
+      "version": "2.5.1",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/slurm/server.json
+++ b/clio-kit-mcp-servers/slurm/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.0",
+      "version": "2.5.1",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/spack/server.json
+++ b/clio-kit-mcp-servers/spack/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.0",
+      "version": "2.5.1",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/terrain/server.json
+++ b/clio-kit-mcp-servers/terrain/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.0",
+      "version": "2.5.1",
       "transport": {
         "type": "stdio"
       },

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "clio-kit",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "mcpServers": {
     "clio-adios": {
       "command": "clio-kit",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "clio-kit"
-version = "2.5.0"
+version = "2.5.1"
 description = "CLIO Kit - MCP Servers, Clients, and Tools for AI Agents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -61,7 +61,7 @@ wheels = [
 
 [[package]]
 name = "clio-kit"
-version = "2.5.0"
+version = "2.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Direct and script-only JARVIS executions now keep lifecycle in terminal.state while returning scheduler_phase=null. Only a genuinely submitted scheduler-owned execution with provider and native identity reports scheduler_phase. This prevents non-Slurm work from being represented as scheduler running/completed. Focused direct, scheduler, script-only, package-coordinate, Ruff, and Pyright checks pass. Package version: 2.5.1; JARVIS contract remains v3.2 with unchanged contract bytes.