### PR TITLE
chore(release): prepare clio-kit 2.5.8

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "CLIO Kit - MCP Servers for Scientific Computing and HPC",
-    "version": "2.5.7",
+    "version": "2.5.8",
     "pluginRoot": "./clio-kit-mcp-servers"
   },
   "plugins": [

--- a/clio-kit-mcp-servers/adios/server.json
+++ b/clio-kit-mcp-servers/adios/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.7",
+      "version": "2.5.8",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/arxiv/server.json
+++ b/clio-kit-mcp-servers/arxiv/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.7",
+      "version": "2.5.8",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/chronolog/server.json
+++ b/clio-kit-mcp-servers/chronolog/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.7",
+      "version": "2.5.8",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/compression/server.json
+++ b/clio-kit-mcp-servers/compression/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.7",
+      "version": "2.5.8",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/darshan/server.json
+++ b/clio-kit-mcp-servers/darshan/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.7",
+      "version": "2.5.8",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/geo/server.json
+++ b/clio-kit-mcp-servers/geo/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.7",
+      "version": "2.5.8",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/geojson/server.json
+++ b/clio-kit-mcp-servers/geojson/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.7",
+      "version": "2.5.8",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/hdf5/server.json
+++ b/clio-kit-mcp-servers/hdf5/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.7",
+      "version": "2.5.8",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/jarvis/server.json
+++ b/clio-kit-mcp-servers/jarvis/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.7",
+      "version": "2.5.8",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/lmod/server.json
+++ b/clio-kit-mcp-servers/lmod/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.7",
+      "version": "2.5.8",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/ndp/server.json
+++ b/clio-kit-mcp-servers/ndp/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.7",
+      "version": "2.5.8",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/node-hardware/server.json
+++ b/clio-kit-mcp-servers/node-hardware/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.7",
+      "version": "2.5.8",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/pandas/server.json
+++ b/clio-kit-mcp-servers/pandas/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.7",
+      "version": "2.5.8",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/parallel-sort/server.json
+++ b/clio-kit-mcp-servers/parallel-sort/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.7",
+      "version": "2.5.8",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/paraview/server.json
+++ b/clio-kit-mcp-servers/paraview/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.7",
+      "version": "2.5.8",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/parquet/server.json
+++ b/clio-kit-mcp-servers/parquet/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.7",
+      "version": "2.5.8",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/plot/server.json
+++ b/clio-kit-mcp-servers/plot/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.7",
+      "version": "2.5.8",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/sac/server.json
+++ b/clio-kit-mcp-servers/sac/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.7",
+      "version": "2.5.8",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/scientific-catalog/server.json
+++ b/clio-kit-mcp-servers/scientific-catalog/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.7",
+      "version": "2.5.8",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/seismic/server.json
+++ b/clio-kit-mcp-servers/seismic/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.7",
+      "version": "2.5.8",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/slurm/server.json
+++ b/clio-kit-mcp-servers/slurm/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.7",
+      "version": "2.5.8",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/spack/server.json
+++ b/clio-kit-mcp-servers/spack/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.7",
+      "version": "2.5.8",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/terrain/server.json
+++ b/clio-kit-mcp-servers/terrain/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.7",
+      "version": "2.5.8",
       "transport": {
         "type": "stdio"
       },

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "clio-kit",
-  "version": "2.5.7",
+  "version": "2.5.8",
   "mcpServers": {
     "clio-adios": {
       "command": "clio-kit",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "clio-kit"
-version = "2.5.7"
+version = "2.5.8"
 description = "CLIO Kit - MCP Servers, Clients, and Tools for AI Agents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -61,7 +61,7 @@ wheels = [
 
 [[package]]
 name = "clio-kit"
-version = "2.5.7"
+version = "2.5.8"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Prepares the corrected immutable release after the unpublished v2.5.7 tag failed its exact-main guard. The JARVIS 3.3.0 contract and registry identity are unchanged; only the root wheel/package coordinates advance to 2.5.8. Focused manifest coherence tests, lock validation, and local wheel/sdist build pass.