### PR TITLE
fix(scientific-catalog): add discovery prompt

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "CLIO Kit - MCP Servers for Scientific Computing and HPC",
-    "version": "2.5.15",
+    "version": "2.5.16",
     "pluginRoot": "./clio-kit-mcp-servers"
   },
   "plugins": [
@@ -268,7 +268,7 @@
       "name": "clio-scientific-catalog",
       "source": "./clio-kit-mcp-servers/scientific-catalog",
       "description": "Operator-owned scientific dataset discovery for remote agents",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "category": "development",
       "keywords": [],
       "license": "BSD-3-Clause",

--- a/clio-kit-mcp-servers/adios/server.json
+++ b/clio-kit-mcp-servers/adios/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.15",
+      "version": "2.5.16",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/arxiv/server.json
+++ b/clio-kit-mcp-servers/arxiv/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.15",
+      "version": "2.5.16",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/chronolog/server.json
+++ b/clio-kit-mcp-servers/chronolog/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.15",
+      "version": "2.5.16",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/compression/server.json
+++ b/clio-kit-mcp-servers/compression/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.15",
+      "version": "2.5.16",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/darshan/server.json
+++ b/clio-kit-mcp-servers/darshan/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.15",
+      "version": "2.5.16",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/geo/server.json
+++ b/clio-kit-mcp-servers/geo/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.15",
+      "version": "2.5.16",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/geojson/server.json
+++ b/clio-kit-mcp-servers/geojson/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.15",
+      "version": "2.5.16",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/hdf5/server.json
+++ b/clio-kit-mcp-servers/hdf5/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.15",
+      "version": "2.5.16",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/jarvis/server.json
+++ b/clio-kit-mcp-servers/jarvis/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.15",
+      "version": "2.5.16",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/lmod/server.json
+++ b/clio-kit-mcp-servers/lmod/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.15",
+      "version": "2.5.16",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/ndp/server.json
+++ b/clio-kit-mcp-servers/ndp/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.15",
+      "version": "2.5.16",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/node-hardware/server.json
+++ b/clio-kit-mcp-servers/node-hardware/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.15",
+      "version": "2.5.16",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/pandas/server.json
+++ b/clio-kit-mcp-servers/pandas/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.15",
+      "version": "2.5.16",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/parallel-sort/server.json
+++ b/clio-kit-mcp-servers/parallel-sort/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.15",
+      "version": "2.5.16",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/paraview/server.json
+++ b/clio-kit-mcp-servers/paraview/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.15",
+      "version": "2.5.16",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/parquet/server.json
+++ b/clio-kit-mcp-servers/parquet/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.15",
+      "version": "2.5.16",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/plot/server.json
+++ b/clio-kit-mcp-servers/plot/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.15",
+      "version": "2.5.16",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/sac/server.json
+++ b/clio-kit-mcp-servers/sac/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.15",
+      "version": "2.5.16",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/scientific-catalog/.claude-plugin/plugin.json
+++ b/clio-kit-mcp-servers/scientific-catalog/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "clio-scientific-catalog",
   "description": "Operator-owned scientific dataset discovery for remote agents",
-  "version": "1.1.0"
+  "version": "1.1.1"
 }

--- a/clio-kit-mcp-servers/scientific-catalog/README.md
+++ b/clio-kit-mcp-servers/scientific-catalog/README.md
@@ -15,6 +15,9 @@ returns its exact descriptor as the top-level `dataset_descriptor` field. Pass t
 unchanged as `jarvis_add_step.config.dataset_descriptor`; do not pass the surrounding `dataset`
 record. `descriptor_sha256` identifies the same descriptor bytes after canonical JSON encoding.
 
