### PR TITLE
fix(jarvis): enforce package-owned configuration

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "CLIO Kit - MCP Servers for Scientific Computing and HPC",
-    "version": "2.5.6",
+    "version": "2.5.7",
     "pluginRoot": "./clio-kit-mcp-servers"
   },
   "plugins": [

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -252,6 +252,7 @@ jobs:
         "$clio_kit" --help >/dev/null
         listed_servers="$("$clio_kit" mcp-servers)"
         listed_contracts="$("$clio_kit" mcp-contracts)"
+        grep -Fq 'clio-kit-jarvis-user-v3.3' <<< "$listed_contracts"
         grep -Fq 'clio-kit-jarvis-user-v3.2' <<< "$listed_contracts"
         grep -Fq 'clio-kit-jarvis-user-v3.1' <<< "$listed_contracts"
         grep -Fq 'clio-kit-jarvis-user-v3' <<< "$listed_contracts"
@@ -259,9 +260,13 @@ jobs:
         grep -Fq 'clio-kit-slurm-user-v3' <<< "$listed_contracts"
         grep -Fq 'clio-kit-spack-user-v2' <<< "$listed_contracts"
         jarvis_contract="$("$clio_kit" \
-          mcp-contract clio-kit-jarvis-user-v3.2)"
-        python -c 'import json,sys; value=json.load(sys.stdin); assert value["contract_id"] == "clio-kit-jarvis-user-v3.2"; assert {tool["name"] for tool in value["tools"]} == {"jarvis_create_pipeline", "jarvis_describe", "jarvis_add_step", "jarvis_edit_step", "jarvis_run", "jarvis_get_execution"}' \
+          mcp-contract clio-kit-jarvis-user-v3.3)"
+        python -c 'import json,sys; value=json.load(sys.stdin); assert value["contract_id"] == "clio-kit-jarvis-user-v3.3"; assert {tool["name"] for tool in value["tools"]} == {"jarvis_create_pipeline", "jarvis_describe", "jarvis_add_step", "jarvis_edit_step", "jarvis_run", "jarvis_get_execution"}' \
           <<< "$jarvis_contract"
+        historical_jarvis_contract_v32="$("$clio_kit" \
+          mcp-contract clio-kit-jarvis-user-v3.2)"
+        python -c 'import json,sys; value=json.load(sys.stdin); assert value["contract_id"] == "clio-kit-jarvis-user-v3.2"' \
+          <<< "$historical_jarvis_contract_v32"
         historical_jarvis_contract_v31="$("$clio_kit" \
           mcp-contract clio-kit-jarvis-user-v3.1)"
         python -c 'import json,sys; value=json.load(sys.stdin); assert value["contract_id"] == "clio-kit-jarvis-user-v3.1"' \

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ federation gates:
 
 ```bash
 clio-kit mcp-contracts
-clio-kit mcp-contract clio-kit-jarvis-user-v3.2
+clio-kit mcp-contract clio-kit-jarvis-user-v3.3
 clio-kit mcp-contract clio-kit-slurm-user-v3
 clio-kit mcp-contract clio-kit-spack-user-v2
 clio-kit mcp-contract clio-kit-scientific-catalog-user-v1

--- a/clio-kit-mcp-servers/adios/server.json
+++ b/clio-kit-mcp-servers/adios/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.6",
+      "version": "2.5.7",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/arxiv/server.json
+++ b/clio-kit-mcp-servers/arxiv/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.6",
+      "version": "2.5.7",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/chronolog/server.json
+++ b/clio-kit-mcp-servers/chronolog/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.6",
+      "version": "2.5.7",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/compression/server.json
+++ b/clio-kit-mcp-servers/compression/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.6",
+      "version": "2.5.7",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/darshan/server.json
+++ b/clio-kit-mcp-servers/darshan/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.6",
+      "version": "2.5.7",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/geo/server.json
+++ b/clio-kit-mcp-servers/geo/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.6",
+      "version": "2.5.7",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/geojson/server.json
+++ b/clio-kit-mcp-servers/geojson/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.6",
+      "version": "2.5.7",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/hdf5/server.json
+++ b/clio-kit-mcp-servers/hdf5/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.6",
+      "version": "2.5.7",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/jarvis/README.md
+++ b/clio-kit-mcp-servers/jarvis/README.md
@@ -53,6 +53,14 @@ jarvis_get_execution
 files. Removal intentionally updates only pipeline membership: it does not invoke
 package cleanup or delete installed or generated package files.
 
+`jarvis_add_step` always runs package-owned configuration and validation on the
+user surface. Use the canonical setting names returned by
+`jarvis_describe(target="package")`; only aliases explicitly listed there are
+also accepted. JSON documents may be passed directly as objects or lists under
+their exact setting name and are canonically serialized before JARVIS validates
+them. The lower-level admin `append_pkg` tool retains its explicit
+`do_configure` compatibility control.
+
 `jarvis_describe` supports:
 
 ```text
@@ -227,7 +235,7 @@ uv --directory clio-kit-mcp-servers/jarvis run pytest -q
 **Tags**: jarvis, pipeline, user
 
 ### `jarvis_add_step`
-**Description**: Add a package-backed step to a JARVIS pipeline and optionally configure that step with package-owned settings.
+**Description**: Add and configure a package-backed step using exact package-owned settings returned by `jarvis_describe`; user-level validation cannot be bypassed.
 **Tags**: jarvis, pipeline, user
 
 ### `jarvis_edit_step`

--- a/clio-kit-mcp-servers/jarvis/server.json
+++ b/clio-kit-mcp-servers/jarvis/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.6",
+      "version": "2.5.7",
       "transport": {
         "type": "stdio"
       },
