### PR TITLE
fix(catalog): expose composable dataset descriptor

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "CLIO Kit - MCP Servers for Scientific Computing and HPC",
-    "version": "2.5.10",
+    "version": "2.5.11",
     "pluginRoot": "./clio-kit-mcp-servers"
   },
   "plugins": [
@@ -268,7 +268,7 @@
       "name": "clio-scientific-catalog",
       "source": "./clio-kit-mcp-servers/scientific-catalog",
       "description": "Operator-owned scientific dataset discovery for remote agents",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "category": "development",
       "keywords": [],
       "license": "BSD-3-Clause",

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -256,6 +256,7 @@ jobs:
         grep -Fq 'clio-kit-jarvis-user-v3.2' <<< "$listed_contracts"
         grep -Fq 'clio-kit-jarvis-user-v3.1' <<< "$listed_contracts"
         grep -Fq 'clio-kit-jarvis-user-v3' <<< "$listed_contracts"
+        grep -Fq 'clio-kit-scientific-catalog-user-v1.1' <<< "$listed_contracts"
         grep -Fq 'clio-kit-scientific-catalog-user-v1' <<< "$listed_contracts"
         grep -Fq 'clio-kit-slurm-user-v3' <<< "$listed_contracts"
         grep -Fq 'clio-kit-spack-user-v2.1' <<< "$listed_contracts"
@@ -277,9 +278,13 @@ jobs:
         python -c 'import json,sys; value=json.load(sys.stdin); assert value["contract_id"] == "clio-kit-jarvis-user-v3"' \
           <<< "$historical_jarvis_contract_v3"
         catalog_contract="$("$clio_kit" \
-          mcp-contract clio-kit-scientific-catalog-user-v1)"
-        python -c 'import json,sys; value=json.load(sys.stdin); assert value["contract_id"] == "clio-kit-scientific-catalog-user-v1"; assert {tool["name"] for tool in value["tools"]} == {"scientific_dataset_search", "scientific_dataset_describe"}' \
+          mcp-contract clio-kit-scientific-catalog-user-v1.1)"
+        python -c 'import json,sys; value=json.load(sys.stdin); assert value["contract_id"] == "clio-kit-scientific-catalog-user-v1.1"; assert {tool["name"] for tool in value["tools"]} == {"scientific_dataset_search", "scientific_dataset_describe"}' \
           <<< "$catalog_contract"
+        historical_catalog_contract_v1="$("$clio_kit" \
+          mcp-contract clio-kit-scientific-catalog-user-v1)"
+        python -c 'import json,sys; value=json.load(sys.stdin); assert value["contract_id"] == "clio-kit-scientific-catalog-user-v1"' \
+          <<< "$historical_catalog_contract_v1"
         slurm_contract="$("$clio_kit" \
           mcp-contract clio-kit-slurm-user-v3)"
         python -c 'import json,sys; value=json.load(sys.stdin); assert value["contract_id"] == "clio-kit-slurm-user-v3"' \

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ clio-kit mcp-contracts
 clio-kit mcp-contract clio-kit-jarvis-user-v3.3
 clio-kit mcp-contract clio-kit-slurm-user-v3
 clio-kit mcp-contract clio-kit-spack-user-v2.1