+The `discover_scientific_dataset` prompt provides the same generic search-then-describe workflow
+for MCP clients that support prompts. It does not add dataset-specific or visualization behavior.
+
 Run from the containing clio-kit installation:
 
 ```console

--- a/clio-kit-mcp-servers/scientific-catalog/server.json
+++ b/clio-kit-mcp-servers/scientific-catalog/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.iowarp/scientific-catalog-mcp",
   "title": "CLIO Scientific Catalog",
   "description": "Operator-owned scientific dataset discovery for remote agents",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "repository": {
     "url": "https://github.com/iowarp/clio-kit",
     "source": "github"
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.15",
+      "version": "2.5.16",
       "transport": {
         "type": "stdio"
       },
@@ -43,6 +43,12 @@
       "uri": "scientific-catalog://capabilities",
       "name": "scientific_catalog_capabilities",
       "description": "Describe the separation between discovery and runtime visualization."
+    }
+  ],
+  "prompts": [
+    {
+      "name": "discover_scientific_dataset",
+      "description": "Guide an agent through catalog search and exact descriptor handoff."
     }
   ],
   "tags": []

--- a/clio-kit-mcp-servers/scientific-catalog/src/scientific_catalog_mcp/server.py
+++ b/clio-kit-mcp-servers/scientific-catalog/src/scientific_catalog_mcp/server.py
@@ -10,6 +10,7 @@ from typing import Annotated
 
 from fastmcp import FastMCP
 from fastmcp.exceptions import ToolError
+from fastmcp.prompts import Message
 from pydantic import Field
 
 from .backend import CatalogError, CatalogStore
@@ -127,6 +128,21 @@ def scientific_catalog_capabilities() -> dict[str, object]:
         "visualization_owner": "vigil",
         "scene_semantics_in_catalog": False,
     }
+
+
+@mcp.prompt()
+def discover_scientific_dataset(query: str) -> list[Message]:
+    """Guide an agent through catalog search and exact descriptor handoff."""
+    return [
+        Message(
+            f"Find an operator-registered scientific dataset matching {query!r}. "
+            "Call scientific_dataset_search with that query first. Use only dataset identifiers "
+            "returned by the search, and report a no-match result before broadening the query. "
+            "For the chosen dataset_id, call scientific_dataset_describe and pass only its "
+            "top-level dataset_descriptor unchanged to JARVIS. Do not invent camera, colormap, "
+            "filter, scheduler, or demo-recipe semantics."
+        )
+    ]
 
 
 def main() -> None:

--- a/clio-kit-mcp-servers/scientific-catalog/tests/test_catalog.py
+++ b/clio-kit-mcp-servers/scientific-catalog/tests/test_catalog.py
@@ -200,3 +200,23 @@ async def test_mcp_surface_has_two_agent_oriented_tools(tmp_path: Path) -> None:
     assert described_content["dataset_descriptor"]["schema_version"] == (
         "jarvis.dataset-descriptor.v1"
     )
+
+
+@pytest.mark.asyncio
+async def test_discover_prompt_preserves_search_describe_boundary() -> None:
+    """The generic prompt must guide discovery without smuggling scene semantics."""
+    async with Client(mcp) as client:
+        prompts = {prompt.name for prompt in await client.list_prompts()}
+        rendered = await client.get_prompt(
+            "discover_scientific_dataset",
+            {"query": "asteroid impact volume"},
+        )
+
+    assert "discover_scientific_dataset" in prompts
+    assert rendered.messages
+    text = rendered.messages[0].content.text
+    assert "asteroid impact volume" in text
+    assert "scientific_dataset_search" in text
+    assert "scientific_dataset_describe" in text
+    assert "dataset_descriptor unchanged" in text
+    assert "Do not invent camera, colormap, filter, scheduler" in text

--- a/clio-kit-mcp-servers/seismic/server.json
+++ b/clio-kit-mcp-servers/seismic/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.15",
+      "version": "2.5.16",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/slurm/server.json
+++ b/clio-kit-mcp-servers/slurm/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.15",
+      "version": "2.5.16",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/spack/server.json
+++ b/clio-kit-mcp-servers/spack/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.15",
+      "version": "2.5.16",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/terrain/server.json
+++ b/clio-kit-mcp-servers/terrain/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.15",
+      "version": "2.5.16",
       "transport": {
         "type": "stdio"
       },

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "clio-kit",
-  "version": "2.5.15",
+  "version": "2.5.16",
   "mcpServers": {
     "clio-adios": {
       "command": "clio-kit",

--- a/mcp-server-versions.toml
+++ b/mcp-server-versions.toml
@@ -1,9 +1,9 @@
 schema-version = 1
 
-# Only this JARVIS server record has a new package/runtime patch in this wheel.
-# Its v3.4 user schema remains unchanged while the locked JARVIS-CD runtime advances.
+# Only scientific-catalog has a new agent-facing prompt in this wheel. Its
+# frozen v1.1 two-tool schema remains unchanged.
 [mcp-registry-release]
-publish = ["jarvis"]
+publish = ["scientific-catalog"]
 
 # Generated website metadata must not depend on the wall clock. Advance this
 # date intentionally whenever current contract metadata is regenerated.
@@ -32,7 +32,7 @@ paraview = "2.2.3"
 parquet = "2.2.3"
 plot = "2.2.3"
 sac = "2.2.3"
-scientific-catalog = "1.1.0"
+scientific-catalog = "1.1.1"
 seismic = "2.2.3"
 slurm = "3.0.0"
 spack = "2.1.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "clio-kit"
-version = "2.5.15"
+version = "2.5.16"
 description = "CLIO Kit - MCP Servers, Clients, and Tools for AI Agents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -61,7 +61,7 @@ wheels = [
 
 [[package]]
 name = "clio-kit"
-version = "2.5.15"
+version = "2.5.16"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- add a generic scientific-catalog search-to-describe prompt
- preserve the frozen two-tool user contract and exact descriptor handoff
- release the containing wheel as clio-kit 2.5.16 and the catalog MCP surface as 1.1.1

## Root cause
The repository-wide FastMCP validator requires every packaged server to expose at least one useful prompt, but scientific-catalog exposed only tools.

## Validation
- 43 release and frozen-contract tests passed
- 10 scientific-catalog tests passed
- FastMCP validation passed
- Ruff, formatting, mypy, and lock checks passed