@@ -39,7 +39,7 @@
     },
     {
       "name": "jarvis_add_step",
-      "description": "Add a package-backed step to a JARVIS pipeline and optionally configure that step with package-owned settings."
+      "description": "Add and configure a package-backed step in a JARVIS pipeline. First use jarvis_describe(target='package') for the selected package; config keys must use its canonical setting names exactly, except for aliases explicitly listed there. User-level step configuration is always validated and cannot be bypassed."
     },
     {
       "name": "jarvis_edit_step",

--- a/clio-kit-mcp-servers/jarvis/src/jarvis_mcp/server.py
+++ b/clio-kit-mcp-servers/jarvis/src/jarvis_mcp/server.py
@@ -1362,8 +1362,11 @@ async def jarvis_describe_tool(
 @mcp.tool(
     name="jarvis_add_step",
     description=(
-        "Add a package-backed step to a JARVIS pipeline and optionally configure "
-        "that step with package-owned settings."
+        "Add and configure a package-backed step in a JARVIS pipeline. First use "
+        "jarvis_describe(target='package') for the selected package; config keys "
+        "must use its canonical setting names exactly, except for aliases explicitly "
+        "listed there. User-level step configuration is always validated and cannot "
+        "be bypassed."
     ),
     annotations={
         "readOnlyHint": False,
@@ -1376,15 +1379,27 @@ async def jarvis_add_step_tool(
     pipeline_id: str,
     package_name: str,
     step_id: Optional[str] = None,
-    config: Optional[dict[str, Any]] = None,
-    do_configure: bool = True,
+    config: Annotated[
+        Optional[dict[str, Any]],
+        Field(
+            description=(
+                "Package-owned configuration. Use canonical setting names exactly as "
+                "returned by jarvis_describe(target='package'); only aliases listed "
+                "there are also accepted, and settings must not be renamed or placed "
+                "under invented nesting. JSON documents may be passed directly as "
+                "objects or lists under their exact setting name; clio-kit serializes "
+                "them canonically before JARVIS package validation. Omit config to use "
+                "the package defaults."
+            )
+        ),
+    ] = None,
 ) -> dict:
-    """Add a step to a pipeline."""
+    """Add and configure one package step without a user-level validation bypass."""
     return await append_pkg(
         pipeline_id,
         package_name,
         pkg_id=step_id,
-        do_configure=do_configure,
+        do_configure=True,
         **(config or {}),
     )
 
@@ -2364,6 +2379,17 @@ def _setting_from_menu_item(item: dict[str, Any]) -> dict[str, Any]:
         setting["type"] = str(kind)
     if "default" in item:
         setting["default"] = item["default"]
+    choices = item.get("choices")
+    if isinstance(choices, (list, tuple)):
+        setting["choices"] = list(choices)
+    required = item.get("required")
+    if isinstance(required, bool):
+        setting["required"] = required
+    aliases = item.get("aliases")
+    if isinstance(aliases, (list, tuple)) and all(
+        isinstance(alias, str) and alias for alias in aliases
+    ):
+        setting["aliases"] = list(aliases)
     return {key: value for key, value in setting.items() if value is not None}
 
 

--- a/clio-kit-mcp-servers/jarvis/tests/test_package_search.py
+++ b/clio-kit-mcp-servers/jarvis/tests/test_package_search.py
@@ -11,6 +11,7 @@ from fastmcp.exceptions import ToolError
 
 from jarvis_mcp.server import (
     PACKAGE_SEARCH_MAX_RESULT_BYTES,
+    _setting_from_menu_item,
     jarvis_describe_tool,
     mcp,
 )
@@ -276,3 +277,46 @@ async def test_jarvis_describe_schema_teaches_exact_then_bounded_discovery() -> 
         "type": "integer",
     }
     assert "only for target='pipeline'" in properties["include_yaml"]["description"]
+
+
+def test_package_setting_preserves_agent_relevant_parser_metadata() -> None:
+    """Package-owned choices, requirements, and aliases survive discovery."""
+
+    assert _setting_from_menu_item(
+        {
+            "name": "mode",
+            "msg": "Execution mode",
+            "type": str,
+            "default": "service",
+            "choices": ("service", "batch"),
+            "required": True,
+            "aliases": ("execution_mode",),
+        }
+    ) == {
+        "name": "mode",
+        "description": "Execution mode",
+        "type": "str",
+        "default": "service",
+        "choices": ["service", "batch"],
+        "required": True,
+        "aliases": ["execution_mode"],
+    }
+
+
+@pytest.mark.asyncio
+async def test_jarvis_add_step_schema_is_exact_and_has_no_user_bypass() -> None:
+    """The compact user mutation teaches exact keys and always configures."""
+
+    tools = await mcp.list_tools()
+    add_step = next(tool for tool in tools if tool.name == "jarvis_add_step")
+    legacy_append = next(tool for tool in tools if tool.name == "append_pkg")
+    properties = add_step.parameters["properties"]
+
+    assert "do_configure" not in properties
+    assert "do_configure" in legacy_append.parameters["properties"]
+    assert isinstance(add_step.description, str)
+    assert "canonical setting names exactly" in add_step.description
+    config_description = properties["config"]["description"]
+    assert "must not be renamed" in config_description
+    assert "objects or lists" in config_description
+    assert "serializes them canonically" in config_description

--- a/clio-kit-mcp-servers/jarvis/tests/test_server_direct.py
+++ b/clio-kit-mcp-servers/jarvis/tests/test_server_direct.py
@@ -547,7 +547,7 @@ class TestPipelineToolsDirect:
 
     @pytest.mark.asyncio
     async def test_jarvis_add_step_tool_direct(self):
-        """Test user-facing step addition maps to package append."""
+        """User-facing step addition always runs package-owned validation."""
         with patch("jarvis_mcp.server.append_pkg") as mock_handler:
             mock_handler.return_value = {"pipeline_id": "test", "appended": "lammps"}
 
@@ -567,6 +567,36 @@ class TestPipelineToolsDirect:
                 pkg_id="lammps_1",
                 do_configure=True,
                 nodes=4,
+            )
+
+    @pytest.mark.asyncio
+    async def test_jarvis_add_step_preserves_structured_json_config(self):
+        """JSON documents stay structured until the generic handler serializes them."""
+        descriptor = {
+            "schema_version": "jarvis.dataset-descriptor.v1",
+            "dataset_id": "scientific-run",
+            "members": [{"index": 0, "location": "/data/frame-0000.vti"}],
+        }
+        with patch("jarvis_mcp.server.append_pkg") as mock_handler:
+            mock_handler.return_value = {
+                "pipeline_id": "test",
+                "appended": "builtin.paraview",
+            }
+
+            from jarvis_mcp.server import jarvis_add_step_tool
+
+            await jarvis_add_step_tool(
+                "test",
+                "builtin.paraview",
+                config={"dataset_descriptor": descriptor},
+            )
+
+            mock_handler.assert_called_once_with(
+                "test",
+                "builtin.paraview",
+                pkg_id=None,
+                do_configure=True,
+                dataset_descriptor=descriptor,
             )
 
     @pytest.mark.asyncio

--- a/clio-kit-mcp-servers/lmod/server.json
+++ b/clio-kit-mcp-servers/lmod/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.6",
+      "version": "2.5.7",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/ndp/server.json
+++ b/clio-kit-mcp-servers/ndp/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.6",
+      "version": "2.5.7",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/node-hardware/server.json
+++ b/clio-kit-mcp-servers/node-hardware/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.6",
+      "version": "2.5.7",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/pandas/server.json
+++ b/clio-kit-mcp-servers/pandas/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.6",
+      "version": "2.5.7",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/parallel-sort/server.json
+++ b/clio-kit-mcp-servers/parallel-sort/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.6",
+      "version": "2.5.7",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/paraview/server.json
+++ b/clio-kit-mcp-servers/paraview/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.6",
+      "version": "2.5.7",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/parquet/server.json
+++ b/clio-kit-mcp-servers/parquet/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.6",
+      "version": "2.5.7",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/plot/server.json
+++ b/clio-kit-mcp-servers/plot/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.6",
+      "version": "2.5.7",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/sac/server.json
+++ b/clio-kit-mcp-servers/sac/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.6",
+      "version": "2.5.7",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/scientific-catalog/server.json
+++ b/clio-kit-mcp-servers/scientific-catalog/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.6",
+      "version": "2.5.7",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/seismic/server.json
+++ b/clio-kit-mcp-servers/seismic/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.6",
+      "version": "2.5.7",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/slurm/server.json
+++ b/clio-kit-mcp-servers/slurm/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.6",
+      "version": "2.5.7",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/spack/server.json
+++ b/clio-kit-mcp-servers/spack/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.6",
+      "version": "2.5.7",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/terrain/server.json
+++ b/clio-kit-mcp-servers/terrain/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.6",
+      "version": "2.5.7",
       "transport": {
         "type": "stdio"
       },

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "clio-kit",
-  "version": "2.5.6",
+  "version": "2.5.7",
   "mcpServers": {
     "clio-adios": {
       "command": "clio-kit",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "clio-kit"
-version = "2.5.6"
+version = "2.5.7"
 description = "CLIO Kit - MCP Servers, Clients, and Tools for AI Agents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/clio_kit/_mcp_contracts/index.json
+++ b/src/clio_kit/_mcp_contracts/index.json
@@ -1,13 +1,13 @@
 {
   "contracts": [
     {
-      "artifact": "jarvis-user-v3.2.json",
-      "artifact_sha256": "621f80e5a78a07488e04e93b7bba69c8e8aafac7ce544f76e642d1265bdf6b3a",
-      "contract_id": "clio-kit-jarvis-user-v3.2",
-      "contract_sha256": "12f6d349c9d44d8ce3594943dcd4018ec9b6e01ebb0e59d468bb1bb783a1ad5d",
+      "artifact": "jarvis-user-v3.3.json",
+      "artifact_sha256": "d5deb5f69af618be6a857544e770ac6f1ad1c335d80f3853e2fbbe09419672f5",
+      "contract_id": "clio-kit-jarvis-user-v3.3",
+      "contract_sha256": "0993ee9b2ee9b3c2b021a3967d9221199c3a6be50d726d4b125812e6b1148115",
       "profile": "user",
       "server_name": "jarvis",
-      "wire_sha256": "bda0abe2b57d5e52ef639bf530e967c3b65072ebc4761d25cd9cbbcf0cd934e9"
+      "wire_sha256": "c74276800cab5031ccd1538343180c40a58e9b8700d0b49e9ca9d4461d37696d"
     },
     {
       "artifact": "slurm-user-v3.json",
@@ -53,6 +53,15 @@
       "profile": "user",
       "server_name": "jarvis",
       "wire_sha256": "b2a6e531399c5a24678adf55e5133c1234718363661bde0636d81d0b1ae5db11"
+    },
+    {
+      "artifact": "jarvis-user-v3.2.json",
+      "artifact_sha256": "621f80e5a78a07488e04e93b7bba69c8e8aafac7ce544f76e642d1265bdf6b3a",
+      "contract_id": "clio-kit-jarvis-user-v3.2",
+      "contract_sha256": "12f6d349c9d44d8ce3594943dcd4018ec9b6e01ebb0e59d468bb1bb783a1ad5d",
+      "profile": "user",
+      "server_name": "jarvis",
+      "wire_sha256": "bda0abe2b57d5e52ef639bf530e967c3b65072ebc4761d25cd9cbbcf0cd934e9"
     }
   ],
   "schema_version": "clio-kit.mcp-user-contract-index.v1"

--- a/src/clio_kit/_mcp_contracts/jarvis-user-v3.3.json
+++ b/src/clio_kit/_mcp_contracts/jarvis-user-v3.3.json
@@ -1,0 +1,2404 @@
+{
+  "canonicalization": "json-sort-keys-compact-utf8-v1",
+  "contract_id": "clio-kit-jarvis-user-v3.3",
+  "contract_sha256": "0993ee9b2ee9b3c2b021a3967d9221199c3a6be50d726d4b125812e6b1148115",
+  "profile": "user",
+  "projection": "mcp-agent-tool-schema-v1",
+  "schema_version": "clio-kit.mcp-user-contract.v1",
+  "server_name": "jarvis",
+  "source": {
+    "method": "tools/list",
+    "protocol_version": "2024-11-05",
+    "transport": "stdio"
+  },
+  "tool_names": [
+    "jarvis_add_step",
+    "jarvis_create_pipeline",
+    "jarvis_describe",
+    "jarvis_edit_step",
+    "jarvis_get_execution",
+    "jarvis_run"
+  ],
+  "tools": [
+    {
+      "_meta": {
+        "fastmcp": {
+          "tags": [
+            "jarvis",
+            "pipeline",
+            "user"
+          ]
+        }
+      },
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "readOnlyHint": false
+      },
+      "description": "Add and configure a package-backed step in a JARVIS pipeline. First use jarvis_describe(target='package') for the selected package; config keys must use its canonical setting names exactly, except for aliases explicitly listed there. User-level step configuration is always validated and cannot be bypassed.",
+      "inputSchema": {
+        "additionalProperties": false,
+        "properties": {
+          "config": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Package-owned configuration. Use canonical setting names exactly as returned by jarvis_describe(target='package'); only aliases listed there are also accepted, and settings must not be renamed or placed under invented nesting. JSON documents may be passed directly as objects or lists under their exact setting name; clio-kit serializes them canonically before JARVIS package validation. Omit config to use the package defaults."
+          },
+          "package_name": {
+            "type": "string"
+          },
+          "pipeline_id": {
+            "type": "string"
+          },
+          "step_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          }
+        },
+        "required": [
+          "pipeline_id",
+          "package_name"
+        ],
+        "type": "object"
+      },
+      "name": "jarvis_add_step",
+      "outputSchema": {
+        "additionalProperties": true,
+        "type": "object"
+      }
+    },
+    {
+      "_meta": {
+        "fastmcp": {
+          "tags": [
+            "jarvis",
+            "pipeline",
+            "user"
+          ]
+        }
+      },
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "readOnlyHint": false
+      },
+      "description": "Create a JARVIS pipeline. Optionally pass execution intent such as local, cluster, or hostfile mode; backend details are resolved where the MCP server runs.",
+      "inputSchema": {
+        "additionalProperties": false,
+        "properties": {
+          "execution": {
+            "anyOf": [
+              {
+                "additionalProperties": false,
+                "description": "Validated, backend-neutral execution request for a JARVIS pipeline.",
+                "properties": {
+                  "account": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "cpus_per_task": {
+                    "anyOf": [
+                      {
+                        "exclusiveMinimum": 0,
+                        "type": "integer"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "error": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "exclusive": {
+                    "anyOf": [
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "gpus": {
+                    "anyOf": [
+                      {
+                        "exclusiveMinimum": 0,
+                        "type": "integer"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "gpus_per_node": {
+                    "anyOf": [
+                      {
+                        "exclusiveMinimum": 0,
+                        "type": "integer"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "hostfile": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "hosts": {
+                    "anyOf": [
+                      {
+                        "items": {
+                          "type": "string"
+                        },
+                        "minItems": 1,
+                        "type": "array"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "job_name": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "mode": {
+                    "default": "auto",
+                    "enum": [
+                      "auto",
+                      "local",
+                      "direct",
+                      "cluster",
+                      "scheduler",
+                      "hostfile"
+                    ],
+                    "type": "string"
+                  },
+                  "nodes": {
+                    "anyOf": [
+                      {
+                        "exclusiveMinimum": 0,
+                        "type": "integer"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "output": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "partition": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "qos": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "tasks": {
+                    "anyOf": [
+                      {
+                        "exclusiveMinimum": 0,
+                        "type": "integer"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "tasks_per_node": {
+                    "anyOf": [
+                      {
+                        "exclusiveMinimum": 0,
+                        "type": "integer"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "walltime": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  }
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "pipeline_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "pipeline_id"
+        ],
+        "type": "object"
+      },
+      "name": "jarvis_create_pipeline",
+      "outputSchema": {
+        "additionalProperties": true,
+        "type": "object"
+      }
+    },
+    {
+      "_meta": {
+        "fastmcp": {
+          "tags": [
+            "jarvis",
+            "pipeline",
+            "user"
+          ]
+        }
+      },
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "readOnlyHint": true
+      },
+      "description": "Describe JARVIS packages, one package, a pipeline, or one pipeline step. For a named application, first use target='package' with its unique short name or fully qualified package name. Use target='package_search' for bounded discovery, then describe the selected canonical name. target='packages' is an exhaustive legacy inventory with every package's settings and can be large; use it only when the complete installed catalog is explicitly required.",
+      "inputSchema": {
+        "additionalProperties": false,
+        "properties": {
+          "cursor": {
+            "anyOf": [
+              {
+                "maxLength": 1024,
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Opaque next-page cursor returned by an earlier package_search with the identical query."
+          },
+          "include_yaml": {
+            "default": true,
+            "description": "Include stored pipeline YAML only for target='pipeline'; ignored for package and package discovery targets.",
+            "type": "boolean"
+          },
+          "package_name": {
+            "anyOf": [
+              {
+                "maxLength": 512,
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Case-insensitive unique short name or fully qualified package name for target='package', for example paraview or builtin.paraview. Ambiguous short names fail with canonical candidates."
+          },
+          "page_size": {
+            "default": 10,
+            "description": "Maximum summary matches returned by target='package_search'; bounded to 25.",
+            "maximum": 25,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "pipeline_id": {
+            "anyOf": [
+              {
+                "maxLength": 256,
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Pipeline identifier for target='pipeline' or target='step'."
+          },
+          "query": {
+            "anyOf": [
+              {
+                "maxLength": 256,
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Natural-language or package-name query required for target='package_search'."
+          },
+          "step_id": {
+            "anyOf": [
+              {
+                "maxLength": 256,
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Pipeline step identifier for target='step'."
+          },
+          "target": {
+            "description": "Object to describe. Prefer package for a named application and package_search for discovery; packages is exhaustive and unbounded.",
+            "enum": [
+              "packages",
+              "package_search",
+              "package",
+              "pipeline",
+              "step"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "target"
+        ],
+        "type": "object"
+      },
+      "name": "jarvis_describe",
+      "outputSchema": {
+        "additionalProperties": true,
+        "type": "object"
+      }
+    },
+    {
+      "_meta": {
+        "fastmcp": {
+          "tags": [
+            "jarvis",
+            "pipeline",
+            "user"
+          ]
+        }
+      },
+      "annotations": {
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "readOnlyHint": false
+      },
+      "description": "Edit or remove a step in a JARVIS pipeline. Use operation='edit' with config, or operation='remove' without config.",
+      "inputSchema": {
+        "additionalProperties": false,
+        "properties": {
+          "config": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "operation": {
+            "default": "edit",
+            "enum": [
+              "edit",
+              "remove"
+            ],
+            "type": "string"
+          },
+          "pipeline_id": {
+            "type": "string"
+          },
+          "step_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "pipeline_id",
+          "step_id"
+        ],
+        "type": "object"
+      },
+      "name": "jarvis_edit_step",
+      "outputSchema": {
+        "additionalProperties": true,
+        "type": "object"
+      }
+    },
+    {
+      "_meta": {
+        "fastmcp": {
+          "tags": [
+            "execution",
+            "jarvis",
+            "pipeline",
+            "user"
+          ]
+        }
+      },
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "readOnlyHint": true
+      },
+      "description": "Query one JARVIS execution handle, durable lifecycle record, and runtime metadata. Progress is included by default and can be omitted. Set include_service_runtimes=true to include execution-owned network services such as an interactive ParaView runtime. Set artifacts to {} or filters to include one bounded artifact page; omit artifacts to avoid querying the artifact manifest.",
+      "inputSchema": {
+        "additionalProperties": false,
+        "properties": {
+          "artifacts": {
+            "anyOf": [
+              {
+                "additionalProperties": false,
+                "description": "Optional filters for one bounded page of execution artifacts.",
+                "properties": {
+                  "artifact_id": {
+                    "anyOf": [
+                      {
+                        "maxLength": 90,
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "Exact opaque JARVIS artifact ID filter."
+                  },
+                  "cursor": {
+                    "anyOf": [
+                      {
+                        "maxLength": 1024,
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "Opaque next-page cursor."
+                  },
+                  "package_id": {
+                    "anyOf": [
+                      {
+                        "maxLength": 256,
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "Exact JARVIS package alias filter."
+                  },
+                  "page_size": {
+                    "default": 50,
+                    "description": "Maximum artifacts to return in this page.",
+                    "maximum": 100,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "role": {
+                    "anyOf": [
+                      {
+                        "enum": [
+                          "intermediate",
+                          "output",
+                          "log",
+                          "checkpoint",
+                          "provenance",
+                          "validation"
+                        ],
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "state": {
+                    "anyOf": [
+                      {
+                        "enum": [
+                          "producing",
+                          "available",
+                          "finalized",
+                          "incomplete",
+                          "failed"
+                        ],
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  }
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "execution_id": {
+            "type": "string"
+          },
+          "include_progress": {
+            "default": true,
+            "type": "boolean"
+          },
+          "include_service_runtimes": {
+            "default": false,
+            "type": "boolean"
+          },
+          "pipeline_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "pipeline_id",
+          "execution_id"
+        ],
+        "type": "object"
+      },
+      "name": "jarvis_get_execution",
+      "outputSchema": {
+        "additionalProperties": false,
+        "description": "Frozen top-level result envelope for a selectable execution query.",
+        "properties": {
+          "artifact_page": {
+            "anyOf": [
+              {
+                "additionalProperties": false,
+                "description": "Bounded artifact page nested in a unified execution query.",
+                "properties": {
+                  "artifacts": {
+                    "items": {
+                      "additionalProperties": false,
+                      "description": "Current JARVIS-owned lifecycle observation for one generated artifact.",
+                      "properties": {
+                        "artifact_id": {
+                          "type": "string"
+                        },
+                        "checksum": {
+                          "type": "string"
+                        },
+                        "execution_id": {
+                          "type": "string"
+                        },
+                        "format": {
+                          "type": "string"
+                        },
+                        "kind": {
+                          "type": "string"
+                        },
+                        "location": {
+                          "additionalProperties": false,
+                          "description": "Transport-neutral location in a JARVIS artifact manifest.",
+                          "properties": {
+                            "kind": {
+                              "enum": [
+                                "execution_path",
+                                "cluster_path",
+                                "external_uri"
+                              ],
+                              "type": "string"
+                            },
+                            "value": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "value"
+                          ],
+                          "type": "object"
+                        },
+                        "logical_name": {
+                          "type": "string"
+                        },
+                        "media_type": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "metadata": {
+                          "additionalProperties": true,
+                          "type": "object"
+                        },
+                        "observed_at_epoch": {
+                          "type": "number"
+                        },
+                        "ownership": {
+                          "enum": [
+                            "execution",
+                            "external",
+                            "shared"
+                          ],
+                          "type": "string"
+                        },
+                        "package_id": {
+                          "type": "string"
+                        },
+                        "package_name": {
+                          "type": "string"
+                        },
+                        "revision": {
+                          "type": "integer"
+                        },
+                        "role": {
+                          "enum": [
+                            "intermediate",
+                            "output",
+                            "log",
+                            "checkpoint",
+                            "provenance",
+                            "validation"
+                          ],
+                          "type": "string"
+                        },
+                        "schema_version": {
+                          "const": "jarvis.artifact.v1",
+                          "type": "string"
+                        },
+                        "sequence": {
+                          "type": "integer"
+                        },
+                        "size_bytes": {
+                          "type": "integer"
+                        },
+                        "state": {
+                          "enum": [
+                            "producing",
+                            "available",
+                            "finalized",
+                            "incomplete",
+                            "failed"
+                          ],
+                          "type": "string"
+                        },
+                        "structure": {
+                          "enum": [
+                            "file",
+                            "directory",
+                            "collection",
+                            "stream"
+                          ],
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "schema_version",
+                        "package_name",
+                        "package_id",
+                        "execution_id",
+                        "artifact_id",
+                        "logical_name",
+                        "kind",
+                        "role",
+                        "structure",
+                        "ownership",
+                        "state",
+                        "revision",
+                        "sequence",
+                        "observed_at_epoch",
+                        "metadata"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "execution_id": {
+                    "type": "string"
+                  },
+                  "execution_state": {
+                    "enum": [
+                      "preparing",
+                      "scripted",
+                      "submitting",
+                      "submitted",
+                      "running",
+                      "completed",
+                      "failed",
+                      "canceled",
+                      "unknown"
+                    ],
+                    "type": "string"
+                  },
+                  "matching_artifact_count": {
+                    "type": "integer"
+                  },
+                  "next_cursor": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "pipeline_id": {
+                    "type": "string"
+                  },
+                  "producer_schema_version": {
+                    "const": "jarvis.execution.artifacts.v1",
+                    "type": "string"
+                  },
+                  "returned_artifact_count": {
+                    "type": "integer"
+                  },
+                  "terminal": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "producer_schema_version",
+                  "pipeline_id",
+                  "execution_id",
+                  "execution_state",
+                  "terminal",
+                  "artifacts",
+                  "matching_artifact_count",
+                  "returned_artifact_count",
+                  "next_cursor"
+                ],
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "execution_handle": {
+            "additionalProperties": false,
+            "description": "Stable JARVIS-CD execution-handle document.",
+            "properties": {
+              "cluster": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "execution_id": {
+                "type": "string"
+              },
+              "mode": {
+                "enum": [
+                  "direct",
+                  "scheduler"
+                ],
+                "type": "string"
+              },
+              "pipeline_id": {
+                "type": "string"
+              },
+              "scheduler_native_id": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "scheduler_provider": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "schema_version": {
+                "const": "jarvis.execution.handle.v1",
+                "type": "string"
+              }
+            },
+            "required": [
+              "schema_version",
+              "execution_id",
+              "pipeline_id",
+              "mode",
+              "scheduler_provider",
+              "scheduler_native_id",
+              "cluster"
+            ],
+            "type": "object"
+          },
+          "execution_id": {
+            "type": "string"
+          },
+          "execution_record": {
+            "additionalProperties": false,
+            "description": "Stable JARVIS-CD durable execution-record document.",
+            "properties": {
+              "cluster": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "created_at": {
+                "type": "string"
+              },
+              "error": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "execution_id": {
+                "type": "string"
+              },
+              "metadata": {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              "mode": {
+                "enum": [
+                  "direct",
+                  "scheduler"
+                ],
+                "type": "string"
+              },
+              "pipeline_id": {
+                "type": "string"
+              },
+              "pipeline_name": {
+                "type": "string"
+              },
+              "return_code": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "scheduler_native_id": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "scheduler_provider": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "schema_version": {
+                "const": "jarvis.execution.record.v1",
+                "type": "string"
+              },
+              "state": {
+                "enum": [
+                  "preparing",
+                  "scripted",
+                  "submitting",
+                  "submitted",
+                  "running",
+                  "completed",
+                  "failed",
+                  "canceled",
+                  "unknown"
+                ],
+                "type": "string"
+              },
+              "submitted": {
+                "type": "boolean"
+              },
+              "terminal": {
+                "type": "boolean"
+              },
+              "updated_at": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "schema_version",
+              "execution_id",
+              "pipeline_id",
+              "pipeline_name",
+              "mode",
+              "scheduler_provider",
+              "scheduler_native_id",
+              "cluster",
+              "state",
+              "submitted",
+              "terminal",
+              "created_at",
+              "updated_at",
+              "return_code",
+              "error",
+              "metadata"
+            ],
+            "type": "object"
+          },
+          "pipeline_id": {
+            "type": "string"
+          },
+          "progress": {
+            "anyOf": [
+              {
+                "additionalProperties": false,
+                "description": "Stable aggregate returned by JARVIS-CD's execution progress API.",
+                "properties": {
+                  "execution_id": {
+                    "maxLength": 256,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "execution_state": {
+                    "enum": [
+                      "preparing",
+                      "scripted",
+                      "submitting",
+                      "submitted",
+                      "running",
+                      "completed",
+                      "failed",
+                      "canceled",
+                      "unknown"
+                    ],
+                    "type": "string"
+                  },
+                  "packages": {
+                    "items": {
+                      "additionalProperties": false,
+                      "description": "Latest stable progress observation for one package alias.",
+                      "properties": {
+                        "event_count": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "latest": {
+                          "anyOf": [
+                            {
+                              "additionalProperties": false,
+                              "description": "One closed, JARVIS-owned package progress observation.",
+                              "properties": {
+                                "current": {
+                                  "anyOf": [
+                                    {
+                                      "minimum": 0,
+                                      "type": "number"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ],
+                                  "default": null
+                                },
+                                "determinate": {
+                                  "type": "boolean"
+                                },
+                                "execution_id": {
+                                  "maxLength": 256,
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "label": {
+                                  "maxLength": 256,
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "message": {
+                                  "anyOf": [
+                                    {
+                                      "maxLength": 4096,
+                                      "minLength": 1,
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ],
+                                  "default": null
+                                },
+                                "metadata": {
+                                  "additionalProperties": true,
+                                  "type": "object"
+                                },
+                                "observed_at_epoch": {
+                                  "minimum": 0,
+                                  "type": "number"
+                                },
+                                "package_id": {
+                                  "maxLength": 256,
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "package_name": {
+                                  "maxLength": 256,
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "schema_version": {
+                                  "const": "jarvis.progress.v1",
+                                  "type": "string"
+                                },
+                                "sequence": {
+                                  "minimum": 0,
+                                  "type": "integer"
+                                },
+                                "state": {
+                                  "enum": [
+                                    "pending",
+                                    "starting",
+                                    "running",
+                                    "ready",
+                                    "completed",
+                                    "failed",
+                                    "canceled"
+                                  ],
+                                  "type": "string"
+                                },
+                                "total": {
+                                  "anyOf": [
+                                    {
+                                      "exclusiveMinimum": 0,
+                                      "type": "number"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ],
+                                  "default": null
+                                },
+                                "unit": {
+                                  "anyOf": [
+                                    {
+                                      "maxLength": 256,
+                                      "minLength": 1,
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ],
+                                  "default": null
+                                }
+                              },
+                              "required": [
+                                "schema_version",
+                                "package_name",
+                                "package_id",
+                                "execution_id",
+                                "label",
+                                "state",
+                                "sequence",
+                                "observed_at_epoch",
+                                "determinate",
+                                "metadata"
+                              ],
+                              "type": "object"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "package_id": {
+                          "maxLength": 256,
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "package_name": {
+                          "maxLength": 256,
+                          "minLength": 1,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "package_id",
+                        "package_name",
+                        "event_count",
+                        "latest"
+                      ],
+                      "type": "object"
+                    },
+                    "maxItems": 4096,
+                    "type": "array"
+                  },
+                  "pipeline_id": {
+                    "maxLength": 256,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "schema_version": {
+                    "const": "jarvis.execution.progress.v1",
+                    "type": "string"
+                  },
+                  "terminal": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "schema_version",
+                  "execution_id",
+                  "pipeline_id",
+                  "execution_state",
+                  "terminal",
+                  "packages"
+                ],
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "runtime_metadata": {
+            "additionalProperties": true,
+            "type": "object"
+          },
+          "schema_version": {
+            "const": "clio-kit.jarvis-execution.v2",
+            "type": "string"
+          },
+          "service_runtimes": {
+            "anyOf": [
+              {
+                "additionalProperties": false,
+                "description": "Execution-bound current service runtimes returned by JARVIS.",
+                "properties": {
+                  "execution_id": {
+                    "maxLength": 256,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "execution_state": {
+                    "enum": [
+                      "preparing",
+                      "scripted",
+                      "submitting",
+                      "submitted",
+                      "running",
+                      "completed",
+                      "failed",
+                      "canceled",
+                      "unknown"
+                    ],
+                    "type": "string"
+                  },
+                  "pipeline_id": {
+                    "maxLength": 256,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "schema_version": {
+                    "const": "jarvis.execution.service-runtimes.v1",
+                    "type": "string"
+                  },
+                  "service_runtimes": {
+                    "items": {
+                      "additionalProperties": false,
+                      "description": "Latest durable observation of one execution-owned service.",
+                      "properties": {
+                        "command_path": {
+                          "maxLength": 256,
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "dataset_descriptor": {
+                          "additionalProperties": false,
+                          "description": "Intrinsic, recipe-free dataset identity owned by JARVIS.",
+                          "properties": {
+                            "arrays": {
+                              "items": {
+                                "additionalProperties": false,
+                                "description": "One intrinsic array exposed by a JARVIS-owned service.",
+                                "properties": {
+                                  "association": {
+                                    "enum": [
+                                      "point",
+                                      "cell",
+                                      "field"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "components": {
+                                    "maximum": 64,
+                                    "minimum": 1,
+                                    "type": "integer"
+                                  },
+                                  "name": {
+                                    "maxLength": 512,
+                                    "minLength": 1,
+                                    "type": "string"
+                                  },
+                                  "units": {
+                                    "anyOf": [
+                                      {
+                                        "maxLength": 256,
+                                        "minLength": 1,
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "null"
+                                      }
+                                    ],
+                                    "default": null
+                                  }
+                                },
+                                "required": [
+                                  "name",
+                                  "association",
+                                  "components"
+                                ],
+                                "type": "object"
+                              },
+                              "maxItems": 256,
+                              "type": "array"
+                            },
+                            "bounds": {
+                              "anyOf": [
+                                {
+                                  "items": {
+                                    "type": "number"
+                                  },
+                                  "maxItems": 6,
+                                  "minItems": 6,
+                                  "type": "array"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ],
+                              "default": null
+                            },
+                            "dataset_id": {
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "fingerprint": {
+                              "additionalProperties": false,
+                              "description": "Canonical identity digest for one bounded dataset descriptor.",
+                              "properties": {
+                                "algorithm": {
+                                  "const": "sha256",
+                                  "type": "string"
+                                },
+                                "digest": {
+                                  "pattern": "^[0-9a-f]{64}$",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "algorithm",
+                                "digest"
+                              ],
+                              "type": "object"
+                            },
+                            "format": {
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "kind": {
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "members": {
+                              "items": {
+                                "additionalProperties": false,
+                                "description": "One ordered member in a JARVIS service dataset descriptor.",
+                                "properties": {
+                                  "index": {
+                                    "minimum": 0,
+                                    "type": "integer"
+                                  },
+                                  "location": {
+                                    "maxLength": 4096,
+                                    "minLength": 1,
+                                    "type": "string"
+                                  },
+                                  "timestep": {
+                                    "anyOf": [
+                                      {
+                                        "type": "number"
+                                      },
+                                      {
+                                        "type": "null"
+                                      }
+                                    ],
+                                    "default": null
+                                  }
+                                },
+                                "required": [
+                                  "index",
+                                  "location"
+                                ],
+                                "type": "object"
+                              },
+                              "maxItems": 512,
+                              "minItems": 1,
+                              "type": "array"
+                            },
+                            "schema_version": {
+                              "const": "jarvis.dataset-descriptor.v1",
+                              "type": "string"
+                            },
+                            "source_artifact": {
+                              "anyOf": [
+                                {
+                                  "additionalProperties": false,
+                                  "description": "Optional content identity of a JARVIS-generated source artifact.",
+                                  "properties": {
+                                    "artifact_id": {
+                                      "pattern": "^art_[A-Za-z0-9_-]{22,86}$",
+                                      "type": "string"
+                                    },
+                                    "sha256": {
+                                      "pattern": "^[0-9a-f]{64}$",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "artifact_id",
+                                    "sha256"
+                                  ],
+                                  "type": "object"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            }
+                          },
+                          "required": [
+                            "schema_version",
+                            "dataset_id",
+                            "kind",
+                            "format",
+                            "members",
+                            "arrays",
+                            "fingerprint",
+                            "source_artifact"
+                          ],
+                          "type": "object"
+                        },
+                        "delivery_mode": {
+                          "const": "push",
+                          "type": "string"
+                        },
+                        "events_path": {
+                          "maxLength": 256,
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "execution_id": {
+                          "maxLength": 256,
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "health_path": {
+                          "maxLength": 256,
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "host": {
+                          "maxLength": 255,
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "lifecycle": {
+                          "enum": [
+                            "starting",
+                            "ready",
+                            "degraded",
+                            "stopping",
+                            "stopped",
+                            "failed"
+                          ],
+                          "type": "string"
+                        },
+                        "live_data_path": {
+                          "maxLength": 256,
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "message": {
+                          "anyOf": [
+                            {
+                              "maxLength": 4096,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "observed_at_epoch": {
+                          "minimum": 0,
+                          "type": "number"
+                        },
+                        "package_id": {
+                          "maxLength": 256,
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "package_name": {
+                          "maxLength": 256,
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "port": {
+                          "maximum": 65535,
+                          "minimum": 1,
+                          "type": "integer"
+                        },
+                        "protocol": {
+                          "enum": [
+                            "http",
+                            "https"
+                          ],
+                          "type": "string"
+                        },
+                        "revision": {
+                          "minimum": 1,
+                          "type": "integer"
+                        },
+                        "schema_version": {
+                          "const": "jarvis.service-runtime.v1",
+                          "type": "string"
+                        },
+                        "service_instance_id": {
+                          "maxLength": 256,
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "state_path": {
+                          "maxLength": 256,
+                          "minLength": 1,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "schema_version",
+                        "execution_id",
+                        "package_name",
+                        "package_id",
+                        "service_instance_id",
+                        "revision",
+                        "lifecycle",
+                        "host",
+                        "port",
+                        "protocol",
+                        "health_path",
+                        "live_data_path",
+                        "events_path",
+                        "state_path",
+                        "command_path",
+                        "delivery_mode",
+                        "dataset_descriptor",
+                        "observed_at_epoch"
+                      ],
+                      "type": "object"
+                    },
+                    "maxItems": 4096,
+                    "type": "array"
+                  },
+                  "terminal": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "schema_version",
+                  "execution_id",
+                  "pipeline_id",
+                  "execution_state",
+                  "terminal",
+                  "service_runtimes"
+                ],
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "schema_version",
+          "pipeline_id",
+          "execution_id",
+          "execution_handle",
+          "execution_record",
+          "runtime_metadata",
+          "progress",
+          "artifact_page",
+          "service_runtimes"
+        ],
+        "type": "object"
+      }
+    },
+    {
+      "_meta": {
+        "fastmcp": {
+          "tags": [
+            "jarvis",
+            "pipeline",
+            "user"
+          ]
+        }
+      },
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "readOnlyHint": false
+      },
+      "description": "Run a configured JARVIS pipeline. Optional execution intent selects local, cluster, or hostfile mode without exposing scheduler internals. Optional spack_specs are resolved into a filtered environment that JARVIS persists before direct or scheduler execution.",
+      "inputSchema": {
+        "additionalProperties": false,
+        "properties": {
+          "execution": {
+            "anyOf": [
+              {
+                "additionalProperties": false,
+                "description": "Validated, backend-neutral execution request for a JARVIS pipeline.",
+                "properties": {
+                  "account": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "cpus_per_task": {
+                    "anyOf": [
+                      {
+                        "exclusiveMinimum": 0,
+                        "type": "integer"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "error": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "exclusive": {
+                    "anyOf": [
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "gpus": {
+                    "anyOf": [
+                      {
+                        "exclusiveMinimum": 0,
+                        "type": "integer"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "gpus_per_node": {
+                    "anyOf": [
+                      {
+                        "exclusiveMinimum": 0,
+                        "type": "integer"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "hostfile": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "hosts": {
+                    "anyOf": [
+                      {
+                        "items": {
+                          "type": "string"
+                        },
+                        "minItems": 1,
+                        "type": "array"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "job_name": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "mode": {
+                    "default": "auto",
+                    "enum": [
+                      "auto",
+                      "local",
+                      "direct",
+                      "cluster",
+                      "scheduler",
+                      "hostfile"
+                    ],
+                    "type": "string"
+                  },
+                  "nodes": {
+                    "anyOf": [
+                      {
+                        "exclusiveMinimum": 0,
+                        "type": "integer"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "output": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "partition": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "qos": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "tasks": {
+                    "anyOf": [
+                      {
+                        "exclusiveMinimum": 0,
+                        "type": "integer"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "tasks_per_node": {
+                    "anyOf": [
+                      {
+                        "exclusiveMinimum": 0,
+                        "type": "integer"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "walltime": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  }
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "execution_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "pipeline_id": {
+            "type": "string"
+          },
+          "spack_specs": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "submit": {
+            "default": true,
+            "type": "boolean"
+          },
+          "wait": {
+            "default": false,
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "pipeline_id"
+        ],
+        "type": "object"
+      },
+      "name": "jarvis_run",
+      "outputSchema": {
+        "description": "Frozen top-level result envelope for ``jarvis_run``.",
+        "properties": {
+          "execution_handle": {
+            "description": "Stable JARVIS-CD execution-handle document.",
+            "properties": {
+              "cluster": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "execution_id": {
+                "type": "string"
+              },
+              "mode": {
+                "enum": [
+                  "direct",
+                  "scheduler"
+                ],
+                "type": "string"
+              },
+              "pipeline_id": {
+                "type": "string"
+              },
+              "scheduler_native_id": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "scheduler_provider": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "schema_version": {
+                "const": "jarvis.execution.handle.v1",
+                "type": "string"
+              }
+            },
+            "required": [
+              "schema_version",
+              "execution_id",
+              "pipeline_id",
+              "mode",
+              "scheduler_provider",
+              "scheduler_native_id",
+              "cluster"
+            ],
+            "type": "object"
+          },
+          "execution_id": {
+            "type": "string"
+          },
+          "execution_record": {
+            "description": "Stable JARVIS-CD durable execution-record document.",
+            "properties": {
+              "cluster": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "created_at": {
+                "type": "string"
+              },
+              "error": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "execution_id": {
+                "type": "string"
+              },
+              "metadata": {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              "mode": {
+                "enum": [
+                  "direct",
+                  "scheduler"
+                ],
+                "type": "string"
+              },
+              "pipeline_id": {
+                "type": "string"
+              },
+              "pipeline_name": {
+                "type": "string"
+              },
+              "return_code": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "scheduler_native_id": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "scheduler_provider": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "schema_version": {
+                "const": "jarvis.execution.record.v1",
+                "type": "string"
+              },
+              "state": {
+                "enum": [
+                  "preparing",
+                  "scripted",
+                  "submitting",
+                  "submitted",
+                  "running",
+                  "completed",
+                  "failed",
+                  "canceled",
+                  "unknown"
+                ],
+                "type": "string"
+              },
+              "submitted": {
+                "type": "boolean"
+              },
+              "terminal": {
+                "type": "boolean"
+              },
+              "updated_at": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "schema_version",
+              "execution_id",
+              "pipeline_id",
+              "pipeline_name",
+              "mode",
+              "scheduler_provider",
+              "scheduler_native_id",
+              "cluster",
+              "state",
+              "submitted",
+              "terminal",
+              "created_at",
+              "updated_at",
+              "return_code",
+              "error",
+              "metadata"
+            ],
+            "type": "object"
+          },
+          "mode": {
+            "enum": [
+              "direct",
+              "scheduler"
+            ],
+            "type": "string"
+          },
+          "pipeline_id": {
+            "type": "string"
+          },
+          "progress": {
+            "additionalProperties": false,
+            "description": "Stable aggregate returned by JARVIS-CD's execution progress API.",
+            "properties": {
+              "execution_id": {
+                "maxLength": 256,
+                "minLength": 1,
+                "type": "string"
+              },
+              "execution_state": {
+                "enum": [
+                  "preparing",
+                  "scripted",
+                  "submitting",
+                  "submitted",
+                  "running",
+                  "completed",
+                  "failed",
+                  "canceled",
+                  "unknown"
+                ],
+                "type": "string"
+              },
+              "packages": {
+                "items": {
+                  "additionalProperties": false,
+                  "description": "Latest stable progress observation for one package alias.",
+                  "properties": {
+                    "event_count": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "latest": {
+                      "anyOf": [
+                        {
+                          "additionalProperties": false,
+                          "description": "One closed, JARVIS-owned package progress observation.",
+                          "properties": {
+                            "current": {
+                              "anyOf": [
+                                {
+                                  "minimum": 0,
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ],
+                              "default": null
+                            },
+                            "determinate": {
+                              "type": "boolean"
+                            },
+                            "execution_id": {
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "label": {
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "message": {
+                              "anyOf": [
+                                {
+                                  "maxLength": 4096,
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ],
+                              "default": null
+                            },
+                            "metadata": {
+                              "additionalProperties": true,
+                              "type": "object"
+                            },
+                            "observed_at_epoch": {
+                              "minimum": 0,
+                              "type": "number"
+                            },
+                            "package_id": {
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "package_name": {
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "schema_version": {
+                              "const": "jarvis.progress.v1",
+                              "type": "string"
+                            },
+                            "sequence": {
+                              "minimum": 0,
+                              "type": "integer"
+                            },
+                            "state": {
+                              "enum": [
+                                "pending",
+                                "starting",
+                                "running",
+                                "ready",
+                                "completed",
+                                "failed",
+                                "canceled"
+                              ],
+                              "type": "string"
+                            },
+                            "total": {
+                              "anyOf": [
+                                {
+                                  "exclusiveMinimum": 0,
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ],
+                              "default": null
+                            },
+                            "unit": {
+                              "anyOf": [
+                                {
+                                  "maxLength": 256,
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ],
+                              "default": null
+                            }
+                          },
+                          "required": [
+                            "schema_version",
+                            "package_name",
+                            "package_id",
+                            "execution_id",
+                            "label",
+                            "state",
+                            "sequence",
+                            "observed_at_epoch",
+                            "determinate",
+                            "metadata"
+                          ],
+                          "type": "object"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "package_id": {
+                      "maxLength": 256,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "package_name": {
+                      "maxLength": 256,
+                      "minLength": 1,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "package_id",
+                    "package_name",
+                    "event_count",
+                    "latest"
+                  ],
+                  "type": "object"
+                },
+                "maxItems": 4096,
+                "type": "array"
+              },
+              "pipeline_id": {
+                "maxLength": 256,
+                "minLength": 1,
+                "type": "string"
+              },
+              "schema_version": {
+                "const": "jarvis.execution.progress.v1",
+                "type": "string"
+              },
+              "terminal": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "schema_version",
+              "execution_id",
+              "pipeline_id",
+              "execution_state",
+              "terminal",
+              "packages"
+            ],
+            "type": "object"
+          },
+          "runtime_metadata": {
+            "additionalProperties": true,
+            "type": "object"
+          },
+          "scheduler": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "schema_version": {
+            "const": "clio-kit.jarvis-run.v1",
+            "type": "string"
+          },
+          "script_path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "status": {
+            "enum": [
+              "preparing",
+              "scripted",
+              "submitting",
+              "submitted",
+              "running",
+              "completed",
+              "failed",
+              "canceled",
+              "unknown"
+            ],
+            "type": "string"
+          },
+          "wait": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "schema_version",
+          "pipeline_id",
+          "execution_id",
+          "status",
+          "mode",
+          "scheduler",
+          "script_path",
+          "wait",
+          "execution_handle",
+          "execution_record",
+          "progress",
+          "runtime_metadata"
+        ],
+        "type": "object"
+      }
+    }
+  ],
+  "wire_sha256": "c74276800cab5031ccd1538343180c40a58e9b8700d0b49e9ca9d4461d37696d"
+}

--- a/src/clio_kit/mcp_contracts.py
+++ b/src/clio_kit/mcp_contracts.py
@@ -112,8 +112,8 @@ class UserContractSpec:
 
 USER_CONTRACT_SPECS: Final = (
     UserContractSpec(
-        contract_id="clio-kit-jarvis-user-v3.2",
-        artifact_name="jarvis-user-v3.2.json",
+        contract_id="clio-kit-jarvis-user-v3.3",
+        artifact_name="jarvis-user-v3.3.json",
         server_name="jarvis",
         distribution_name="jarvis-mcp",
         entry_command="jarvis-mcp",
@@ -173,6 +173,7 @@ USER_CONTRACT_SPECS: Final = (
 HISTORICAL_USER_CONTRACT_ARTIFACTS: Final = (
     "jarvis-user-v3.json",
     "jarvis-user-v3.1.json",
+    "jarvis-user-v3.2.json",
 )
 
 

--- a/tests/test_mcp_user_contracts.py
+++ b/tests/test_mcp_user_contracts.py
@@ -74,7 +74,7 @@ def test_contract_probe_uses_a_fresh_isolated_child_environment(
     ("contract_id", "expected_names"),
     [
         (
-            "clio-kit-jarvis-user-v3.2",
+            "clio-kit-jarvis-user-v3.3",
             {
                 "jarvis_create_pipeline",
                 "jarvis_describe",
@@ -122,12 +122,17 @@ def test_shipped_contract_digest_covers_exact_user_surface(
     )
 
 
-def test_previous_jarvis_contract_remains_loadable_by_exact_identity() -> None:
-    """An additive JARVIS contract revision does not erase released evidence."""
-    previous = load_mcp_user_contract("clio-kit-jarvis-user-v3.1")
+def test_previous_jarvis_contracts_remain_loadable_by_exact_identity() -> None:
+    """JARVIS contract revisions do not erase released evidence."""
+    previous = load_mcp_user_contract("clio-kit-jarvis-user-v3.2")
 
-    assert previous["contract_id"] == "clio-kit-jarvis-user-v3.1"
+    assert previous["contract_id"] == "clio-kit-jarvis-user-v3.2"
     assert previous["contract_sha256"] == (
+        "12f6d349c9d44d8ce3594943dcd4018ec9b6e01ebb0e59d468bb1bb783a1ad5d"
+    )
+    older = load_mcp_user_contract("clio-kit-jarvis-user-v3.1")
+    assert older["contract_id"] == "clio-kit-jarvis-user-v3.1"
+    assert older["contract_sha256"] == (
         "adc7756025fbcc90b0695bd4eaac00bda5c6cff4eb2f248fd7be263bd90b9b8b"
     )
     oldest = load_mcp_user_contract("clio-kit-jarvis-user-v3")
@@ -198,7 +203,7 @@ def test_spack_install_contract_exposes_explicit_concretization_modes() -> None:
 
 def test_jarvis_contract_combines_mutations_and_execution_observation() -> None:
     """JARVIS gives agents one mutation and one durable observation semantic."""
-    artifact = load_mcp_user_contract("clio-kit-jarvis-user-v3.2")
+    artifact = load_mcp_user_contract("clio-kit-jarvis-user-v3.3")
     tools = {
         cast(str, tool["name"]): cast(JSON, tool)
         for tool in cast(list[JSON], artifact["tools"])
@@ -236,6 +241,14 @@ def test_jarvis_contract_combines_mutations_and_execution_observation() -> None:
     assert describe_properties["query"]["description"].endswith(
         "target='package_search'."
     )
+    add_step = cast(JSON, tools["jarvis_add_step"])
+    add_input = cast(JSON, add_step["inputSchema"])
+    add_properties = cast(JSON, add_input["properties"])
+    assert "do_configure" not in add_properties
+    assert "cannot be bypassed" in cast(str, add_step["description"])
+    config_description = cast(str, cast(JSON, add_properties["config"])["description"])
+    assert "canonical setting names exactly" in config_description
+    assert "objects or lists" in config_description
     run_input = cast(JSON, tools["jarvis_run"]["inputSchema"])
     run_properties = cast(JSON, run_input["properties"])
     execution_id = cast(JSON, run_properties["execution_id"])
@@ -515,6 +528,7 @@ def test_contract_cli_lists_and_prints_verified_artifacts() -> None:
     shown = runner.invoke(main, ["mcp-contract", "clio-kit-spack-user-v2"])
 
     assert listed.exit_code == 0, listed.output
+    assert "clio-kit-jarvis-user-v3.3" in listed.output
     assert "clio-kit-jarvis-user-v3.2" in listed.output
     assert "clio-kit-slurm-user-v3" in listed.output
     assert "clio-kit-spack-user-v2" in listed.output

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -365,7 +365,7 @@ def test_wheel_smoke_binds_jarvis_artifacts_to_exact_release_wheel() -> None:
     start = WORKFLOW.index("    - name: Smoke installed root wheel")
     end = WORKFLOW.index("    - name: Attest release distributions", start)
     smoke_block = WORKFLOW[start:end]
-    assert "mcp-contract clio-kit-jarvis-user-v3.2" in smoke_block
+    assert "mcp-contract clio-kit-jarvis-user-v3.3" in smoke_block
     assert '"jarvis_get_execution"' in smoke_block
     assert '"jarvis_get_execution_progress"' not in smoke_block
     assert '"jarvis_get_execution_artifacts"' not in smoke_block
@@ -420,13 +420,14 @@ def test_release_regenerates_and_smokes_shipped_user_contracts() -> None:
     )
     smoke_block = WORKFLOW[smoke_start:smoke_end]
     assert '"$clio_kit" mcp-contracts' in smoke_block
+    assert "mcp-contract clio-kit-jarvis-user-v3.3" in smoke_block
     assert "mcp-contract clio-kit-jarvis-user-v3.2" in smoke_block
     assert "mcp-contract clio-kit-jarvis-user-v3.1" in smoke_block
     assert "mcp-contract clio-kit-jarvis-user-v3" in smoke_block
     assert "mcp-contract clio-kit-scientific-catalog-user-v1" in smoke_block
     assert "mcp-contract clio-kit-slurm-user-v3" in smoke_block
     assert "mcp-contract clio-kit-spack-user-v2" in smoke_block
-    assert "clio-kit-jarvis-user-v3.2" in smoke_block
+    assert "clio-kit-jarvis-user-v3.3" in smoke_block
 
 
 def test_quality_matrix_is_required_and_lock_sensitive() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -61,7 +61,7 @@ wheels = [
 
 [[package]]
 name = "clio-kit"
-version = "2.5.6"
+version = "2.5.7"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Publishes clio-kit 2.5.7 with JARVIS user contract v3.3. The user-facing jarvis_add_step always runs package-owned validation, teaches exact settings discovered through jarvis_describe, and preserves structured JSON descriptors. Historical v3.2 remains loadable unchanged. Focused JARVIS and contract/release tests pass; Ruff, Pyright, lock validation, and local wheel/sdist build pass.