-clio-kit mcp-contract clio-kit-scientific-catalog-user-v1
+clio-kit mcp-contract clio-kit-scientific-catalog-user-v1.1
 ```
 
 <details>
@@ -260,7 +260,7 @@ distinct `not_installed` semantic, while real Spack failures remain errors.
 | **`plot`** | 2.2.3 | Visualization | Generate plots from CSV data | `clio-kit mcp-server plot` |
 | **`sac`** | 2.2.3 | Seismology | Analyze SAC waveforms and archives | `clio-kit mcp-server sac` |
 | **`seismic`** | 2.2.3 | Seismology | Analyze earthquake catalogs and sequences | `clio-kit mcp-server seismic` |
-| **`scientific-catalog`** | 1.0.0 | Discovery | Operator-owned scientific dataset discovery | `clio-kit mcp-server scientific-catalog` |
+| **`scientific-catalog`** | 1.1.0 | Discovery | Operator-owned scientific dataset discovery | `clio-kit mcp-server scientific-catalog` |
 | **`slurm`** | 3.0.0 | HPC | Job submission and management | `clio-kit mcp-server slurm` |
 | **`spack`** | 2.1.0 | Package Management | Structured package discovery, installation, and location | `clio-kit mcp-server spack` |
 | **`terrain`** | 2.2.3 | Geospatial | Analyze DEMs and terrain point clouds | `clio-kit mcp-server terrain` |

--- a/clio-kit-mcp-servers/adios/server.json
+++ b/clio-kit-mcp-servers/adios/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.10",
+      "version": "2.5.11",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/arxiv/server.json
+++ b/clio-kit-mcp-servers/arxiv/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.10",
+      "version": "2.5.11",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/chronolog/server.json
+++ b/clio-kit-mcp-servers/chronolog/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.10",
+      "version": "2.5.11",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/compression/server.json
+++ b/clio-kit-mcp-servers/compression/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.10",
+      "version": "2.5.11",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/darshan/server.json
+++ b/clio-kit-mcp-servers/darshan/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.10",
+      "version": "2.5.11",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/geo/server.json
+++ b/clio-kit-mcp-servers/geo/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.10",
+      "version": "2.5.11",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/geojson/server.json
+++ b/clio-kit-mcp-servers/geojson/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.10",
+      "version": "2.5.11",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/hdf5/server.json
+++ b/clio-kit-mcp-servers/hdf5/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.10",
+      "version": "2.5.11",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/jarvis/server.json
+++ b/clio-kit-mcp-servers/jarvis/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.10",
+      "version": "2.5.11",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/lmod/server.json
+++ b/clio-kit-mcp-servers/lmod/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.10",
+      "version": "2.5.11",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/ndp/server.json
+++ b/clio-kit-mcp-servers/ndp/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.10",
+      "version": "2.5.11",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/node-hardware/server.json
+++ b/clio-kit-mcp-servers/node-hardware/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.10",
+      "version": "2.5.11",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/pandas/server.json
+++ b/clio-kit-mcp-servers/pandas/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.10",
+      "version": "2.5.11",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/parallel-sort/server.json
+++ b/clio-kit-mcp-servers/parallel-sort/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.10",
+      "version": "2.5.11",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/paraview/server.json
+++ b/clio-kit-mcp-servers/paraview/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.10",
+      "version": "2.5.11",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/parquet/server.json
+++ b/clio-kit-mcp-servers/parquet/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.10",
+      "version": "2.5.11",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/plot/server.json
+++ b/clio-kit-mcp-servers/plot/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.10",
+      "version": "2.5.11",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/sac/server.json
+++ b/clio-kit-mcp-servers/sac/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.10",
+      "version": "2.5.11",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/scientific-catalog/.claude-plugin/plugin.json
+++ b/clio-kit-mcp-servers/scientific-catalog/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "clio-scientific-catalog",
   "description": "Operator-owned scientific dataset discovery for remote agents",
-  "version": "1.0.0"
+  "version": "1.1.0"
 }

--- a/clio-kit-mcp-servers/scientific-catalog/README.md
+++ b/clio-kit-mcp-servers/scientific-catalog/README.md
@@ -10,6 +10,11 @@ contain camera positions, colormaps, filters, thresholds, render recipes, schedu
 demo behavior. JARVIS consumes the returned `jarvis.dataset-descriptor.v1`; visualization choices
 remain runtime commands.
 
+`scientific_dataset_describe` keeps the human-facing catalog record under `dataset` and also
+returns its exact descriptor as the top-level `dataset_descriptor` field. Pass that named value
+unchanged as `jarvis_add_step.config.dataset_descriptor`; do not pass the surrounding `dataset`
+record. `descriptor_sha256` identifies the same descriptor bytes after canonical JSON encoding.
+
 Run from the containing clio-kit installation:
 
 ```console

--- a/clio-kit-mcp-servers/scientific-catalog/server.json
+++ b/clio-kit-mcp-servers/scientific-catalog/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.iowarp/scientific-catalog-mcp",
   "title": "CLIO Scientific Catalog",
   "description": "Operator-owned scientific dataset discovery for remote agents",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "repository": {
     "url": "https://github.com/iowarp/clio-kit",
     "source": "github"
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.10",
+      "version": "2.5.11",
       "transport": {
         "type": "stdio"
       },
@@ -35,7 +35,7 @@
     },
     {
       "name": "scientific_dataset_describe",
-      "description": "Return one exact operator catalog record and its jarvis.dataset-descriptor.v1."
+      "description": "Return one exact operator catalog record plus a top-level dataset_descriptor. Pass dataset_descriptor unchanged as jarvis_add_step config.dataset_descriptor; do not pass the surrounding dataset record."
     }
   ],
   "resources": [

--- a/clio-kit-mcp-servers/scientific-catalog/src/scientific_catalog_mcp/backend.py
+++ b/clio-kit-mcp-servers/scientific-catalog/src/scientific_catalog_mcp/backend.py
@@ -109,6 +109,7 @@ class CatalogStore:
             catalog_revision=catalog.revision,
             catalog_sha256=catalog.canonical_digest,
             dataset=match,
+            dataset_descriptor=match.descriptor,
             descriptor_sha256=match.descriptor.canonical_digest,
         )
 

--- a/clio-kit-mcp-servers/scientific-catalog/src/scientific_catalog_mcp/models.py
+++ b/clio-kit-mcp-servers/scientific-catalog/src/scientific_catalog_mcp/models.py
@@ -305,7 +305,17 @@ class DatasetDescribeResult(StrictModel):
     catalog_revision: str
     catalog_sha256: str
     dataset: CatalogDataset
+    dataset_descriptor: DatasetDescriptor
     descriptor_sha256: str
+
+    @model_validator(mode="after")
+    def validate_descriptor_handoff(self) -> Self:
+        """Keep the explicit JARVIS handoff identical to the catalog record."""
+        if self.dataset_descriptor != self.dataset.descriptor:
+            raise ValueError("dataset_descriptor must match dataset.descriptor")
+        if self.descriptor_sha256 != self.dataset_descriptor.canonical_digest:
+            raise ValueError("descriptor_sha256 must identify dataset_descriptor")
+        return self
 
 
 def summary_of(dataset: CatalogDataset) -> DatasetSummary:

--- a/clio-kit-mcp-servers/scientific-catalog/src/scientific_catalog_mcp/server.py
+++ b/clio-kit-mcp-servers/scientific-catalog/src/scientific_catalog_mcp/server.py
@@ -94,7 +94,11 @@ def scientific_dataset_search_tool(
 
 @mcp.tool(
     name="scientific_dataset_describe",
-    description=("Return one exact operator catalog record and its jarvis.dataset-descriptor.v1."),
+    description=(
+        "Return one exact operator catalog record plus a top-level dataset_descriptor. "
+        "Pass dataset_descriptor unchanged as jarvis_add_step config.dataset_descriptor; "
+        "do not pass the surrounding dataset record."
+    ),
     annotations={
         "readOnlyHint": True,
         "destructiveHint": False,
@@ -104,7 +108,7 @@ def scientific_dataset_search_tool(
     tags={"scientific-data", "catalog", "user"},
 )
 def scientific_dataset_describe_tool(dataset_id: str) -> DatasetDescribeResult:
-    """Resolve a stable dataset id without accepting raw paths or scene parameters."""
+    """Resolve a stable dataset id and an explicit JARVIS-ready descriptor handoff."""
     try:
         return _store().describe(dataset_id)
     except CatalogError as exc:

--- a/clio-kit-mcp-servers/scientific-catalog/tests/test_catalog.py
+++ b/clio-kit-mcp-servers/scientific-catalog/tests/test_catalog.py
@@ -10,7 +10,11 @@ import pytest
 from fastmcp import Client
 
 from scientific_catalog_mcp.backend import CatalogError, CatalogStore
-from scientific_catalog_mcp.models import DatasetDescriptor, canonical_sha256
+from scientific_catalog_mcp.models import (
+    DatasetDescribeResult,
+    DatasetDescriptor,
+    canonical_sha256,
+)
 from scientific_catalog_mcp.server import configure_catalog, mcp
 
 
@@ -109,9 +113,25 @@ def test_search_and_describe_return_stable_intrinsic_contracts(tmp_path: Path) -
     described = store.describe("deep-water-impact-2018")
     assert described.schema_version == "clio-kit.scientific-dataset-description.v1"
     assert described.dataset.descriptor.schema_version == "jarvis.dataset-descriptor.v1"
+    assert described.dataset_descriptor == described.dataset.descriptor
     assert described.descriptor_sha256 == canonical_sha256(
-        described.dataset.descriptor.model_dump(mode="json")
+        described.dataset_descriptor.model_dump(mode="json")
     )
+
+
+def test_describe_result_rejects_a_divergent_handoff(tmp_path: Path) -> None:
+    """Catalog metadata and the explicit JARVIS handoff cannot silently diverge."""
+    path = tmp_path / "catalog.json"
+    _write_catalog(path, _catalog())
+    store = CatalogStore(path)
+    asteroid = store.describe("deep-water-impact-2018")
+    red_sea = store.describe("red-sea-eddies-2020")
+    payload = asteroid.model_dump(mode="json")
+    payload["dataset_descriptor"] = red_sea.dataset_descriptor.model_dump(mode="json")
+    payload["descriptor_sha256"] = red_sea.descriptor_sha256
+
+    with pytest.raises(ValueError, match="must match dataset.descriptor"):
+        DatasetDescribeResult.model_validate(payload)
 
 
 def test_pagination_cursor_is_bound_to_catalog_revision(tmp_path: Path) -> None:
@@ -167,6 +187,16 @@ async def test_mcp_surface_has_two_agent_oriented_tools(tmp_path: Path) -> None:
             "scientific_dataset_search",
             {"query": "red sea", "page_size": 10},
         )
+        described = await client.call_tool(
+            "scientific_dataset_describe",
+            {"dataset_id": "red-sea-eddies-2020"},
+        )
     content = cast(dict[str, Any], result.structured_content)
     assert content["total_matches"] == 1
     assert content["datasets"][0]["dataset_id"] == "red-sea-eddies-2020"
+    described_content = cast(dict[str, Any], described.structured_content)
+    dataset = cast(dict[str, Any], described_content["dataset"])
+    assert described_content["dataset_descriptor"] == dataset["descriptor"]
+    assert described_content["dataset_descriptor"]["schema_version"] == (
+        "jarvis.dataset-descriptor.v1"
+    )

--- a/clio-kit-mcp-servers/seismic/server.json
+++ b/clio-kit-mcp-servers/seismic/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.10",
+      "version": "2.5.11",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/slurm/server.json
+++ b/clio-kit-mcp-servers/slurm/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.10",
+      "version": "2.5.11",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/spack/server.json
+++ b/clio-kit-mcp-servers/spack/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.10",
+      "version": "2.5.11",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/terrain/server.json
+++ b/clio-kit-mcp-servers/terrain/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.10",
+      "version": "2.5.11",
       "transport": {
         "type": "stdio"
       },

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "clio-kit",
-  "version": "2.5.10",
+  "version": "2.5.11",
   "mcpServers": {
     "clio-adios": {
       "command": "clio-kit",

--- a/mcp-server-versions.toml
+++ b/mcp-server-versions.toml
@@ -4,12 +4,12 @@ schema-version = 1
 # Existing Registry versions are immutable and must not be republished merely
 # because a newer clio-kit wheel also contains their unchanged implementation.
 [mcp-registry-release]
-publish = ["spack"]
+publish = ["scientific-catalog"]
 
 # Generated website metadata must not depend on the wall clock. Advance this
 # date intentionally whenever current contract metadata is regenerated.
 [documentation]
-updated = "2026-07-17"
+updated = "2026-07-18"
 
 # MCP Registry server versions describe each agent-facing contract. They are
 # intentionally independent of the clio-kit PyPI distribution version, which
@@ -33,7 +33,7 @@ paraview = "2.2.3"
 parquet = "2.2.3"
 plot = "2.2.3"
 sac = "2.2.3"
-scientific-catalog = "1.0.0"
+scientific-catalog = "1.1.0"
 seismic = "2.2.3"
 slurm = "3.0.0"
 spack = "2.1.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "clio-kit"
-version = "2.5.10"
+version = "2.5.11"
 description = "CLIO Kit - MCP Servers, Clients, and Tools for AI Agents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/clio_kit/_mcp_contracts/index.json
+++ b/src/clio_kit/_mcp_contracts/index.json
@@ -28,13 +28,13 @@
       "wire_sha256": "5f1d3aaf1d7311df84d9b25a66c3ed1987f3b84799658eaf8d9ccbbb79485ed2"
     },
     {
-      "artifact": "scientific-catalog-user-v1.json",
-      "artifact_sha256": "86097ef70d5b4e740a93ae0cdd0eb723cae1ac8898cfd8cbbc1911835cb22d56",
-      "contract_id": "clio-kit-scientific-catalog-user-v1",
-      "contract_sha256": "a53006f24f4698f659f0a7c8bf61fc7bd7ad23274b06d2eed2ccfca68b9ecb0a",
+      "artifact": "scientific-catalog-user-v1.1.json",
+      "artifact_sha256": "29cbbfe64eaa7bcf29531b3d28762b8ff47e89d291b0a5b66119da96c790135e",
+      "contract_id": "clio-kit-scientific-catalog-user-v1.1",
+      "contract_sha256": "80a9b583c26a084ff07d638ddf0c2c7d4325dbc8d4299931d0c4f3627cb8674c",
       "profile": "user",
       "server_name": "scientific-catalog",
-      "wire_sha256": "55bd04f45653c9117b8a1ae41cbc5e79dd6383e86a851b43caa071ae357bb2c4"
+      "wire_sha256": "1c8df94a298f92b92126c953a7b8124d90b2fa12919de93738a40e563c3eaa28"
     },
     {
       "artifact": "jarvis-user-v3.json",
@@ -62,6 +62,15 @@
       "profile": "user",
       "server_name": "jarvis",
       "wire_sha256": "bda0abe2b57d5e52ef639bf530e967c3b65072ebc4761d25cd9cbbcf0cd934e9"
+    },
+    {
+      "artifact": "scientific-catalog-user-v1.json",
+      "artifact_sha256": "86097ef70d5b4e740a93ae0cdd0eb723cae1ac8898cfd8cbbc1911835cb22d56",
+      "contract_id": "clio-kit-scientific-catalog-user-v1",
+      "contract_sha256": "a53006f24f4698f659f0a7c8bf61fc7bd7ad23274b06d2eed2ccfca68b9ecb0a",
+      "profile": "user",
+      "server_name": "scientific-catalog",
+      "wire_sha256": "55bd04f45653c9117b8a1ae41cbc5e79dd6383e86a851b43caa071ae357bb2c4"
     },
     {
       "artifact": "spack-user-v2.json",

--- a/src/clio_kit/_mcp_contracts/scientific-catalog-user-v1.1.json
+++ b/src/clio_kit/_mcp_contracts/scientific-catalog-user-v1.1.json
@@ -1,0 +1,671 @@
+{
+  "canonicalization": "json-sort-keys-compact-utf8-v1",
+  "contract_id": "clio-kit-scientific-catalog-user-v1.1",
+  "contract_sha256": "80a9b583c26a084ff07d638ddf0c2c7d4325dbc8d4299931d0c4f3627cb8674c",
+  "profile": "user",
+  "projection": "mcp-agent-tool-schema-v1",
+  "schema_version": "clio-kit.mcp-user-contract.v1",
+  "server_name": "scientific-catalog",
+  "source": {
+    "method": "tools/list",
+    "protocol_version": "2024-11-05",
+    "transport": "stdio"
+  },
+  "tool_names": [
+    "scientific_dataset_describe",
+    "scientific_dataset_search"
+  ],
+  "tools": [
+    {
+      "_meta": {
+        "fastmcp": {
+          "tags": [
+            "catalog",
+            "scientific-data",
+            "user"
+          ]
+        }
+      },
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false,
+        "readOnlyHint": true
+      },
+      "description": "Return one exact operator catalog record plus a top-level dataset_descriptor. Pass dataset_descriptor unchanged as jarvis_add_step config.dataset_descriptor; do not pass the surrounding dataset record.",
+      "inputSchema": {
+        "additionalProperties": false,
+        "properties": {
+          "dataset_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "dataset_id"
+        ],
+        "type": "object"
+      },
+      "name": "scientific_dataset_describe",
+      "outputSchema": {
+        "additionalProperties": false,
+        "description": "Complete catalog record and exact JARVIS descriptor.",
+        "properties": {
+          "catalog_revision": {
+            "type": "string"
+          },
+          "catalog_sha256": {
+            "type": "string"
+          },
+          "dataset": {
+            "additionalProperties": false,
+            "description": "Human-discoverable metadata around one intrinsic dataset descriptor.",
+            "properties": {
+              "dataset_id": {
+                "type": "string"
+              },
+              "descriptor": {
+                "additionalProperties": false,
+                "description": "JARVIS-owned intrinsic dataset descriptor without visualization semantics.",
+                "properties": {
+                  "arrays": {
+                    "items": {
+                      "additionalProperties": false,
+                      "description": "Intrinsic array facts discovered for one dataset.",
+                      "properties": {
+                        "association": {
+                          "enum": [
+                            "point",
+                            "cell",
+                            "field"
+                          ],
+                          "type": "string"
+                        },
+                        "components": {
+                          "maximum": 64,
+                          "minimum": 1,
+                          "type": "integer"
+                        },
+                        "name": {
+                          "maxLength": 512,
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "units": {
+                          "anyOf": [
+                            {
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        }
+                      },
+                      "required": [
+                        "name",
+                        "association",
+                        "components"
+                      ],
+                      "type": "object"
+                    },
+                    "maxItems": 256,
+                    "type": "array"
+                  },
+                  "bounds": {
+                    "anyOf": [
+                      {
+                        "items": {
+                          "type": "number"
+                        },
+                        "maxItems": 6,
+                        "minItems": 6,
+                        "type": "array"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "dataset_id": {
+                    "type": "string"
+                  },
+                  "fingerprint": {
+                    "additionalProperties": false,
+                    "description": "Content or collection identity for one dataset descriptor.",
+                    "properties": {
+                      "algorithm": {
+                        "const": "sha256",
+                        "type": "string"
+                      },
+                      "digest": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "algorithm",
+                      "digest"
+                    ],
+                    "type": "object"
+                  },
+                  "format": {
+                    "maxLength": 256,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "kind": {
+                    "maxLength": 256,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "members": {
+                    "items": {
+                      "additionalProperties": false,
+                      "description": "One ordered, cluster-local member in the bounded catalog view.",
+                      "properties": {
+                        "index": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "location": {
+                          "maxLength": 4096,
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "timestep": {
+                          "anyOf": [
+                            {
+                              "type": "number"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        }
+                      },
+                      "required": [
+                        "index",
+                        "location"
+                      ],
+                      "type": "object"
+                    },
+                    "maxItems": 512,
+                    "minItems": 1,
+                    "type": "array"
+                  },
+                  "schema_version": {
+                    "const": "jarvis.dataset-descriptor.v1",
+                    "type": "string"
+                  },
+                  "source_artifact": {
+                    "anyOf": [
+                      {
+                        "additionalProperties": false,
+                        "description": "Optional durable JARVIS artifact that owns a dataset.",
+                        "properties": {
+                          "artifact_id": {
+                            "pattern": "^art_[A-Za-z0-9_-]{22,86}$",
+                            "type": "string"
+                          },
+                          "sha256": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "artifact_id",
+                          "sha256"
+                        ],
+                        "type": "object"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  }
+                },
+                "required": [
+                  "schema_version",
+                  "dataset_id",
+                  "kind",
+                  "format",
+                  "members",
+                  "fingerprint"
+                ],
+                "type": "object"
+              },
+              "summary": {
+                "maxLength": 4096,
+                "minLength": 1,
+                "type": "string"
+              },
+              "tags": {
+                "items": {
+                  "type": "string"
+                },
+                "maxItems": 64,
+                "type": "array"
+              },
+              "title": {
+                "maxLength": 512,
+                "minLength": 1,
+                "type": "string"
+              }
+            },
+            "required": [
+              "dataset_id",
+              "title",
+              "summary",
+              "descriptor"
+            ],
+            "type": "object"
+          },
+          "dataset_descriptor": {
+            "additionalProperties": false,
+            "description": "JARVIS-owned intrinsic dataset descriptor without visualization semantics.",
+            "properties": {
+              "arrays": {
+                "items": {
+                  "additionalProperties": false,
+                  "description": "Intrinsic array facts discovered for one dataset.",
+                  "properties": {
+                    "association": {
+                      "enum": [
+                        "point",
+                        "cell",
+                        "field"
+                      ],
+                      "type": "string"
+                    },
+                    "components": {
+                      "maximum": 64,
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    "name": {
+                      "maxLength": 512,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "units": {
+                      "anyOf": [
+                        {
+                          "maxLength": 256,
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "association",
+                    "components"
+                  ],
+                  "type": "object"
+                },
+                "maxItems": 256,
+                "type": "array"
+              },
+              "bounds": {
+                "anyOf": [
+                  {
+                    "items": {
+                      "type": "number"
+                    },
+                    "maxItems": 6,
+                    "minItems": 6,
+                    "type": "array"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "dataset_id": {
+                "type": "string"
+              },
+              "fingerprint": {
+                "additionalProperties": false,
+                "description": "Content or collection identity for one dataset descriptor.",
+                "properties": {
+                  "algorithm": {
+                    "const": "sha256",
+                    "type": "string"
+                  },
+                  "digest": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "algorithm",
+                  "digest"
+                ],
+                "type": "object"
+              },
+              "format": {
+                "maxLength": 256,
+                "minLength": 1,
+                "type": "string"
+              },
+              "kind": {
+                "maxLength": 256,
+                "minLength": 1,
+                "type": "string"
+              },
+              "members": {
+                "items": {
+                  "additionalProperties": false,
+                  "description": "One ordered, cluster-local member in the bounded catalog view.",
+                  "properties": {
+                    "index": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "location": {
+                      "maxLength": 4096,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "timestep": {
+                      "anyOf": [
+                        {
+                          "type": "number"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    }
+                  },
+                  "required": [
+                    "index",
+                    "location"
+                  ],
+                  "type": "object"
+                },
+                "maxItems": 512,
+                "minItems": 1,
+                "type": "array"
+              },
+              "schema_version": {
+                "const": "jarvis.dataset-descriptor.v1",
+                "type": "string"
+              },
+              "source_artifact": {
+                "anyOf": [
+                  {
+                    "additionalProperties": false,
+                    "description": "Optional durable JARVIS artifact that owns a dataset.",
+                    "properties": {
+                      "artifact_id": {
+                        "pattern": "^art_[A-Za-z0-9_-]{22,86}$",
+                        "type": "string"
+                      },
+                      "sha256": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "artifact_id",
+                      "sha256"
+                    ],
+                    "type": "object"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              }
+            },
+            "required": [
+              "schema_version",
+              "dataset_id",
+              "kind",
+              "format",
+              "members",
+              "fingerprint"
+            ],
+            "type": "object"
+          },
+          "descriptor_sha256": {
+            "type": "string"
+          },
+          "schema_version": {
+            "const": "clio-kit.scientific-dataset-description.v1",
+            "default": "clio-kit.scientific-dataset-description.v1",
+            "type": "string"
+          },
+          "site_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "site_id",
+          "catalog_revision",
+          "catalog_sha256",
+          "dataset",
+          "dataset_descriptor",
+          "descriptor_sha256"
+        ],
+        "type": "object"
+      }
+    },
+    {
+      "_meta": {
+        "fastmcp": {
+          "tags": [
+            "catalog",
+            "scientific-data",
+            "user"
+          ]
+        }
+      },
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false,
+        "readOnlyHint": true
+      },
+      "description": "Search operator-registered scientific datasets and return bounded intrinsic summaries.",
+      "inputSchema": {
+        "additionalProperties": false,
+        "properties": {
+          "cursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "format": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "kind": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "page_size": {
+            "default": 20,
+            "maximum": 100,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "query": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "tags": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          }
+        },
+        "type": "object"
+      },
+      "name": "scientific_dataset_search",
+      "outputSchema": {
+        "additionalProperties": false,
+        "description": "Stable paginated response from scientific dataset search.",
+        "properties": {
+          "catalog_revision": {
+            "type": "string"
+          },
+          "catalog_sha256": {
+            "type": "string"
+          },
+          "datasets": {
+            "items": {
+              "additionalProperties": false,
+              "description": "Bounded discovery record returned by search.",
+              "properties": {
+                "dataset_fingerprint": {
+                  "type": "string"
+                },
+                "dataset_id": {
+                  "type": "string"
+                },
+                "descriptor_sha256": {
+                  "type": "string"
+                },
+                "first_timestep": {
+                  "anyOf": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "format": {
+                  "type": "string"
+                },
+                "kind": {
+                  "type": "string"
+                },
+                "last_timestep": {
+                  "anyOf": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "member_count": {
+                  "type": "integer"
+                },
+                "summary": {
+                  "type": "string"
+                },
+                "tags": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "title": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "dataset_id",
+                "title",
+                "summary",
+                "tags",
+                "kind",
+                "format",
+                "member_count",
+                "first_timestep",
+                "last_timestep",
+                "dataset_fingerprint",
+                "descriptor_sha256"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "next_cursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "schema_version": {
+            "const": "clio-kit.scientific-dataset-search.v1",
+            "default": "clio-kit.scientific-dataset-search.v1",
+            "type": "string"
+          },
+          "site_id": {
+            "type": "string"
+          },
+          "total_matches": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "site_id",
+          "catalog_revision",
+          "catalog_sha256",
+          "datasets",
+          "total_matches",
+          "next_cursor"
+        ],
+        "type": "object"
+      }
+    }
+  ],
+  "wire_sha256": "1c8df94a298f92b92126c953a7b8124d90b2fa12919de93738a40e563c3eaa28"
+}

--- a/src/clio_kit/mcp_contracts.py
+++ b/src/clio_kit/mcp_contracts.py
@@ -156,8 +156,8 @@ USER_CONTRACT_SPECS: Final = (
         expected_tools=frozenset({"spack_find", "spack_install", "spack_locate"}),
     ),
     UserContractSpec(
-        contract_id="clio-kit-scientific-catalog-user-v1",
-        artifact_name="scientific-catalog-user-v1.json",
+        contract_id="clio-kit-scientific-catalog-user-v1.1",
+        artifact_name="scientific-catalog-user-v1.1.json",
         server_name="scientific-catalog",
         distribution_name="scientific-catalog-mcp",
         entry_command="scientific-catalog-mcp",
@@ -174,6 +174,7 @@ HISTORICAL_USER_CONTRACT_ARTIFACTS: Final = (
     "jarvis-user-v3.json",
     "jarvis-user-v3.1.json",
     "jarvis-user-v3.2.json",
+    "scientific-catalog-user-v1.json",
     "spack-user-v2.json",
 )
 

--- a/tests/test_generate_server_json_contract.py
+++ b/tests/test_generate_server_json_contract.py
@@ -99,7 +99,7 @@ def test_every_committed_server_has_an_agent_runnable_package_coordinate() -> No
     assert manifests == [project / "server.json" for project in projects]
     assert list(expected_server_versions) == sorted(expected_server_versions)
     assert set(expected_server_versions) == {project.name for project in projects}
-    assert publish_servers == ("spack",)
+    assert publish_servers == ("scientific-catalog",)
     assert marketplace["metadata"]["version"] == expected_version
     assert set(marketplace_plugins) == set(expected_server_versions)
     assert gemini_extension["version"] == expected_version

--- a/tests/test_mcp_user_contracts.py
+++ b/tests/test_mcp_user_contracts.py
@@ -99,7 +99,7 @@ def test_contract_probe_uses_a_fresh_isolated_child_environment(
             {"spack_find", "spack_install", "spack_locate"},
         ),
         (
-            "clio-kit-scientific-catalog-user-v1",
+            "clio-kit-scientific-catalog-user-v1.1",
             {"scientific_dataset_search", "scientific_dataset_describe"},
         ),
     ],
@@ -149,6 +149,16 @@ def test_previous_spack_contract_remains_loadable_by_exact_identity() -> None:
     )
 
 
+def test_previous_scientific_catalog_contract_remains_loadable() -> None:
+    """The explicit handoff revision does not erase released v1 evidence."""
+    previous = load_mcp_user_contract("clio-kit-scientific-catalog-user-v1")
+
+    assert previous["contract_id"] == "clio-kit-scientific-catalog-user-v1"
+    assert previous["contract_sha256"] == (
+        "a53006f24f4698f659f0a7c8bf61fc7bd7ad23274b06d2eed2ccfca68b9ecb0a"
+    )
+
+
 def test_spack_contract_requires_load_spec_without_exposing_load() -> None:
     """Spack locate returns JARVIS's reload input without a fake load operation."""
     artifact = load_mcp_user_contract("clio-kit-spack-user-v2.1")
@@ -167,7 +177,7 @@ def test_spack_contract_requires_load_spec_without_exposing_load() -> None:
 
 def test_scientific_catalog_contract_separates_discovery_from_scene_control() -> None:
     """Catalog tools expose exact descriptors without paths or scene inputs."""
-    artifact = load_mcp_user_contract("clio-kit-scientific-catalog-user-v1")
+    artifact = load_mcp_user_contract("clio-kit-scientific-catalog-user-v1.1")
     tools = {
         cast(str, tool["name"]): cast(JSON, tool)
         for tool in cast(list[JSON], artifact["tools"])
@@ -190,6 +200,12 @@ def test_scientific_catalog_contract_separates_discovery_from_scene_control() ->
     ):
         assert prohibited not in encoded_inputs
     describe_output = cast(JSON, tools["scientific_dataset_describe"]["outputSchema"])
+    describe_properties = cast(JSON, describe_output["properties"])
+    assert "dataset_descriptor" in cast(list[str], describe_output["required"])
+    assert (
+        describe_properties["dataset_descriptor"]
+        == cast(JSON, describe_properties["dataset"])["properties"]["descriptor"]
+    )
     assert "jarvis.dataset-descriptor.v1" in json.dumps(describe_output, sort_keys=True)
 
 
@@ -543,6 +559,7 @@ def test_contract_cli_lists_and_prints_verified_artifacts() -> None:
     assert "clio-kit-slurm-user-v3" in listed.output
     assert "clio-kit-spack-user-v2.1" in listed.output
     assert "clio-kit-spack-user-v2" in listed.output
+    assert "clio-kit-scientific-catalog-user-v1.1" in listed.output
     assert "clio-kit-scientific-catalog-user-v1" in listed.output
     assert shown.exit_code == 0, shown.output
     assert json.loads(shown.output)["contract_id"] == "clio-kit-spack-user-v2.1"

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -442,6 +442,7 @@ def test_release_regenerates_and_smokes_shipped_user_contracts() -> None:
     assert "mcp-contract clio-kit-jarvis-user-v3.2" in smoke_block
     assert "mcp-contract clio-kit-jarvis-user-v3.1" in smoke_block
     assert "mcp-contract clio-kit-jarvis-user-v3" in smoke_block
+    assert "mcp-contract clio-kit-scientific-catalog-user-v1.1" in smoke_block
     assert "mcp-contract clio-kit-scientific-catalog-user-v1" in smoke_block
     assert "mcp-contract clio-kit-slurm-user-v3" in smoke_block
     assert "mcp-contract clio-kit-spack-user-v2.1" in smoke_block

--- a/uv.lock
+++ b/uv.lock
@@ -61,7 +61,7 @@ wheels = [
 
 [[package]]
 name = "clio-kit"
-version = "2.5.10"
+version = "2.5.11"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## What changed

- adds an explicit top-level `dataset_descriptor` to `scientific_dataset_describe`
- guarantees that handoff matches `dataset.descriptor` and its canonical digest
- preserves the immutable v1 contract while publishing scientific-catalog contract v1.1.0
- prepares the clio-kit 2.5.11 wheel and deterministic generated manifests

## Why

The live Ares asteroid workflow exposed a producer/consumer ambiguity: the catalog returned a surrounding dataset record, while JARVIS correctly accepts only the intrinsic `jarvis.dataset-descriptor.v1`. An agent forwarded the outer record unchanged and JARVIS rejected unknown fields. This change makes the composable handoff explicit without weakening JARVIS validation or adding demo-specific behavior.

## Validation

- scientific-catalog tests: 9 passed
- root contract and release-workflow tests: 43 passed
- deterministic metadata tests: 6 passed
- all 23 server manifests regenerated without warnings
- Ruff, strict mypy, lock checks, contract regeneration, and diff checks passed