### PR TITLE
feat(jarvis): publish generic deployment and input contracts

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "CLIO Kit - MCP Servers for Scientific Computing and HPC",
-    "version": "2.5.23",
+    "version": "2.6.0",
     "pluginRoot": "./clio-kit-mcp-servers"
   },
   "plugins": [
@@ -125,7 +125,7 @@
       "name": "clio-jarvis",
       "source": "./clio-kit-mcp-servers/jarvis",
       "description": "JARVIS-CD MCP with a compact user pipeline contract and explicit admin compatibility profiles",
-      "version": "3.5.4",
+      "version": "3.6.0",
       "category": "development",
       "keywords": [
         "pipeline-management",

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -252,6 +252,7 @@ jobs:
         "$clio_kit" --help >/dev/null
         listed_servers="$("$clio_kit" mcp-servers)"
         listed_contracts="$("$clio_kit" mcp-contracts)"
+        grep -Fq 'clio-kit-jarvis-user-v3.6' <<< "$listed_contracts"
         grep -Fq 'clio-kit-jarvis-user-v3.5' <<< "$listed_contracts"
         grep -Fq 'clio-kit-jarvis-user-v3.4' <<< "$listed_contracts"
         grep -Fq 'clio-kit-jarvis-user-v3.3' <<< "$listed_contracts"
@@ -264,9 +265,13 @@ jobs:
         grep -Fq 'clio-kit-spack-user-v2.1' <<< "$listed_contracts"
         grep -Fq 'clio-kit-spack-user-v2' <<< "$listed_contracts"
         jarvis_contract="$("$clio_kit" \
-          mcp-contract clio-kit-jarvis-user-v3.5)"
-        python -c 'import json,sys; value=json.load(sys.stdin); assert value["contract_id"] == "clio-kit-jarvis-user-v3.5"; assert {tool["name"] for tool in value["tools"]} == {"jarvis_create_pipeline", "jarvis_describe", "jarvis_add_step", "jarvis_edit_step", "jarvis_run", "jarvis_get_execution"}' \
+          mcp-contract clio-kit-jarvis-user-v3.6)"
+        python -c 'import json,sys; value=json.load(sys.stdin); assert value["contract_id"] == "clio-kit-jarvis-user-v3.6"; assert {tool["name"] for tool in value["tools"]} == {"jarvis_create_pipeline", "jarvis_describe", "jarvis_add_step", "jarvis_edit_step", "jarvis_run", "jarvis_get_execution"}' \
           <<< "$jarvis_contract"
+        historical_jarvis_contract_v35="$("$clio_kit" \
+          mcp-contract clio-kit-jarvis-user-v3.5)"
+        python -c 'import json,sys; value=json.load(sys.stdin); assert value["contract_id"] == "clio-kit-jarvis-user-v3.5"' \
+          <<< "$historical_jarvis_contract_v35"
         historical_jarvis_contract_v34="$("$clio_kit" \
           mcp-contract clio-kit-jarvis-user-v3.4)"
         python -c 'import json,sys; value=json.load(sys.stdin); assert value["contract_id"] == "clio-kit-jarvis-user-v3.4"' \
@@ -369,8 +374,8 @@ jobs:
 
         from clio_kit import get_servers_path, locked_server_environment
 
-        expected_url = "https://github.com/grc-iit/jarvis-cd/releases/download/v1.4.8/jarvis_cd-1.4.8-py3-none-any.whl"
-        expected_digest = "ebf5e5f375b921f20c79075d461926431a5a017ca8b45e598878a89b229b3935"
+        expected_url = "https://github.com/grc-iit/jarvis-cd/releases/download/v1.6.0/jarvis_cd-1.6.0-py3-none-any.whl"
+        expected_digest = "c4853138f3263715e806fcd794233d89f4aa58161e3c5fbab59e7f96d24f0e98"
         expected_requirement = f"jarvis-cd @ {expected_url}#sha256={expected_digest}"
         server = get_servers_path() / "jarvis"
         project = tomllib.loads(
@@ -383,7 +388,7 @@ jobs:
             for package in jarvis_lock["package"]
             if package["name"] == "jarvis-cd"
         )
-        assert jarvis_package["version"] == "1.4.8"
+        assert jarvis_package["version"] == "1.6.0"
         assert jarvis_package["source"] == {"url": expected_url}
         assert jarvis_package["wheels"] == [
             {"url": expected_url, "hash": f"sha256:{expected_digest}"}
@@ -412,9 +417,9 @@ jobs:
         from jarvis_cd.core.pkg import Pkg
         from jarvis_cd.core.pipeline import Pipeline
 
-        expected_url = "https://github.com/grc-iit/jarvis-cd/releases/download/v1.4.8/jarvis_cd-1.4.8-py3-none-any.whl"
+        expected_url = "https://github.com/grc-iit/jarvis-cd/releases/download/v1.6.0/jarvis_cd-1.6.0-py3-none-any.whl"
         installed = distribution("jarvis-cd")
-        assert installed.version == "1.4.8"
+        assert installed.version == "1.6.0"
         direct_url_text = installed.read_text("direct_url.json")
         assert direct_url_text is not None
         direct_url = json.loads(direct_url_text)

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ distinct `not_installed` semantic, while real Spack failures remain errors.
 | **`geo`** | 2.2.3 | Geospatial | Render GeoJSON vector layers with basemaps | `clio-kit mcp-server geo` |
 | **`geojson`** | 2.2.3 | Geospatial | Inspect, validate, and summarize GeoJSON | `clio-kit mcp-server geojson` |
 | **`hdf5`** | 2.2.3 | Data I/O | HPC-optimized scientific data with 27 tools, AI insights, caching, streaming | `clio-kit mcp-server hdf5` |
-| **`jarvis`** | 3.5.4 | Workflow | Durable pipeline, bounded package discovery, progress, artifact, and service-runtime management | `clio-kit mcp-server jarvis` |
+| **`jarvis`** | 3.6.0 | Workflow | Durable pipeline, bounded package discovery, progress, artifact, and service-runtime management | `clio-kit mcp-server jarvis` |
 | **`lmod`** | 2.2.3 | Environment | Environment module management | `clio-kit mcp-server lmod` |
 | **`ndp`** | 2.2.3 | Data Protocol | Search and discover datasets across CKAN instances | `clio-kit mcp-server ndp` |
 | **`node-hardware`** | 2.2.3 | System | System hardware information | `clio-kit mcp-server node-hardware` |

--- a/clio-kit-mcp-servers/adios/server.json
+++ b/clio-kit-mcp-servers/adios/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.23",
+      "version": "2.6.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/arxiv/server.json
+++ b/clio-kit-mcp-servers/arxiv/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.23",
+      "version": "2.6.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/chronolog/server.json
+++ b/clio-kit-mcp-servers/chronolog/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.23",
+      "version": "2.6.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/compression/server.json
+++ b/clio-kit-mcp-servers/compression/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.23",
+      "version": "2.6.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/darshan/server.json
+++ b/clio-kit-mcp-servers/darshan/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.23",
+      "version": "2.6.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/geo/server.json
+++ b/clio-kit-mcp-servers/geo/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.23",
+      "version": "2.6.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/geojson/server.json
+++ b/clio-kit-mcp-servers/geojson/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.23",
+      "version": "2.6.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/hdf5/server.json
+++ b/clio-kit-mcp-servers/hdf5/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.23",
+      "version": "2.6.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/jarvis/.claude-plugin/plugin.json
+++ b/clio-kit-mcp-servers/jarvis/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "clio-jarvis",
   "description": "JARVIS-CD MCP with a compact user pipeline contract and explicit admin compatibility profiles",
-  "version": "3.5.4"
+  "version": "3.6.0"
 }

--- a/clio-kit-mcp-servers/jarvis/pyproject.toml
+++ b/clio-kit-mcp-servers/jarvis/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jarvis-mcp"
-version = "3.5.4"
+version = "3.6.0"
 description = "JARVIS-CD MCP with a compact user pipeline contract and explicit admin compatibility profiles"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -15,7 +15,7 @@ dependencies = [
   "fastmcp>=3.2.0",
   "fastapi",
   "python-dotenv>=1.2.2",
-  "jarvis-cd @ https://github.com/grc-iit/jarvis-cd/releases/download/v1.4.8/jarvis_cd-1.4.8-py3-none-any.whl#sha256=ebf5e5f375b921f20c79075d461926431a5a017ca8b45e598878a89b229b3935",
+  "jarvis-cd @ https://github.com/grc-iit/jarvis-cd/releases/download/v1.6.0/jarvis_cd-1.6.0-py3-none-any.whl#sha256=c4853138f3263715e806fcd794233d89f4aa58161e3c5fbab59e7f96d24f0e98",
   "starlette>=1.3.1",
   "authlib>=1.6.12",
   "cryptography>=48.0.1",

--- a/clio-kit-mcp-servers/jarvis/scripts/live_ares_semantic_mcp_probe.py
+++ b/clio-kit-mcp-servers/jarvis/scripts/live_ares_semantic_mcp_probe.py
@@ -18,10 +18,10 @@ from urllib.parse import urlsplit
 
 
 Json = dict[str, Any]
-EXPECTED_JARVIS_VERSION = "1.4.8"
+EXPECTED_JARVIS_VERSION = "1.6.0"
 EXPECTED_JARVIS_URL = (
-    "https://github.com/grc-iit/jarvis-cd/releases/download/v1.4.8/"
-    "jarvis_cd-1.4.8-py3-none-any.whl"
+    "https://github.com/grc-iit/jarvis-cd/releases/download/v1.6.0/"
+    "jarvis_cd-1.6.0-py3-none-any.whl"
 )
 EXPECTED_JARVIS_SHA256 = (
     "ebf5e5f375b921f20c79075d461926431a5a017ca8b45e598878a89b229b3935"

--- a/clio-kit-mcp-servers/jarvis/server.json
+++ b/clio-kit-mcp-servers/jarvis/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.iowarp/jarvis-mcp",
   "title": "CLIO Jarvis",
   "description": "JARVIS-CD MCP with a compact user pipeline contract and explicit admin compatibility profiles",
-  "version": "3.5.4",
+  "version": "3.6.0",
   "repository": {
     "url": "https://github.com/iowarp/clio-kit",
     "source": "github"
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.23",
+      "version": "2.6.0",
       "transport": {
         "type": "stdio"
       },
@@ -35,11 +35,11 @@
     },
     {
       "name": "jarvis_describe",
-      "description": "Describe JARVIS packages, one package, a pipeline, or one pipeline step. For a named application, first use target='package' with its unique short name or fully qualified package name. Use target='package_search' for bounded discovery, then describe the selected canonical name. target='packages' is an exhaustive legacy inventory with every package's settings and can be large; use it only when the complete installed catalog is explicitly required."
+      "description": "Describe JARVIS packages, one package, a pipeline, or one pipeline step. For a named application, first use target='package' with its unique short name or fully qualified package name. Use target='package_search' for bounded discovery, then describe the selected canonical name. A package description returns package-owned configuration metadata and, when supported, a versioned deployment contract covering execution profiles, runtime requirements, readiness, and configuration rules. Package settings include only semantic parameters explicitly marked agent-visible. A setting may include a versioned input_binding descriptor for a declared local input that must be staged; callers must not infer file semantics from setting names or prose. Installer, scheduler, and other implementation controls remain owned by their dedicated contracts. target='packages' is an exhaustive legacy inventory with every agent-visible package setting and can be large; use it only when the complete installed catalog is explicitly required."
     },
     {
       "name": "jarvis_add_step",
-      "description": "Add and configure a package-backed step in a JARVIS pipeline. First use jarvis_describe(target='package') for the selected package; config keys must use its canonical setting names exactly, except for aliases explicitly listed there. User-level step configuration is always validated and cannot be bypassed."
+      "description": "Add and configure a package-backed step in a JARVIS pipeline. First use jarvis_describe(target='package') for the selected package; config keys must use its canonical setting names exactly, except for aliases explicitly listed there. Explicit null is accepted only when that setting reports nullable=true; omit a setting to use its declared default. Only settings marked agent-visible by the package are accepted here. User-level step configuration is always validated and cannot be bypassed."
     },
     {
       "name": "jarvis_edit_step",
@@ -47,11 +47,11 @@
     },
     {
       "name": "jarvis_run",
-      "description": "Start a configured JARVIS pipeline and return its durable execution handle without waiting for workload completion. Optional execution intent selects local, cluster, or hostfile mode without exposing scheduler internals. Optional spack_specs are resolved into a filtered environment that JARVIS persists before direct or scheduler execution. Use jarvis_get_execution with the returned pipeline_id and execution_id to query lifecycle, progress, artifacts, and execution-owned service runtimes."
+      "description": "Start a configured JARVIS pipeline and return its durable execution handle without waiting for workload completion. Optional execution intent selects local, cluster, or hostfile mode without exposing scheduler internals. For each runtime resolved with Spack, copy spack_locate.output.load_spec unchanged into one element of jarvis_run.input.spack_specs; do not derive an executable path from the Spack prefix. JARVIS resolves those specs into a filtered environment and persists it before direct or scheduler execution. Use jarvis_get_execution with the returned pipeline_id and execution_id to query lifecycle, progress, artifacts, and execution-owned service runtimes."
     },
     {
       "name": "jarvis_get_execution",
-      "description": "Query one JARVIS execution handle, durable lifecycle record, and runtime metadata. Progress is included by default and can be omitted. Set include_service_runtimes=true to include execution-owned network services such as an interactive ParaView runtime; authenticated services expose only a non-secret bearer token SHA-256 fingerprint. Set artifacts to {} or filters to include one bounded artifact page; omit artifacts to avoid querying the artifact manifest."
+      "description": "Query one JARVIS execution handle, durable lifecycle record, and runtime metadata. Progress is included by default and can be omitted. Set include_service_runtimes=true to include execution-owned network services; authenticated services expose only a non-secret bearer token SHA-256 fingerprint. Set artifacts to {} or filters to include one bounded artifact page; omit artifacts to avoid querying the artifact manifest."
     }
   ],
   "resources": [

--- a/clio-kit-mcp-servers/jarvis/src/jarvis_mcp/admin_server.py
+++ b/clio-kit-mcp-servers/jarvis/src/jarvis_mcp/admin_server.py
@@ -6,8 +6,10 @@ import argparse
 import os
 
 from .server import (
+    add_jarvis_root_argument,
     add_spack_command_argument,
     apply_tool_profile,
+    configure_jarvis_root,
     configure_spack_command,
     mcp,
 )
@@ -21,8 +23,10 @@ def main() -> None:
     parser.add_argument("--transport", choices=["stdio", "http"], default=None)
     parser.add_argument("--host", default="0.0.0.0")
     parser.add_argument("--port", type=int, default=8000)
+    add_jarvis_root_argument(parser)
     add_spack_command_argument(parser)
     args = parser.parse_args()
+    configure_jarvis_root(args.jarvis_root)
     configure_spack_command(args.spack_command)
     transport = args.transport or os.getenv("MCP_TRANSPORT", "stdio")
     if transport == "http":

--- a/clio-kit-mcp-servers/jarvis/src/jarvis_mcp/capabilities/__init__.py
+++ b/clio-kit-mcp-servers/jarvis/src/jarvis_mcp/capabilities/__init__.py
@@ -3,12 +3,12 @@ Jarvis MCP Server
 
 Jarvis-CD MCP - Pipeline Management for High-Performance Computing with comprehensive workflow operations
 
-Version: 3.5.4
+Version: 3.6.0
 Author: IoWarp Team - Gnosis Research Center
 License: BSD-3-Clause
 """
 
-__version__ = "3.5.4"
+__version__ = "3.6.0"
 __author__ = "IoWarp Team - Gnosis Research Center"
 __email__ = "grc@illinoistech.edu"
 __license__ = "BSD-3-Clause"

--- a/clio-kit-mcp-servers/jarvis/src/jarvis_mcp/capabilities/jarvis_handler.py
+++ b/clio-kit-mcp-servers/jarvis/src/jarvis_mcp/capabilities/jarvis_handler.py
@@ -518,7 +518,10 @@ async def append_pkg(
                         _get_package(pipeline, resolved_pkg_id)
                     )
                     _require_persisted_package_config(
-                        resolved_pkg_id, expected, persisted_config
+                        resolved_pkg_id,
+                        expected,
+                        persisted_config,
+                        pipeline=pipeline,
                     )
                     if config_flag:
                         pipeline.configure_package(resolved_pkg_id, config_args)
@@ -527,7 +530,10 @@ async def append_pkg(
                             _get_package(persisted, resolved_pkg_id)
                         )
                         _require_persisted_package_config(
-                            resolved_pkg_id, expected, persisted_config
+                            resolved_pkg_id,
+                            expected,
+                            persisted_config,
+                            pipeline=persisted,
                         )
                 except BaseException as exc:
                     try:
@@ -618,7 +624,12 @@ async def configure_pkg(
                 pipeline.configure_package(pkg_id, _kwargs_to_config_args(kwargs))
                 persisted = _load_pipeline(pipeline_id)
                 persisted_config = _package_config(_get_package(persisted, pkg_id))
-                _require_persisted_package_config(pkg_id, expected, persisted_config)
+                _require_persisted_package_config(
+                    pkg_id,
+                    expected,
+                    persisted_config,
+                    pipeline=persisted,
+                )
         return {
             "pipeline_id": pipeline_id,
             "configured": pkg_id,
@@ -3403,9 +3414,13 @@ def _reject_non_agent_visible_package_settings(
 
 
 def _require_persisted_package_config(
-    pkg_id: str, expected: dict[str, Any], persisted: Any
+    pkg_id: str,
+    expected: dict[str, Any],
+    persisted: Any,
+    *,
+    pipeline: Any | None = None,
 ) -> None:
-    """Fail unless every normalized setting survived a durable pipeline reload."""
+    """Require exact persistence or a verified package-owned input rewrite."""
     if not isinstance(persisted, dict):
         raise RuntimeError(f"Package '{pkg_id}' persisted an invalid configuration")
     mismatches = [
@@ -3413,6 +3428,31 @@ def _require_persisted_package_config(
         for name, value in expected.items()
         if name not in persisted or _jsonable(persisted[name]) != _jsonable(value)
     ]
+    if mismatches and pipeline is not None:
+        package = _get_package(pipeline, pkg_id)
+        loader = getattr(pipeline, "_load_package_instance", None)
+        instance = (
+            loader(package, getattr(pipeline, "env", {}))
+            if package is not None and callable(loader)
+            else package
+        )
+        verifier = getattr(
+            instance,
+            "configuration_input_materialization_matches",
+            None,
+        )
+        if callable(verifier):
+            verified: set[str] = set()
+            for name in mismatches:
+                if name not in persisted:
+                    continue
+                try:
+                    matches = verifier(name, expected[name], persisted[name])
+                except Exception:
+                    matches = False
+                if matches is True:
+                    verified.add(name)
+            mismatches = [name for name in mismatches if name not in verified]
     if mismatches:
         raise ValueError(
             f"Package '{pkg_id}' did not persist settings: {', '.join(mismatches)}"

--- a/clio-kit-mcp-servers/jarvis/src/jarvis_mcp/capabilities/jarvis_handler.py
+++ b/clio-kit-mcp-servers/jarvis/src/jarvis_mcp/capabilities/jarvis_handler.py
@@ -482,6 +482,7 @@ async def append_pkg(
     pkg_type: str,
     pkg_id: Optional[str] = None,
     do_configure: bool = True,
+    agent_visible_only: bool = False,
     **kwargs: Any,
 ) -> dict:
     try:
@@ -489,6 +490,8 @@ async def append_pkg(
         config_flag = do_configure
         if "do_configure" in raw_kwargs:
             config_flag = raw_kwargs.pop("do_configure")
+        if agent_visible_only:
+            _reject_non_agent_visible_package_settings(pkg_type, raw_kwargs)
 
         with _protocol_stdout_to_stderr():
             pipeline = _load_pipeline(pipeline_id)
@@ -506,7 +509,10 @@ async def append_pkg(
                 pipeline.append(pkg_type, package_alias=pkg_id, config_args=config_args)
                 try:
                     expected = _normalize_package_config_request(
-                        pipeline, resolved_pkg_id, raw_kwargs
+                        pipeline,
+                        resolved_pkg_id,
+                        raw_kwargs,
+                        agent_visible_only=agent_visible_only,
                     )
                     persisted_config = _package_config(
                         _get_package(pipeline, resolved_pkg_id)
@@ -581,16 +587,34 @@ async def update_pipeline(pipeline_id: str) -> dict:
 
 
 @_locked_pipeline_operation
-async def configure_pkg(pipeline_id: str, pkg_id: str, **kwargs: Any) -> dict:
+async def configure_pkg(
+    pipeline_id: str,
+    pkg_id: str,
+    *,
+    agent_visible_only: bool = False,
+    **kwargs: Any,
+) -> dict:
     try:
         with _protocol_stdout_to_stderr():
             pipeline = _load_pipeline(pipeline_id)
             if _is_legacy_pipeline(pipeline):
+                if agent_visible_only:
+                    _normalize_package_config_request(
+                        pipeline,
+                        pkg_id,
+                        kwargs,
+                        agent_visible_only=True,
+                    )
                 pipeline.configure(pkg_id, **kwargs)
                 _save_pipeline(pipeline)
                 persisted_config = _package_config(_get_package(pipeline, pkg_id))
             else:
-                expected = _normalize_package_config_request(pipeline, pkg_id, kwargs)
+                expected = _normalize_package_config_request(
+                    pipeline,
+                    pkg_id,
+                    kwargs,
+                    agent_visible_only=agent_visible_only,
+                )
                 pipeline.configure_package(pkg_id, _kwargs_to_config_args(kwargs))
                 persisted = _load_pipeline(pipeline_id)
                 persisted_config = _package_config(_get_package(persisted, pkg_id))
@@ -3242,7 +3266,11 @@ def _package_config(pkg: Any) -> Any:
 
 
 def _normalize_package_config_request(
-    pipeline: Any, pkg_id: str, kwargs: dict[str, Any]
+    pipeline: Any,
+    pkg_id: str,
+    kwargs: dict[str, Any],
+    *,
+    agent_visible_only: bool = False,
 ) -> dict[str, Any]:
     """Validate and normalize structured settings with the package-owned parser."""
     pkg = _get_package(pipeline, pkg_id)
@@ -3261,6 +3289,7 @@ def _normalize_package_config_request(
     if not isinstance(menu, list):
         raise RuntimeError(f"Package '{pkg_id}' returned an invalid configuration menu")
     canonical_names: dict[str, str] = {}
+    nullable_names: set[str] = set()
     for spec in menu:
         if not isinstance(spec, dict):
             raise RuntimeError(
@@ -3271,7 +3300,11 @@ def _normalize_package_config_request(
             raise RuntimeError(
                 f"Package '{pkg_id}' returned an invalid configuration option name"
             )
+        if agent_visible_only and spec.get("agent_visible", True) is False:
+            continue
         canonical_names[name] = name
+        if "default" in spec and spec["default"] is None:
+            nullable_names.add(name)
         aliases = spec.get("aliases", [])
         if not isinstance(aliases, list) or not all(
             isinstance(alias, str) and alias for alias in aliases
@@ -3286,11 +3319,15 @@ def _normalize_package_config_request(
         raise ValueError(
             f"Package '{pkg_id}' does not support settings: {', '.join(unknown)}"
         )
-    null_names = sorted(name for name, value in kwargs.items() if value is None)
+    null_names = sorted(
+        name
+        for name, value in kwargs.items()
+        if value is None and canonical_names[name] not in nullable_names
+    )
     if null_names:
         raise ValueError(
-            "Package settings cannot be null; provide a concrete value for: "
-            + ", ".join(null_names)
+            "Package settings cannot be null unless their package description reports "
+            "nullable=true; provide a concrete value for: " + ", ".join(null_names)
         )
 
     parser = cast(Any, get_argparse())
@@ -3312,6 +3349,57 @@ def _normalize_package_config_request(
             )
         normalized[canonical] = converted[canonical]
     return normalized
+
+
+def _reject_non_agent_visible_package_settings(
+    package_name: str,
+    kwargs: dict[str, Any],
+) -> None:
+    """Reject implementation settings before a user append can mutate a pipeline."""
+
+    if not kwargs:
+        return
+    try:
+        from jarvis_cd.core.pkg import Pkg  # type: ignore[import-untyped]
+
+        instance = Pkg.load_standalone(package_name)
+        menu = instance.configure_menu()
+    except Exception as exc:
+        raise RuntimeError(
+            f"Package '{package_name}' does not expose agent configuration metadata"
+        ) from exc
+    if not isinstance(menu, list):
+        raise RuntimeError(
+            f"Package '{package_name}' returned an invalid configuration menu"
+        )
+    hidden_names: set[str] = set()
+    for spec in menu:
+        if not isinstance(spec, dict):
+            raise RuntimeError(
+                f"Package '{package_name}' returned an invalid configuration option"
+            )
+        if spec.get("agent_visible", True) is not False:
+            continue
+        name = spec.get("name")
+        if not isinstance(name, str) or not name:
+            raise RuntimeError(
+                f"Package '{package_name}' returned an invalid configuration option name"
+            )
+        hidden_names.add(name)
+        aliases = spec.get("aliases", [])
+        if not isinstance(aliases, list) or not all(
+            isinstance(alias, str) and alias for alias in aliases
+        ):
+            raise RuntimeError(
+                f"Package '{package_name}' returned invalid aliases for '{name}'"
+            )
+        hidden_names.update(aliases)
+    requested = sorted(set(kwargs) & hidden_names)
+    if requested:
+        raise ValueError(
+            "Package settings are implementation-owned and not agent-visible: "
+            + ", ".join(requested)
+        )
 
 
 def _require_persisted_package_config(

--- a/clio-kit-mcp-servers/jarvis/src/jarvis_mcp/server.py
+++ b/clio-kit-mcp-servers/jarvis/src/jarvis_mcp/server.py
@@ -196,6 +196,7 @@ PACKAGE_SEARCH_SCHEMA = "jarvis.package-search.v1"
 PACKAGE_SEARCH_CURSOR_SCHEMA = "clio-kit.jarvis-package-search-cursor.v1"
 PACKAGE_DESCRIPTION_SCHEMA = "jarvis.package-description.v1"
 PACKAGE_DEPLOYMENT_SCHEMA = "jarvis.package-deployment.v1"
+CONFIGURATION_INPUT_BINDING_SCHEMA = "jarvis.configuration-input-binding.v1"
 PACKAGE_SEARCH_DEFAULT_PAGE_SIZE = 10
 PACKAGE_SEARCH_MAX_PAGE_SIZE = 25
 PACKAGE_SEARCH_MAX_RESULT_BYTES = 64 * 1024
@@ -266,6 +267,15 @@ class JarvisPackageExecutionProfileDocument(_ClosedDocument):
     when: list[JarvisPackageConditionDocument]
     runtime_requirements: list[str]
     readiness: JarvisPackageReadinessDocument
+    description: str | None = None
+
+
+class JarvisConfigurationInputBindingDocument(_ClosedDocument):
+    """Declared client-local input that must be staged before package use."""
+
+    schema_version: Literal["jarvis.configuration-input-binding.v1"]
+    kind: Literal["local_file"]
+    structure: Literal["regular_file"]
 
 
 class JarvisRuntimeRequirementStatusDocument(_ClosedDocument):
@@ -330,6 +340,7 @@ class JarvisPackageSettingDocument(TypedDict):
     required: bool
     nullable: bool
     aliases: NotRequired[list[str]]
+    input_binding: NotRequired[JarvisConfigurationInputBindingDocument]
 
 
 class JarvisPackageDescriptionDocument(_ClosedDocument):
@@ -1468,8 +1479,11 @@ async def jarvis_create_pipeline_tool(
         "returns package-owned configuration metadata and, when supported, a versioned "
         "deployment contract covering execution profiles, runtime requirements, "
         "readiness, and configuration rules. Package settings include only semantic "
-        "parameters explicitly marked agent-visible; installer, scheduler, and other "
-        "implementation controls remain owned by their dedicated contracts. "
+        "parameters explicitly marked agent-visible. A setting may include a versioned "
+        "input_binding descriptor for a declared local input that must be staged; "
+        "callers must not infer file semantics from setting names or prose. Installer, "
+        "scheduler, and other implementation controls remain owned by their dedicated "
+        "contracts. "
         "target='packages' is an exhaustive legacy inventory with every agent-visible "
         "package setting and can be large; use it only when the complete installed "
         "catalog is explicitly required."
@@ -2731,6 +2745,14 @@ def _setting_from_menu_item(item: dict[str, Any]) -> dict[str, Any]:
         isinstance(alias, str) and alias for alias in aliases
     ):
         setting["aliases"] = list(aliases)
+    if "input_binding" in item:
+        try:
+            input_binding = JarvisConfigurationInputBindingDocument.model_validate(
+                item["input_binding"]
+            )
+        except ValidationError as error:
+            raise ValueError("invalid package configuration input binding") from error
+        setting["input_binding"] = input_binding.model_dump(mode="json")
     return {
         key: value
         for key, value in setting.items()
@@ -2851,6 +2873,22 @@ def add_spack_command_argument(parser: argparse.ArgumentParser) -> None:
     )
 
 
+def add_jarvis_root_argument(parser: argparse.ArgumentParser) -> None:
+    """Add the shared validated JARVIS root option to a CLI parser."""
+    parser.add_argument(
+        "--jarvis-root",
+        type=_existing_directory_path,
+        default=None,
+        help="Existing directory to use as the isolated JARVIS_ROOT.",
+    )
+
+
+def configure_jarvis_root(jarvis_root: str | None) -> None:
+    """Apply an explicitly validated JARVIS root before serving requests."""
+    if jarvis_root is not None:
+        os.environ["JARVIS_ROOT"] = jarvis_root
+
+
 def configure_spack_command(spack_command: str | None) -> None:
     """Apply an explicitly validated Spack command for later JARVIS runs."""
     if spack_command is not None:
@@ -2873,6 +2911,20 @@ def _spack_command_path(value: str) -> str:
     return str(resolved)
 
 
+def _existing_directory_path(value: str) -> str:
+    """Resolve and validate an operator-supplied existing directory."""
+    candidate = Path(value).expanduser()
+    try:
+        resolved = candidate.resolve(strict=True)
+    except (OSError, RuntimeError) as exc:
+        raise argparse.ArgumentTypeError(
+            f"JARVIS root does not exist: {candidate}"
+        ) from exc
+    if not resolved.is_dir():
+        raise argparse.ArgumentTypeError(f"JARVIS root is not a directory: {resolved}")
+    return str(resolved)
+
+
 def main() -> None:
     """Main entry point for the Jarvis MCP server."""
     parser = argparse.ArgumentParser(description="Jarvis MCP Server")
@@ -2889,8 +2941,10 @@ def main() -> None:
     )
     parser.add_argument("--host", default="0.0.0.0")
     parser.add_argument("--port", type=int, default=8000)
+    add_jarvis_root_argument(parser)
     add_spack_command_argument(parser)
     args = parser.parse_args()
+    configure_jarvis_root(args.jarvis_root)
     configure_spack_command(args.spack_command)
     transport = args.transport or os.getenv("MCP_TRANSPORT", "stdio")
     profile = args.profile or os.getenv("JARVIS_MCP_PROFILE", "user")

--- a/clio-kit-mcp-servers/jarvis/src/jarvis_mcp/server.py
+++ b/clio-kit-mcp-servers/jarvis/src/jarvis_mcp/server.py
@@ -194,6 +194,8 @@ MCP_METADATA_PROFILE = "user"
 
 PACKAGE_SEARCH_SCHEMA = "jarvis.package-search.v1"
 PACKAGE_SEARCH_CURSOR_SCHEMA = "clio-kit.jarvis-package-search-cursor.v1"
+PACKAGE_DESCRIPTION_SCHEMA = "jarvis.package-description.v1"
+PACKAGE_DEPLOYMENT_SCHEMA = "jarvis.package-deployment.v1"
 PACKAGE_SEARCH_DEFAULT_PAGE_SIZE = 10
 PACKAGE_SEARCH_MAX_PAGE_SIZE = 25
 PACKAGE_SEARCH_MAX_RESULT_BYTES = 64 * 1024
@@ -224,6 +226,182 @@ class _PackageInventoryEntry:
             "description": _bounded_package_search_description(self.description),
         }
         return {key: value for key, value in summary.items() if value is not None}
+
+
+@dataclass(frozen=True)
+class _PackageAgentMetadata:
+    """Package-owned metadata safe to return through the user MCP surface."""
+
+    settings: list[dict[str, Any]] | None
+    deployment: dict[str, Any] | None
+
+
+class _ClosedDocument(BaseModel):
+    """Base for agent-visible documents with no undeclared fields."""
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class JarvisPackageConditionDocument(_ClosedDocument):
+    """One package-owned predicate over a canonical configuration setting."""
+
+    parameter: str
+    operator: Literal["equals", "greater_than", "is_empty", "is_not_empty"]
+    value: str | int | float | bool | None = None
+
+
+class JarvisPackageReadinessDocument(_ClosedDocument):
+    """Observable condition that makes one execution profile ready."""
+
+    mechanism: Literal["process_exit", "progress_event", "service_runtime"]
+    condition: str
+    capability: str | None = None
+
+
+class JarvisPackageExecutionProfileDocument(_ClosedDocument):
+    """Package-owned execution kind, applicability, requirements, and readiness."""
+
+    name: str
+    execution_kind: Literal["batch", "service"]
+    when: list[JarvisPackageConditionDocument]
+    runtime_requirements: list[str]
+    readiness: JarvisPackageReadinessDocument
+
+
+class JarvisRuntimeRequirementStatusDocument(_ClosedDocument):
+    """Package observation of whether a runtime requirement can be used."""
+
+    state: Literal["ready", "unavailable", "unknown"]
+    usable: bool | None
+    reason_code: str
+
+
+class JarvisProviderQueryDocument(_ClosedDocument):
+    """Provider-neutral query that can resolve one runtime requirement."""
+
+    kind: str
+    value: str
+
+
+class JarvisProviderResolutionDocument(_ClosedDocument):
+    """One provider and query capable of resolving a runtime requirement."""
+
+    provider: str
+    query: JarvisProviderQueryDocument
+
+
+class JarvisRuntimeRequirementDocument(_ClosedDocument):
+    """Runtime capabilities and provider resolutions owned by a package."""
+
+    id: str
+    description: str
+    required_capabilities: list[str]
+    available_capabilities: list[str]
+    status: JarvisRuntimeRequirementStatusDocument
+    provider_resolutions: list[JarvisProviderResolutionDocument]
+
+
+class JarvisPackageConfigurationRuleDocument(_ClosedDocument):
+    """Conditional requirement over canonical package configuration settings."""
+
+    when: list[JarvisPackageConditionDocument]
+    requires: list[JarvisPackageConditionDocument]
+    description: str
+
+
+class JarvisPackageDeploymentDocument(_ClosedDocument):
+    """Versioned deployment and readiness contract supplied by JARVIS."""
+
+    schema_version: Literal["jarvis.package-deployment.v1"]
+    package: str
+    execution_profiles: list[JarvisPackageExecutionProfileDocument]
+    runtime_requirements: list[JarvisRuntimeRequirementDocument]
+    configuration_rules: list[JarvisPackageConfigurationRuleDocument]
+
+
+class JarvisPackageSettingDocument(TypedDict):
+    """One package parser setting with truthful default and null semantics."""
+
+    name: str
+    description: NotRequired[str]
+    type: NotRequired[str]
+    default: NotRequired[Any]
+    choices: NotRequired[list[Any]]
+    required: bool
+    nullable: bool
+    aliases: NotRequired[list[str]]
+
+
+class JarvisPackageDescriptionDocument(_ClosedDocument):
+    """Path-free package detail returned after selecting one canonical package."""
+
+    schema_version: Literal["jarvis.package-description.v1"]
+    name: str
+    short_name: str
+    description: str | None
+    deployment: JarvisPackageDeploymentDocument | None
+    settings: list[JarvisPackageSettingDocument] | None = None
+
+
+class JarvisPackageSummaryDocument(_ClosedDocument):
+    """Bounded package identity returned during search."""
+
+    name: str
+    short_name: str
+    repository: str
+    description: str | None = None
+
+
+class JarvisDescribePackagesResult(_ClosedDocument):
+    """Exhaustive legacy package inventory result."""
+
+    target: Literal["packages"]
+    packages: list[JarvisPackageDescriptionDocument]
+
+
+class JarvisDescribePackageSearchResult(_ClosedDocument):
+    """Bounded package search page."""
+
+    schema_version: Literal["jarvis.package-search.v1"]
+    target: Literal["package_search"]
+    query: str
+    inventory_revision: str
+    packages: list[JarvisPackageSummaryDocument]
+    total_matches: int
+    returned_count: int
+    next_cursor: str | None
+
+
+class JarvisDescribePackageResult(_ClosedDocument):
+    """Exact package description result."""
+
+    target: Literal["package"]
+    package: JarvisPackageDescriptionDocument
+
+
+class JarvisDescribePipelineResult(_ClosedDocument):
+    """Stored pipeline snapshot result."""
+
+    target: Literal["pipeline"]
+    pipeline: dict[str, Any]
+
+
+class JarvisDescribeStepResult(_ClosedDocument):
+    """Stored pipeline step and package configuration result."""
+
+    target: Literal["step"]
+    step: dict[str, Any]
+    config: dict[str, Any]
+
+
+JarvisDescribeResult = Annotated[
+    JarvisDescribePackagesResult
+    | JarvisDescribePackageSearchResult
+    | JarvisDescribePackageResult
+    | JarvisDescribePipelineResult
+    | JarvisDescribeStepResult,
+    Field(discriminator="target"),
+]
 
 
 class JarvisExecutionHandleDocument(TypedDict):
@@ -1286,9 +1464,15 @@ async def jarvis_create_pipeline_tool(
         "Describe JARVIS packages, one package, a pipeline, or one pipeline step. "
         "For a named application, first use target='package' with its unique short name "
         "or fully qualified package name. Use target='package_search' for bounded "
-        "discovery, then describe the selected canonical name. target='packages' is an "
-        "exhaustive legacy inventory with every package's settings and can be large; "
-        "use it only when the complete installed catalog is explicitly required."
+        "discovery, then describe the selected canonical name. A package description "
+        "returns package-owned configuration metadata and, when supported, a versioned "
+        "deployment contract covering execution profiles, runtime requirements, "
+        "readiness, and configuration rules. Package settings include only semantic "
+        "parameters explicitly marked agent-visible; installer, scheduler, and other "
+        "implementation controls remain owned by their dedicated contracts. "
+        "target='packages' is an exhaustive legacy inventory with every agent-visible "
+        "package setting and can be large; use it only when the complete installed "
+        "catalog is explicitly required."
     ),
     annotations={
         "readOnlyHint": True,
@@ -1330,8 +1514,7 @@ async def jarvis_describe_tool(
             max_length=512,
             description=(
                 "Case-insensitive unique short name or fully qualified package name for "
-                "target='package', for example paraview or builtin.paraview. Ambiguous "
-                "short names fail with canonical candidates."
+                "target='package'. Ambiguous short names fail with canonical candidates."
             ),
         ),
     ] = None,
@@ -1377,27 +1560,39 @@ async def jarvis_describe_tool(
             )
         ),
     ] = True,
-) -> dict[str, Any]:
+) -> JarvisDescribeResult:
     """Describe user-level JARVIS objects without exposing repository administration."""
     normalized = target.strip().lower()
     if normalized == "packages":
-        return {"target": "packages", "packages": _discover_packages()}
+        return cast(
+            JarvisDescribeResult,
+            {"target": "packages", "packages": _discover_packages()},
+        )
     if normalized == "package_search":
         if query is None or not query.strip():
             raise ToolError("query is required when target='package_search'")
-        return _search_packages(query=query, page_size=page_size, cursor=cursor)
+        return cast(
+            JarvisDescribeResult,
+            _search_packages(query=query, page_size=page_size, cursor=cursor),
+        )
     if normalized == "package":
         if not package_name:
             raise ToolError("package_name is required when target='package'")
         package = _find_package_description(package_name)
         if package is None:
             raise ToolError(f"package not found: {package_name}")
-        return {"target": "package", "package": package}
+        return cast(
+            JarvisDescribeResult,
+            {"target": "package", "package": package},
+        )
     if normalized == "pipeline":
         if not pipeline_id:
             raise ToolError("pipeline_id is required when target='pipeline'")
         snapshot = await export_pipeline(pipeline_id, include_yaml=include_yaml)
-        return {"target": "pipeline", "pipeline": snapshot}
+        return cast(
+            JarvisDescribeResult,
+            {"target": "pipeline", "pipeline": snapshot},
+        )
     if normalized == "step":
         if not pipeline_id or not step_id:
             raise ToolError("pipeline_id and step_id are required when target='step'")
@@ -1406,7 +1601,10 @@ async def jarvis_describe_tool(
         if step is None:
             raise ToolError(f"step not found in pipeline {pipeline_id}: {step_id}")
         config = await get_pkg_config(pipeline_id, step_id)
-        return {"target": "step", "step": step, "config": config}
+        return cast(
+            JarvisDescribeResult,
+            {"target": "step", "step": step, "config": config},
+        )
     raise ToolError(
         "target must be one of: packages, package_search, package, pipeline, step"
     )
@@ -1418,8 +1616,10 @@ async def jarvis_describe_tool(
         "Add and configure a package-backed step in a JARVIS pipeline. First use "
         "jarvis_describe(target='package') for the selected package; config keys "
         "must use its canonical setting names exactly, except for aliases explicitly "
-        "listed there. User-level step configuration is always validated and cannot "
-        "be bypassed."
+        "listed there. Explicit null is accepted only when that setting reports "
+        "nullable=true; omit a setting to use its declared default. Only settings marked "
+        "agent-visible by the package are accepted here. User-level step configuration "
+        "is always validated and cannot be bypassed."
     ),
     annotations={
         "readOnlyHint": False,
@@ -1441,8 +1641,9 @@ async def jarvis_add_step_tool(
                 "there are also accepted, and settings must not be renamed or placed "
                 "under invented nesting. JSON documents may be passed directly as "
                 "objects or lists under their exact setting name; clio-kit serializes "
-                "them canonically before JARVIS package validation. Omit config to use "
-                "the package defaults."
+                "them canonically before JARVIS package validation. Explicit null is "
+                "accepted only for a setting that reports nullable=true. Omit config or "
+                "an individual setting to use the package-owned default."
             )
         ),
     ] = None,
@@ -1453,6 +1654,7 @@ async def jarvis_add_step_tool(
         package_name,
         pkg_id=step_id,
         do_configure=True,
+        agent_visible_only=True,
         **(config or {}),
     )
 
@@ -1480,7 +1682,12 @@ async def jarvis_edit_step_tool(
     if operation == "edit":
         if config is None:
             raise ToolError("config is required when operation='edit'")
-        return await configure_pkg(pipeline_id, step_id, **config)
+        return await configure_pkg(
+            pipeline_id,
+            step_id,
+            agent_visible_only=True,
+            **config,
+        )
     if config not in (None, {}):
         raise ToolError("config is not accepted when operation='remove'")
     return await unlink_pkg(pipeline_id, step_id)
@@ -1492,8 +1699,11 @@ async def jarvis_edit_step_tool(
         "Start a configured JARVIS pipeline and return its durable execution "
         "handle without waiting for workload completion. Optional execution intent "
         "selects local, cluster, or hostfile mode without exposing scheduler "
-        "internals. Optional spack_specs are resolved into a filtered environment "
-        "that JARVIS persists before direct or scheduler execution. Use "
+        "internals. For each runtime resolved with Spack, copy "
+        "spack_locate.output.load_spec unchanged into one element of "
+        "jarvis_run.input.spack_specs; do not derive an executable path from the Spack "
+        "prefix. JARVIS resolves those specs into a filtered environment and persists "
+        "it before direct or scheduler execution. Use "
         "jarvis_get_execution with the returned pipeline_id and execution_id to "
         "query lifecycle, progress, artifacts, and execution-owned service runtimes."
     ),
@@ -1509,7 +1719,17 @@ async def jarvis_run_tool(
     execution: ExecutionIntent | None = None,
     submit: bool = True,
     execution_id: str | None = None,
-    spack_specs: Optional[list[str]] = None,
+    spack_specs: Annotated[
+        Optional[list[str]],
+        Field(
+            description=(
+                "Runtime identities supplied by Spack. Copy each "
+                "spack_locate.output.load_spec unchanged into this list; do not pass "
+                "spack_locate.output.prefix or an inferred executable path. JARVIS "
+                "persists the resolved environment for the execution."
+            )
+        ),
+    ] = None,
     ctx: Context | None = None,
 ) -> JarvisRunResult:
     """Start a pipeline without waiting after persisting its Spack environment."""
@@ -1553,8 +1773,8 @@ async def jarvis_run_tool(
         "Query one JARVIS execution handle, durable lifecycle record, and "
         "runtime metadata. Progress is included by default and can be omitted. "
         "Set include_service_runtimes=true to include execution-owned network "
-        "services such as an interactive ParaView runtime; authenticated "
-        "services expose only a non-secret bearer token SHA-256 fingerprint. "
+        "services; authenticated services expose only a non-secret bearer token "
+        "SHA-256 fingerprint. "
         "Set artifacts to {} or filters to include one bounded artifact page; "
         "omit artifacts to avoid querying the artifact manifest."
     ),
@@ -2072,19 +2292,18 @@ def _package_inventory_entry(repo: Path, pkg_file: Path) -> _PackageInventoryEnt
 def _package_description_from_inventory(
     entry: _PackageInventoryEntry,
 ) -> dict[str, Any]:
-    """Load the package-owned settings for one selected inventory entry."""
+    """Load one selected package's path-free agent contract."""
 
+    metadata = _package_agent_metadata(entry.name)
     package: dict[str, Any] = {
+        "schema_version": PACKAGE_DESCRIPTION_SCHEMA,
         "name": entry.name,
         "short_name": entry.short_name,
         "description": entry.description,
-        "path": str(entry.package_file),
+        "deployment": metadata.deployment,
     }
-    menu = _package_settings(package["name"])
-    if menu is None and package["name"] != package["short_name"]:
-        menu = _package_settings(package["short_name"])
-    if menu is not None:
-        package["settings"] = menu
+    if metadata.settings is not None:
+        package["settings"] = metadata.settings
     return package
 
 
@@ -2417,20 +2636,85 @@ def _step_snapshot(
     return None
 
 
-def _package_settings(package_name: str) -> list[dict[str, Any]] | None:
+def _package_agent_metadata(package_name: str) -> _PackageAgentMetadata:
+    """Load package-owned configuration and deployment metadata once.
+
+    Older JARVIS packages do not implement ``describe_deployment`` and are
+    represented with ``deployment=None``. If a package advertises the method,
+    however, its document must match the versioned, path-free contract instead
+    of being silently downgraded to legacy behavior.
+    """
+
     try:
         from jarvis_cd.core.pkg import Pkg  # type: ignore[import-untyped]
 
         pkg = Pkg.load_standalone(package_name)
-        return [_setting_from_menu_item(item) for item in pkg.configure_menu()]
     except Exception:
-        return None
+        return _PackageAgentMetadata(settings=None, deployment=None)
+
+    try:
+        menu = pkg.configure_menu()
+        settings = [
+            _setting_from_menu_item(item)
+            for item in menu
+            if _setting_is_agent_visible(item)
+        ]
+    except Exception:
+        settings = None
+
+    describe_deployment = getattr(pkg, "describe_deployment", None)
+    if not callable(describe_deployment):
+        return _PackageAgentMetadata(settings=settings, deployment=None)
+    try:
+        raw_deployment = describe_deployment()
+    except Exception:
+        raise ToolError(
+            f"package '{package_name}' failed to describe its deployment contract"
+        ) from None
+    if raw_deployment is None:
+        return _PackageAgentMetadata(settings=settings, deployment=None)
+    if isinstance(raw_deployment, BaseModel):
+        raw_deployment = raw_deployment.model_dump(mode="json")
+    if not isinstance(raw_deployment, dict):
+        raise ToolError(
+            f"package '{package_name}' returned an invalid deployment contract"
+        )
+    try:
+        deployment = json.loads(
+            json.dumps(
+                raw_deployment,
+                allow_nan=False,
+                ensure_ascii=False,
+                separators=(",", ":"),
+                sort_keys=True,
+            )
+        )
+    except (TypeError, ValueError):
+        raise ToolError(
+            f"package '{package_name}' returned a non-JSON deployment contract"
+        ) from None
+    try:
+        validated = JarvisPackageDeploymentDocument.model_validate(deployment)
+    except ValidationError:
+        raise ToolError(
+            f"package '{package_name}' returned an invalid deployment contract"
+        ) from None
+    if (
+        validated.schema_version != PACKAGE_DEPLOYMENT_SCHEMA
+        or validated.package != package_name
+    ):
+        raise ToolError(
+            f"package '{package_name}' returned an invalid deployment contract"
+        )
+    return _PackageAgentMetadata(settings=settings, deployment=deployment)
 
 
 def _setting_from_menu_item(item: dict[str, Any]) -> dict[str, Any]:
     setting: dict[str, Any] = {
         "name": item.get("name"),
         "description": item.get("msg"),
+        "required": bool(item.get("required", False)),
+        "nullable": _setting_accepts_null(item),
     }
     kind = item.get("type")
     if isinstance(kind, type):
@@ -2442,15 +2726,28 @@ def _setting_from_menu_item(item: dict[str, Any]) -> dict[str, Any]:
     choices = item.get("choices")
     if isinstance(choices, (list, tuple)):
         setting["choices"] = list(choices)
-    required = item.get("required")
-    if isinstance(required, bool):
-        setting["required"] = required
     aliases = item.get("aliases")
     if isinstance(aliases, (list, tuple)) and all(
         isinstance(alias, str) and alias for alias in aliases
     ):
         setting["aliases"] = list(aliases)
-    return {key: value for key, value in setting.items() if value is not None}
+    return {
+        key: value
+        for key, value in setting.items()
+        if value is not None or key == "default"
+    }
+
+
+def _setting_is_agent_visible(item: dict[str, Any]) -> bool:
+    """Return whether package metadata exposes a setting to user agents."""
+
+    return item.get("agent_visible", True) is not False
+
+
+def _setting_accepts_null(item: dict[str, Any]) -> bool:
+    """Return whether the structured add-step path accepts explicit null."""
+
+    return "default" in item and item["default"] is None
 
 
 def _validated_execution_intent(

--- a/clio-kit-mcp-servers/jarvis/src/jarvis_mcp/user_server.py
+++ b/clio-kit-mcp-servers/jarvis/src/jarvis_mcp/user_server.py
@@ -6,8 +6,10 @@ import argparse
 import os
 
 from .server import (
+    add_jarvis_root_argument,
     add_spack_command_argument,
     apply_tool_profile,
+    configure_jarvis_root,
     configure_spack_command,
     mcp,
 )
@@ -21,8 +23,10 @@ def main() -> None:
     parser.add_argument("--transport", choices=["stdio", "http"], default=None)
     parser.add_argument("--host", default="0.0.0.0")
     parser.add_argument("--port", type=int, default=8000)
+    add_jarvis_root_argument(parser)
     add_spack_command_argument(parser)
     args = parser.parse_args()
+    configure_jarvis_root(args.jarvis_root)
     configure_spack_command(args.spack_command)
     transport = args.transport or os.getenv("MCP_TRANSPORT", "stdio")
     if transport == "http":

--- a/clio-kit-mcp-servers/jarvis/tests/test_cli_jarvis_root.py
+++ b/clio-kit-mcp-servers/jarvis/tests/test_cli_jarvis_root.py
@@ -1,0 +1,69 @@
+"""Focused tests for operator-selected JARVIS roots."""
+
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    ("module_name", "command"),
+    [
+        ("jarvis_mcp.server", "jarvis-mcp"),
+        ("jarvis_mcp.user_server", "jarvis-user-mcp"),
+        ("jarvis_mcp.admin_server", "jarvis-admin-mcp"),
+    ],
+)
+def test_entrypoints_set_validated_jarvis_root_before_serving(
+    tmp_path: Path,
+    module_name: str,
+    command: str,
+) -> None:
+    """Every entrypoint applies the resolved root before starting its server."""
+    jarvis_root = tmp_path / "isolated root"
+    jarvis_root.mkdir()
+    observed_roots: list[str | None] = []
+
+    def capture_run(**_kwargs: object) -> None:
+        observed_roots.append(os.environ.get("JARVIS_ROOT"))
+
+    if module_name != "jarvis_mcp.server":
+        sys.modules.pop(module_name, None)
+    with (
+        patch("sys.argv", [command, "--jarvis-root", str(jarvis_root)]),
+        patch.dict("os.environ", {}, clear=True),
+        patch("jarvis_mcp.server.apply_tool_profile"),
+        patch("jarvis_mcp.server.mcp.run", side_effect=capture_run),
+    ):
+        module = importlib.import_module(module_name)
+        module.main()
+
+    assert observed_roots == [str(jarvis_root.resolve())]
+
+
+@pytest.mark.parametrize("invalid_kind", ["missing", "file"])
+def test_main_rejects_non_directory_jarvis_root(
+    tmp_path: Path,
+    invalid_kind: str,
+) -> None:
+    """The operator option fails before serving unless its root is a directory."""
+    invalid_root = tmp_path / invalid_kind
+    if invalid_kind == "file":
+        invalid_root.write_text("not a directory", encoding="utf-8")
+
+    with (
+        patch("sys.argv", ["jarvis-mcp", "--jarvis-root", str(invalid_root)]),
+        patch("jarvis_mcp.server.mcp.run") as run_server,
+        pytest.raises(SystemExit) as error,
+    ):
+        from jarvis_mcp.server import main
+
+        main()
+
+    assert error.value.code == 2
+    run_server.assert_not_called()

--- a/clio-kit-mcp-servers/jarvis/tests/test_configuration_input_materialization.py
+++ b/clio-kit-mcp-servers/jarvis/tests/test_configuration_input_materialization.py
@@ -1,0 +1,56 @@
+"""Tests for accepting verified JARVIS configuration-input rewrites."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from jarvis_mcp.capabilities.jarvis_handler import (
+    _require_persisted_package_config,
+)
+
+
+def _pipeline_with_verifier(verifier: Mock) -> SimpleNamespace:
+    package = {"pkg_id": "simulation", "config": {}}
+    instance = SimpleNamespace(
+        configuration_input_materialization_matches=verifier,
+    )
+    return SimpleNamespace(
+        packages=[package],
+        env={},
+        _load_package_instance=Mock(return_value=instance),
+    )
+
+
+def test_verified_configuration_input_rewrite_is_accepted() -> None:
+    """A package-owned byte-for-byte materialization is valid persistence."""
+    verifier = Mock(return_value=True)
+    pipeline = _pipeline_with_verifier(verifier)
+
+    _require_persisted_package_config(
+        "simulation",
+        {"script": "/relay/staging/in.research"},
+        {"script": "/jarvis/shared/configuration-inputs/script/digest.research"},
+        pipeline=pipeline,
+    )
+
+    verifier.assert_called_once_with(
+        "script",
+        "/relay/staging/in.research",
+        "/jarvis/shared/configuration-inputs/script/digest.research",
+    )
+
+
+def test_unverified_configuration_rewrite_still_fails_closed() -> None:
+    """A changed value cannot bypass durable configuration verification."""
+    pipeline = _pipeline_with_verifier(Mock(return_value=False))
+
+    with pytest.raises(ValueError, match="did not persist settings: script"):
+        _require_persisted_package_config(
+            "simulation",
+            {"script": "/relay/staging/in.research"},
+            {"script": "/unowned/changed.research"},
+            pipeline=pipeline,
+        )

--- a/clio-kit-mcp-servers/jarvis/tests/test_jarvis_handler.py
+++ b/clio-kit-mcp-servers/jarvis/tests/test_jarvis_handler.py
@@ -977,6 +977,68 @@ class TestPackageOperations:
         assert exc_info.value.status_code == 422
         assert "does not support settings: message" in str(exc_info.value.detail)
 
+    def test_current_configure_accepts_only_declared_nullable_defaults(self):
+        """Explicit null follows the same default metadata returned by describe."""
+        from jarvis_cd.util import PkgArgParse
+
+        from jarvis_mcp.capabilities.jarvis_handler import (
+            _normalize_package_config_request,
+        )
+
+        class ConfigurablePackage:
+            @staticmethod
+            def configure_menu():
+                return [
+                    {"name": "optional_label", "type": str, "default": None},
+                    {"name": "mode", "type": str, "default": "batch"},
+                    {
+                        "name": "install_query",
+                        "type": str,
+                        "default": "",
+                        "agent_visible": False,
+                    },
+                ]
+
+            def get_argparse(self):
+                return PkgArgParse("package", self.configure_menu())
+
+        package = {
+            "pkg_id": "package",
+            "pkg_type": "site.package",
+            "config": {},
+        }
+        pipeline = Mock(
+            env={},
+            get_pkg=Mock(return_value=package),
+            _load_package_instance=Mock(return_value=ConfigurablePackage()),
+        )
+
+        assert _normalize_package_config_request(
+            pipeline,
+            "package",
+            {"optional_label": None},
+        ) == {"optional_label": None}
+        with pytest.raises(ValueError, match="reports nullable=true"):
+            _normalize_package_config_request(
+                pipeline,
+                "package",
+                {"mode": None},
+            )
+        with pytest.raises(
+            ValueError, match="does not support settings: install_query"
+        ):
+            _normalize_package_config_request(
+                pipeline,
+                "package",
+                {"install_query": "simulator"},
+                agent_visible_only=True,
+            )
+        assert _normalize_package_config_request(
+            pipeline,
+            "package",
+            {"install_query": "simulator"},
+        ) == {"install_query": "simulator"}
+
     @pytest.mark.asyncio
     async def test_current_configure_rejects_false_persistence_success(self):
         """A normal return is insufficient unless the edit survives reload."""

--- a/clio-kit-mcp-servers/jarvis/tests/test_package_search.py
+++ b/clio-kit-mcp-servers/jarvis/tests/test_package_search.py
@@ -11,6 +11,7 @@ from fastmcp.exceptions import ToolError
 
 from jarvis_mcp.server import (
     PACKAGE_SEARCH_MAX_RESULT_BYTES,
+    _PackageAgentMetadata,
     _setting_from_menu_item,
     jarvis_describe_tool,
     mcp,
@@ -47,13 +48,16 @@ async def test_named_package_loads_settings_for_only_the_selected_package(
     _write_package(repo, "site.solver", "Solver package.")
     settings_calls: list[str] = []
 
-    def settings(package_name: str) -> list[dict[str, object]]:
+    def metadata(package_name: str) -> _PackageAgentMetadata:
         settings_calls.append(package_name)
-        return [{"name": "mode", "default": "service"}]
+        return _PackageAgentMetadata(
+            settings=[{"name": "mode", "default": "service"}],
+            deployment=None,
+        )
 
     with (
         patch("jarvis_mcp.server.get_manager", return_value=_manager_for(repo)),
-        patch("jarvis_mcp.server._package_settings", side_effect=settings),
+        patch("jarvis_mcp.server._package_agent_metadata", side_effect=metadata),
     ):
         short = await jarvis_describe_tool("package", package_name="PARAVIEW")
         canonical = await jarvis_describe_tool(
@@ -63,6 +67,123 @@ async def test_named_package_loads_settings_for_only_the_selected_package(
     assert short["package"] == canonical["package"]
     assert short["package"]["name"] == "builtin.paraview"
     assert settings_calls == ["builtin.paraview", "builtin.paraview"]
+
+
+@pytest.mark.asyncio
+async def test_named_package_projects_package_owned_deployment_contract(
+    tmp_path: Path,
+) -> None:
+    """Describe returns the package contract unchanged and without source paths."""
+
+    repo = tmp_path / "repo"
+    _write_package(repo, "site.simulator", "Generic simulation package.")
+    deployment = {
+        "schema_version": "jarvis.package-deployment.v1",
+        "package": "site.simulator",
+        "execution_profiles": [
+            {
+                "name": "distributed_batch",
+                "execution_kind": "batch",
+                "when": [
+                    {
+                        "parameter": "mode",
+                        "operator": "equals",
+                        "value": "batch",
+                    }
+                ],
+                "runtime_requirements": ["simulation_runtime"],
+                "readiness": {
+                    "mechanism": "process_exit",
+                    "condition": "exit_code_zero",
+                },
+            }
+        ],
+        "runtime_requirements": [
+            {
+                "id": "simulation_runtime",
+                "description": "Runtime capable of distributed simulation.",
+                "required_capabilities": ["mpi"],
+                "available_capabilities": ["mpi"],
+                "status": {
+                    "state": "ready",
+                    "usable": True,
+                    "reason_code": "provider_resolved",
+                },
+                "provider_resolutions": [
+                    {
+                        "provider": "spack",
+                        "query": {"kind": "spec", "value": "simulator"},
+                    }
+                ],
+            }
+        ],
+        "configuration_rules": [
+            {
+                "when": [
+                    {
+                        "parameter": "mode",
+                        "operator": "equals",
+                        "value": "batch",
+                    }
+                ],
+                "requires": [
+                    {
+                        "parameter": "tasks",
+                        "operator": "greater_than",
+                        "value": 0,
+                    }
+                ],
+                "description": "Batch execution requires at least one task.",
+            }
+        ],
+    }
+    package = Mock()
+    package.configure_menu.return_value = [
+        {"name": "mode", "type": str, "default": "batch"},
+        {"name": "tasks", "type": int, "default": 1},
+        {
+            "name": "install_query",
+            "type": str,
+            "default": "",
+            "agent_visible": False,
+        },
+    ]
+    package.describe_deployment.return_value = deployment
+
+    with (
+        patch("jarvis_mcp.server.get_manager", return_value=_manager_for(repo)),
+        patch(
+            "jarvis_cd.core.pkg.Pkg.load_standalone",
+            return_value=package,
+        ) as load_standalone,
+    ):
+        result = await jarvis_describe_tool("package", package_name="site.simulator")
+
+    description = result["package"]
+    assert description["schema_version"] == "jarvis.package-description.v1"
+    assert description["deployment"] == deployment
+    assert description["settings"] == [
+        {
+            "name": "mode",
+            "type": "str",
+            "default": "batch",
+            "required": False,
+            "nullable": False,
+        },
+        {
+            "name": "tasks",
+            "type": "int",
+            "default": 1,
+            "required": False,
+            "nullable": False,
+        },
+    ]
+    assert "path" not in description
+    assert "install_query" not in {
+        setting["name"] for setting in description["settings"]
+    }
+    assert "executable" not in json.dumps(description, sort_keys=True).casefold()
+    load_standalone.assert_called_once_with("site.simulator")
 
 
 @pytest.mark.asyncio
@@ -90,6 +211,9 @@ async def test_paraview_description_is_semantic_not_site_runtime_configuration(
 
     package = result["package"]
     assert package["name"] == "builtin.paraview"
+    assert package["schema_version"] == "jarvis.package-description.v1"
+    assert package["deployment"] is None
+    assert "path" not in package
     settings = {setting["name"]: setting for setting in package["settings"]}
     assert settings["mode"]["default"] == "server"
     assert "service for a live dataset view" in settings["mode"]["description"]
@@ -119,13 +243,16 @@ async def test_ambiguous_short_name_fails_with_canonical_candidates(
     _write_package(repo, "site.solver", "Site solver.")
     settings_calls: list[str] = []
 
-    def settings(package_name: str) -> list[dict[str, object]]:
+    def metadata(package_name: str) -> _PackageAgentMetadata:
         settings_calls.append(package_name)
-        return [{"name": "package", "default": package_name}]
+        return _PackageAgentMetadata(
+            settings=[{"name": "package", "default": package_name}],
+            deployment=None,
+        )
 
     with (
         patch("jarvis_mcp.server.get_manager", return_value=_manager_for(repo)),
-        patch("jarvis_mcp.server._package_settings", side_effect=settings),
+        patch("jarvis_mcp.server._package_agent_metadata", side_effect=metadata),
     ):
         with pytest.raises(
             ToolError,
@@ -160,7 +287,7 @@ async def test_package_search_is_ranked_summary_only_and_cursor_bound(
     with (
         patch("jarvis_mcp.server.get_manager", return_value=_manager_for(repo)),
         patch(
-            "jarvis_mcp.server._package_settings",
+            "jarvis_mcp.server._package_agent_metadata",
             side_effect=AssertionError("search must not load settings"),
         ),
     ):
@@ -221,7 +348,7 @@ async def test_package_search_enforces_response_byte_ceiling(tmp_path: Path) -> 
     with (
         patch("jarvis_mcp.server.get_manager", return_value=_manager_for(repo)),
         patch(
-            "jarvis_mcp.server._package_settings",
+            "jarvis_mcp.server._package_agent_metadata",
             side_effect=AssertionError("search must not load settings"),
         ),
     ):
@@ -249,15 +376,18 @@ async def test_legacy_packages_target_remains_exhaustive_with_settings(
     """The released exhaustive response retains its shape and full settings."""
 
     repo = tmp_path / "repo"
-    echo_file = _write_package(repo, "builtin.echo", "Echo package.")
-    paraview_file = _write_package(repo, "builtin.paraview", "ParaView package.")
+    _write_package(repo, "builtin.echo", "Echo package.")
+    _write_package(repo, "builtin.paraview", "ParaView package.")
 
-    def settings(package_name: str) -> list[dict[str, object]]:
-        return [{"name": "package", "default": package_name}]
+    def metadata(package_name: str) -> _PackageAgentMetadata:
+        return _PackageAgentMetadata(
+            settings=[{"name": "package", "default": package_name}],
+            deployment=None,
+        )
 
     with (
         patch("jarvis_mcp.server.get_manager", return_value=_manager_for(repo)),
-        patch("jarvis_mcp.server._package_settings", side_effect=settings),
+        patch("jarvis_mcp.server._package_agent_metadata", side_effect=metadata),
     ):
         result = await jarvis_describe_tool("packages")
 
@@ -265,17 +395,19 @@ async def test_legacy_packages_target_remains_exhaustive_with_settings(
         "target": "packages",
         "packages": [
             {
+                "schema_version": "jarvis.package-description.v1",
                 "name": "builtin.echo",
                 "short_name": "echo",
                 "description": "Echo package.",
-                "path": str(echo_file),
+                "deployment": None,
                 "settings": [{"name": "package", "default": "builtin.echo"}],
             },
             {
+                "schema_version": "jarvis.package-description.v1",
                 "name": "builtin.paraview",
                 "short_name": "paraview",
                 "description": "ParaView package.",
-                "path": str(paraview_file),
+                "deployment": None,
                 "settings": [{"name": "package", "default": "builtin.paraview"}],
             },
         ],
@@ -299,6 +431,10 @@ async def test_jarvis_describe_schema_teaches_exact_then_bounded_discovery() -> 
     ]
     assert isinstance(describe.description, str)
     assert "named application" in describe.description
+    assert "versioned deployment contract" in describe.description
+    assert "runtime requirements" in describe.description
+    assert "readiness" in describe.description
+    assert "agent-visible" in describe.description
     assert (
         "unique short name or fully qualified"
         in properties["package_name"]["description"]
@@ -321,6 +457,51 @@ async def test_jarvis_describe_schema_teaches_exact_then_bounded_discovery() -> 
     }
     assert "only for target='pipeline'" in properties["include_yaml"]["description"]
 
+    output_schema = describe.output_schema
+    assert output_schema is not None
+    result_schema = output_schema["properties"]["result"]
+    package_branch = next(
+        branch
+        for branch in result_schema["oneOf"]
+        if branch["properties"]["target"].get("const") == "package"
+    )
+    package_schema = package_branch["properties"]["package"]
+    assert package_schema["additionalProperties"] is False
+    settings_schema = next(
+        option
+        for option in package_schema["properties"]["settings"]["anyOf"]
+        if option.get("type") == "array"
+    )["items"]
+    assert settings_schema["additionalProperties"] is False
+    assert "default" in settings_schema["properties"]
+    assert "default" not in settings_schema["required"]
+    assert {"name", "required", "nullable"}.issubset(settings_schema["required"])
+    deployment_schema = next(
+        option
+        for option in package_schema["properties"]["deployment"]["anyOf"]
+        if option.get("type") == "object"
+    )
+    assert deployment_schema["additionalProperties"] is False
+    assert deployment_schema["properties"]["schema_version"]["const"] == (
+        "jarvis.package-deployment.v1"
+    )
+    assert set(deployment_schema["properties"]) == {
+        "schema_version",
+        "package",
+        "execution_profiles",
+        "runtime_requirements",
+        "configuration_rules",
+    }
+    encoded_deployment_schema = json.dumps(deployment_schema, sort_keys=True)
+    for required_term in (
+        "execution_kind",
+        "readiness",
+        "provider_resolutions",
+        "required_capabilities",
+        "configuration_rules",
+    ):
+        assert required_term in encoded_deployment_schema
+
 
 def test_package_setting_preserves_agent_relevant_parser_metadata() -> None:
     """Package-owned choices, requirements, and aliases survive discovery."""
@@ -342,7 +523,28 @@ def test_package_setting_preserves_agent_relevant_parser_metadata() -> None:
         "default": "service",
         "choices": ["service", "batch"],
         "required": True,
+        "nullable": False,
         "aliases": ["execution_mode"],
+    }
+
+
+def test_null_default_is_explicitly_advertised_as_nullable() -> None:
+    """Agents can distinguish an omitted default from an invalid null value."""
+
+    assert _setting_from_menu_item(
+        {
+            "name": "optional_label",
+            "msg": "Optional label",
+            "type": str,
+            "default": None,
+        }
+    ) == {
+        "name": "optional_label",
+        "description": "Optional label",
+        "type": "str",
+        "default": None,
+        "required": False,
+        "nullable": True,
     }
 
 
@@ -359,7 +561,26 @@ async def test_jarvis_add_step_schema_is_exact_and_has_no_user_bypass() -> None:
     assert "do_configure" in legacy_append.parameters["properties"]
     assert isinstance(add_step.description, str)
     assert "canonical setting names exactly" in add_step.description
+    assert "agent-visible" in add_step.description
     config_description = properties["config"]["description"]
     assert "must not be renamed" in config_description
     assert "objects or lists" in config_description
     assert "serializes them canonically" in config_description
+    assert "nullable=true" in config_description
+
+
+@pytest.mark.asyncio
+async def test_jarvis_run_schema_teaches_exact_spack_handoff() -> None:
+    """The run tool names both ends of the cross-server runtime handoff."""
+
+    tools = await mcp.list_tools()
+    run = next(tool for tool in tools if tool.name == "jarvis_run")
+    properties = run.parameters["properties"]
+
+    assert isinstance(run.description, str)
+    assert "spack_locate.output.load_spec" in run.description
+    assert "jarvis_run.input.spack_specs" in run.description
+    assert "executable path" in run.description
+    spack_specs = properties["spack_specs"]
+    assert "spack_locate.output.load_spec" in spack_specs["description"]
+    assert "spack_locate.output.prefix" in spack_specs["description"]

--- a/clio-kit-mcp-servers/jarvis/tests/test_package_search.py
+++ b/clio-kit-mcp-servers/jarvis/tests/test_package_search.py
@@ -84,6 +84,7 @@ async def test_named_package_projects_package_owned_deployment_contract(
             {
                 "name": "distributed_batch",
                 "execution_kind": "batch",
+                "description": "Run the selected distributed simulation workload.",
                 "when": [
                     {
                         "parameter": "mode",
@@ -142,6 +143,16 @@ async def test_named_package_projects_package_owned_deployment_contract(
         {"name": "mode", "type": str, "default": "batch"},
         {"name": "tasks", "type": int, "default": 1},
         {
+            "name": "input_deck",
+            "type": str,
+            "default": "",
+            "input_binding": {
+                "schema_version": "jarvis.configuration-input-binding.v1",
+                "kind": "local_file",
+                "structure": "regular_file",
+            },
+        },
+        {
             "name": "install_query",
             "type": str,
             "default": "",
@@ -177,6 +188,18 @@ async def test_named_package_projects_package_owned_deployment_contract(
             "required": False,
             "nullable": False,
         },
+        {
+            "name": "input_deck",
+            "type": "str",
+            "default": "",
+            "required": False,
+            "nullable": False,
+            "input_binding": {
+                "schema_version": "jarvis.configuration-input-binding.v1",
+                "kind": "local_file",
+                "structure": "regular_file",
+            },
+        },
     ]
     assert "path" not in description
     assert "install_query" not in {
@@ -184,6 +207,22 @@ async def test_named_package_projects_package_owned_deployment_contract(
     }
     assert "executable" not in json.dumps(description, sort_keys=True).casefold()
     load_standalone.assert_called_once_with("site.simulator")
+
+
+def test_setting_projection_rejects_unversioned_or_open_input_bindings() -> None:
+    """File staging authority comes only from the exact closed descriptor."""
+    with pytest.raises(ValueError, match="invalid package configuration input binding"):
+        _setting_from_menu_item(
+            {
+                "name": "input_deck",
+                "type": str,
+                "input_binding": {
+                    "kind": "local_file",
+                    "structure": "regular_file",
+                    "untrusted": True,
+                },
+            }
+        )
 
 
 @pytest.mark.asyncio
@@ -212,7 +251,31 @@ async def test_paraview_description_is_semantic_not_site_runtime_configuration(
     package = result["package"]
     assert package["name"] == "builtin.paraview"
     assert package["schema_version"] == "jarvis.package-description.v1"
-    assert package["deployment"] is None
+    deployment = package["deployment"]
+    assert deployment["schema_version"] == "jarvis.package-deployment.v1"
+    assert deployment["package"] == "builtin.paraview"
+    assert {
+        (profile["name"], profile["execution_kind"])
+        for profile in deployment["execution_profiles"]
+    } == {
+        ("batch_script", "batch"),
+        ("client_server", "service"),
+        ("live_dataset_service", "service"),
+    }
+    assert {
+        requirement["id"] for requirement in deployment["runtime_requirements"]
+    } == {"paraview.batch", "paraview.server", "paraview.service"}
+    for requirement in deployment["runtime_requirements"]:
+        assert requirement["provider_resolutions"] == [
+            {
+                "provider": "spack",
+                "query": {"kind": "spec", "value": "paraview"},
+            }
+        ]
+    deployment_text = json.dumps(deployment, sort_keys=True).lower()
+    assert "pvpython" not in deployment_text
+    assert "pvbatch" not in deployment_text
+    assert "--mesa" not in deployment_text
     assert "path" not in package
     settings = {setting["name"]: setting for setting in package["settings"]}
     assert settings["mode"]["default"] == "server"
@@ -435,6 +498,7 @@ async def test_jarvis_describe_schema_teaches_exact_then_bounded_discovery() -> 
     assert "runtime requirements" in describe.description
     assert "readiness" in describe.description
     assert "agent-visible" in describe.description
+    assert "input_binding" in describe.description
     assert (
         "unique short name or fully qualified"
         in properties["package_name"]["description"]

--- a/clio-kit-mcp-servers/jarvis/tests/test_server_direct.py
+++ b/clio-kit-mcp-servers/jarvis/tests/test_server_direct.py
@@ -633,6 +633,7 @@ class TestPipelineToolsDirect:
                 "builtin.lammps",
                 pkg_id="lammps_1",
                 do_configure=True,
+                agent_visible_only=True,
                 nodes=4,
             )
 
@@ -663,6 +664,7 @@ class TestPipelineToolsDirect:
                 "builtin.paraview",
                 pkg_id=None,
                 do_configure=True,
+                agent_visible_only=True,
                 dataset_descriptor=descriptor,
             )
 
@@ -680,7 +682,12 @@ class TestPipelineToolsDirect:
             result = await jarvis_edit_step_tool("test", "lammps_1", {"nodes": 2})
 
             assert result["configured"] == "lammps_1"
-            mock_handler.assert_called_once_with("test", "lammps_1", nodes=2)
+            mock_handler.assert_called_once_with(
+                "test",
+                "lammps_1",
+                agent_visible_only=True,
+                nodes=2,
+            )
 
     @pytest.mark.asyncio
     async def test_jarvis_edit_step_remove_operation_unlinks(self):
@@ -1220,6 +1227,7 @@ class TestPipelineToolsDirect:
     ):
         """Package helper functions extract descriptions and optional settings."""
         from jarvis_mcp.server import (
+            _PackageAgentMetadata,
             _first_docstring_or_comment,
             _package_from_pkg_file,
             _setting_from_menu_item,
@@ -1240,6 +1248,8 @@ class TestPipelineToolsDirect:
             "description": "Node count",
             "type": "int",
             "default": 1,
+            "required": False,
+            "nullable": False,
         }
 
         repo = tmp_path / "repo"
@@ -1248,8 +1258,11 @@ class TestPipelineToolsDirect:
         pkg_file = pkg_dir / "pkg.py"
         pkg_file.write_text('"""Demo."""\n')
         with patch(
-            "jarvis_mcp.server._package_settings",
-            side_effect=[[{"name": "x"}], None],
+            "jarvis_mcp.server._package_agent_metadata",
+            return_value=_PackageAgentMetadata(
+                settings=[{"name": "x"}],
+                deployment=None,
+            ),
         ):
             assert _package_from_pkg_file(repo, pkg_file)["settings"] == [{"name": "x"}]
 
@@ -1291,21 +1304,24 @@ class TestPipelineToolsDirect:
         package_file.write_text('"""Site solver."""\n', encoding="utf-8")
         manager = Mock()
         manager.list_repos.return_value = [repo]
+        from jarvis_mcp.server import _PackageAgentMetadata, jarvis_describe_tool
 
         with (
             patch("jarvis_mcp.server.get_manager", return_value=manager),
-            patch("jarvis_mcp.server._package_settings", return_value=None),
+            patch(
+                "jarvis_mcp.server._package_agent_metadata",
+                return_value=_PackageAgentMetadata(settings=None, deployment=None),
+            ),
         ):
-            from jarvis_mcp.server import jarvis_describe_tool
-
             result = await jarvis_describe_tool("packages")
 
         assert result["packages"] == [
             {
+                "schema_version": "jarvis.package-description.v1",
                 "name": "site.solver",
                 "short_name": "solver",
                 "description": "Site solver.",
-                "path": str(package_file),
+                "deployment": None,
             }
         ]
 
@@ -1335,13 +1351,15 @@ class TestPipelineToolsDirect:
         )
         manager = Mock()
         manager.list_repos.return_value = [repo]
+        from jarvis_mcp.server import _PackageAgentMetadata, jarvis_describe_tool
 
         with (
             patch("jarvis_mcp.server.get_manager", return_value=manager),
-            patch("jarvis_mcp.server._package_settings", return_value=None),
+            patch(
+                "jarvis_mcp.server._package_agent_metadata",
+                return_value=_PackageAgentMetadata(settings=None, deployment=None),
+            ),
         ):
-            from jarvis_mcp.server import jarvis_describe_tool
-
             result = await jarvis_describe_tool("package", package_name="builtin.demo")
 
             assert result["target"] == "package"

--- a/clio-kit-mcp-servers/jarvis/uv.lock
+++ b/clio-kit-mcp-servers/jarvis/uv.lock
@@ -791,8 +791,8 @@ wheels = [
 
 [[package]]
 name = "jarvis-cd"
-version = "1.4.8"
-source = { url = "https://github.com/grc-iit/jarvis-cd/releases/download/v1.4.8/jarvis_cd-1.4.8-py3-none-any.whl" }
+version = "1.6.0"
+source = { url = "https://github.com/grc-iit/jarvis-cd/releases/download/v1.6.0/jarvis_cd-1.6.0-py3-none-any.whl" }
 dependencies = [
     { name = "pandas" },
     { name = "podman-compose" },
@@ -800,7 +800,7 @@ dependencies = [
     { name = "pyyaml" },
 ]
 wheels = [
-    { url = "https://github.com/grc-iit/jarvis-cd/releases/download/v1.4.8/jarvis_cd-1.4.8-py3-none-any.whl", hash = "sha256:ebf5e5f375b921f20c79075d461926431a5a017ca8b45e598878a89b229b3935" },
+    { url = "https://github.com/grc-iit/jarvis-cd/releases/download/v1.6.0/jarvis_cd-1.6.0-py3-none-any.whl", hash = "sha256:c4853138f3263715e806fcd794233d89f4aa58161e3c5fbab59e7f96d24f0e98" },
 ]
 
 [package.metadata]
@@ -813,7 +813,7 @@ requires-dist = [
 
 [[package]]
 name = "jarvis-mcp"
-version = "3.5.4"
+version = "3.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "authlib" },
@@ -853,7 +853,7 @@ requires-dist = [
     { name = "fastapi" },
     { name = "fastmcp", specifier = ">=3.2.0" },
     { name = "idna", specifier = ">=3.15" },
-    { name = "jarvis-cd", url = "https://github.com/grc-iit/jarvis-cd/releases/download/v1.4.8/jarvis_cd-1.4.8-py3-none-any.whl" },
+    { name = "jarvis-cd", url = "https://github.com/grc-iit/jarvis-cd/releases/download/v1.6.0/jarvis_cd-1.6.0-py3-none-any.whl" },
     { name = "pydantic", specifier = ">=2.12.5" },
     { name = "pydantic-settings", specifier = ">=2.14.2" },
     { name = "pygments", specifier = ">=2.20.0" },

--- a/clio-kit-mcp-servers/lmod/server.json
+++ b/clio-kit-mcp-servers/lmod/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.23",
+      "version": "2.6.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/ndp/server.json
+++ b/clio-kit-mcp-servers/ndp/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.23",
+      "version": "2.6.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/node-hardware/server.json
+++ b/clio-kit-mcp-servers/node-hardware/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.23",
+      "version": "2.6.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/pandas/server.json
+++ b/clio-kit-mcp-servers/pandas/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.23",
+      "version": "2.6.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/parallel-sort/server.json
+++ b/clio-kit-mcp-servers/parallel-sort/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.23",
+      "version": "2.6.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/paraview/server.json
+++ b/clio-kit-mcp-servers/paraview/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.23",
+      "version": "2.6.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/parquet/server.json
+++ b/clio-kit-mcp-servers/parquet/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.23",
+      "version": "2.6.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/plot/server.json
+++ b/clio-kit-mcp-servers/plot/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.23",
+      "version": "2.6.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/sac/server.json
+++ b/clio-kit-mcp-servers/sac/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.23",
+      "version": "2.6.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/scientific-catalog/server.json
+++ b/clio-kit-mcp-servers/scientific-catalog/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.23",
+      "version": "2.6.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/seismic/server.json
+++ b/clio-kit-mcp-servers/seismic/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.23",
+      "version": "2.6.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/slurm/server.json
+++ b/clio-kit-mcp-servers/slurm/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.23",
+      "version": "2.6.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/spack/server.json
+++ b/clio-kit-mcp-servers/spack/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.23",
+      "version": "2.6.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/spack/src/spack_mcp/backend.py
+++ b/clio-kit-mcp-servers/spack/src/spack_mcp/backend.py
@@ -126,7 +126,13 @@ class SpackLocateResult(BaseModel):
     schema_version: Literal["spack.mcp.result.v1"] = SPACK_RESULT_SCHEMA
     operation: Literal["locate"] = "locate"
     requested_spec: str
-    load_spec: str
+    load_spec: str = Field(
+        description=(
+            "Exact runtime identity for JARVIS. Copy this value unchanged from "
+            "spack_locate.output.load_spec into one element of "
+            "jarvis_run.input.spack_specs."
+        )
+    )
     package: SpackPackage
     prefix: str
 

--- a/clio-kit-mcp-servers/spack/src/spack_mcp/server.py
+++ b/clio-kit-mcp-servers/spack/src/spack_mcp/server.py
@@ -34,7 +34,8 @@ mcp: FastMCP = FastMCP(
         "locating an absent package returns the structured not_installed error. "
         "This server never pretends that a shell-local `spack load` changes later "
         "agent or scheduler processes. Runtime environment materialization is an "
-        "admin diagnostic; JARVIS should persist it inside jarvis_run."
+        "admin diagnostic. Copy spack_locate.output.load_spec unchanged into "
+        "jarvis_run.input.spack_specs so JARVIS persists the runtime environment."
     ),
 )
 
@@ -66,8 +67,11 @@ async def spack_find_tool(query: str | None = None) -> SpackFindResult:
 @mcp.tool(
     name="spack_locate",
     description=(
-        "Resolve one unique installed Spack spec and return its exact prefix. "
-        "An absent package returns the structured not_installed error."
+        "Resolve one unique installed Spack spec. Copy "
+        "spack_locate.output.load_spec unchanged into one element of "
+        "jarvis_run.input.spack_specs; do not derive or pass an executable path from "
+        "the returned prefix. An absent package returns the structured not_installed "
+        "error."
     ),
     annotations={
         "readOnlyHint": True,
@@ -155,8 +159,9 @@ def prepare_spack_package(spec: str) -> list[Message]:
     return [
         Message(
             f"Prepare Spack package {spec!r}. First call spack_find, install only if "
-            "needed, then call spack_locate. Pass the exact spec to jarvis_run via "
-            "spack_specs so JARVIS persists the runtime environment."
+            "needed, then call spack_locate. Copy spack_locate.output.load_spec "
+            "unchanged into jarvis_run.input.spack_specs so JARVIS persists the "
+            "runtime environment."
         )
     ]
 

--- a/clio-kit-mcp-servers/spack/tests/test_server.py
+++ b/clio-kit-mcp-servers/spack/tests/test_server.py
@@ -37,6 +37,23 @@ async def test_find_returns_typed_result(monkeypatch: pytest.MonkeyPatch) -> Non
 
 
 @pytest.mark.asyncio
+async def test_locate_tools_list_teaches_exact_jarvis_handoff() -> None:
+    """Agents can discover the cross-server handoff before calling locate."""
+
+    tools = await server.mcp.list_tools(run_middleware=False)
+    locate = next(tool for tool in tools if tool.name == "spack_locate")
+
+    assert isinstance(locate.description, str)
+    assert "spack_locate.output.load_spec" in locate.description
+    assert "jarvis_run.input.spack_specs" in locate.description
+    assert "executable path" in locate.description
+    assert locate.output_schema is not None
+    load_spec = locate.output_schema["properties"]["load_spec"]
+    assert "spack_locate.output.load_spec" in load_spec["description"]
+    assert "jarvis_run.input.spack_specs" in load_spec["description"]
+
+
+@pytest.mark.asyncio
 async def test_install_forwards_explicit_reuse_false(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/clio-kit-mcp-servers/terrain/server.json
+++ b/clio-kit-mcp-servers/terrain/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.5.23",
+      "version": "2.6.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-website/docs/mcps/jarvis.md
+++ b/clio-kit-website/docs/mcps/jarvis.md
@@ -10,7 +10,7 @@ import MCPDetail from '@site/src/components/MCPDetail';
   icon="🤖"
   category="Data Processing"
   description="JARVIS-CD MCP with a compact user pipeline contract and explicit admin compatibility profiles"
-  version="3.5.4"
+  version="3.6.0"
   actions={["jarvis_create_pipeline", "jarvis_describe", "jarvis_add_step", "jarvis_edit_step", "jarvis_run", "jarvis_get_execution"]}
   platforms={["claude", "cursor", "vscode"]}
   keywords={["jarvis", "pipeline-management", "high-performance-computing", "hpc", "workflow", "data-pipelines", "scientific-computing", "mcp", "package-management"]}

--- a/clio-kit-website/src/data/mcpData.js
+++ b/clio-kit-website/src/data/mcpData.js
@@ -256,7 +256,7 @@ export const mcpData = {
       "jarvis_get_execution"
     ],
     "stats": {
-      "version": "3.5.4",
+      "version": "3.6.0",
       "updated": "2026-07-18"
     },
     "platforms": [

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "clio-kit",
-  "version": "2.5.23",
+  "version": "2.6.0",
   "mcpServers": {
     "clio-adios": {
       "command": "clio-kit",

--- a/mcp-server-versions.toml
+++ b/mcp-server-versions.toml
@@ -8,7 +8,7 @@ publish = ["jarvis"]
 # Generated website metadata must not depend on the wall clock. Advance this
 # date intentionally whenever current contract metadata is regenerated.
 [documentation]
-updated = "2026-07-18"
+updated = "2026-07-22"
 
 # MCP Registry server versions describe each agent-facing contract. They are
 # intentionally independent of the clio-kit PyPI distribution version, which
@@ -22,7 +22,7 @@ darshan = "2.2.3"
 geo = "2.2.3"
 geojson = "2.2.3"
 hdf5 = "2.2.3"
-jarvis = "3.5.4"
+jarvis = "3.6.0"
 lmod = "2.2.3"
 ndp = "2.2.3"
 node-hardware = "2.2.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "clio-kit"
-version = "2.5.23"
+version = "2.6.0"
 description = "CLIO Kit - MCP Servers, Clients, and Tools for AI Agents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/clio_kit/_mcp_contracts/index.json
+++ b/src/clio_kit/_mcp_contracts/index.json
@@ -1,13 +1,13 @@
 {
   "contracts": [
     {
-      "artifact": "jarvis-user-v3.5.json",
-      "artifact_sha256": "88f8a256262f4c27e0c23359cb3c86b6fb1b2d7c787f56c9c91e0a69e0e719af",
-      "contract_id": "clio-kit-jarvis-user-v3.5",
-      "contract_sha256": "9933815ca7ee913d56a7cb1081d7702474bc984efcc97bf16434980172d0469d",
+      "artifact": "jarvis-user-v3.6.json",
+      "artifact_sha256": "6e839f3ac975f247053ef4b6a048c53686882c2ab6a1b103f91dfc744ed29ed5",
+      "contract_id": "clio-kit-jarvis-user-v3.6",
+      "contract_sha256": "055c6697dc9a25fb033c949db92c928aee8d5673f7b2e3a4d90a237f4f87a40d",
       "profile": "user",
       "server_name": "jarvis",
-      "wire_sha256": "05f7d8a6286e211657ca40b64f0645bbd529e402fbf55770c845403695ddd366"
+      "wire_sha256": "c69db36bda5d1cc97043d7b7cee88cabcf044d506865046537e0fb17ab0b2023"
     },
     {
       "artifact": "slurm-user-v3.json",
@@ -20,12 +20,12 @@
     },
     {
       "artifact": "spack-user-v2.1.json",
-      "artifact_sha256": "1bae2c8386a85e90fde674819c04a598033b360367745fd36bead97b5728d537",
+      "artifact_sha256": "24f6e2b340ef5e2649241c10d7c2260b8d8cbbaa4e10f1a389c9249c2e7e6171",
       "contract_id": "clio-kit-spack-user-v2.1",
-      "contract_sha256": "cc90789227aa0baea99d0e0379b320811c1dbd40c7fa66877d372309201be1c2",
+      "contract_sha256": "f1a62d96179012975f763402446571146e04e519f98df30583f9800f233216fc",
       "profile": "user",
       "server_name": "spack",
-      "wire_sha256": "5f1d3aaf1d7311df84d9b25a66c3ed1987f3b84799658eaf8d9ccbbb79485ed2"
+      "wire_sha256": "e06bfa71153e19ea44f03ed55f03873bc643f42b4b25b96788c02892df719da8"
     },
     {
       "artifact": "scientific-catalog-user-v1.1.json",
@@ -80,6 +80,15 @@
       "profile": "user",
       "server_name": "jarvis",
       "wire_sha256": "2ced8dc66ecee832ee86df0c99c29610bce61a82f9d80a8a53e0ea037d262219"
+    },
+    {
+      "artifact": "jarvis-user-v3.5.json",
+      "artifact_sha256": "88f8a256262f4c27e0c23359cb3c86b6fb1b2d7c787f56c9c91e0a69e0e719af",
+      "contract_id": "clio-kit-jarvis-user-v3.5",
+      "contract_sha256": "9933815ca7ee913d56a7cb1081d7702474bc984efcc97bf16434980172d0469d",
+      "profile": "user",
+      "server_name": "jarvis",
+      "wire_sha256": "05f7d8a6286e211657ca40b64f0645bbd529e402fbf55770c845403695ddd366"
     },
     {
       "artifact": "scientific-catalog-user-v1.json",

--- a/src/clio_kit/_mcp_contracts/jarvis-user-v3.6.json
+++ b/src/clio_kit/_mcp_contracts/jarvis-user-v3.6.json
@@ -1,0 +1,3845 @@
+{
+  "canonicalization": "json-sort-keys-compact-utf8-v1",
+  "contract_id": "clio-kit-jarvis-user-v3.6",
+  "contract_sha256": "055c6697dc9a25fb033c949db92c928aee8d5673f7b2e3a4d90a237f4f87a40d",
+  "profile": "user",
+  "projection": "mcp-agent-tool-schema-v1",
+  "schema_version": "clio-kit.mcp-user-contract.v1",
+  "server_name": "jarvis",
+  "source": {
+    "method": "tools/list",
+    "protocol_version": "2024-11-05",
+    "transport": "stdio"
+  },
+  "tool_names": [
+    "jarvis_add_step",
+    "jarvis_create_pipeline",
+    "jarvis_describe",
+    "jarvis_edit_step",
+    "jarvis_get_execution",
+    "jarvis_run"
+  ],
+  "tools": [
+    {
+      "_meta": {
+        "fastmcp": {
+          "tags": [
+            "jarvis",
+            "pipeline",
+            "user"
+          ]
+        }
+      },
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "readOnlyHint": false
+      },
+      "description": "Add and configure a package-backed step in a JARVIS pipeline. First use jarvis_describe(target='package') for the selected package; config keys must use its canonical setting names exactly, except for aliases explicitly listed there. Explicit null is accepted only when that setting reports nullable=true; omit a setting to use its declared default. Only settings marked agent-visible by the package are accepted here. User-level step configuration is always validated and cannot be bypassed.",
+      "inputSchema": {
+        "additionalProperties": false,
+        "properties": {
+          "config": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Package-owned configuration. Use canonical setting names exactly as returned by jarvis_describe(target='package'); only aliases listed there are also accepted, and settings must not be renamed or placed under invented nesting. JSON documents may be passed directly as objects or lists under their exact setting name; clio-kit serializes them canonically before JARVIS package validation. Explicit null is accepted only for a setting that reports nullable=true. Omit config or an individual setting to use the package-owned default."
+          },
+          "package_name": {
+            "type": "string"
+          },
+          "pipeline_id": {
+            "type": "string"
+          },
+          "step_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          }
+        },
+        "required": [
+          "pipeline_id",
+          "package_name"
+        ],
+        "type": "object"
+      },
+      "name": "jarvis_add_step",
+      "outputSchema": {
+        "additionalProperties": true,
+        "type": "object"
+      }
+    },
+    {
+      "_meta": {
+        "fastmcp": {
+          "tags": [
+            "jarvis",
+            "pipeline",
+            "user"
+          ]
+        }
+      },
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "readOnlyHint": false
+      },
+      "description": "Create a JARVIS pipeline. Optionally pass execution intent such as local, cluster, or hostfile mode; backend details are resolved where the MCP server runs.",
+      "inputSchema": {
+        "additionalProperties": false,
+        "properties": {
+          "execution": {
+            "anyOf": [
+              {
+                "additionalProperties": false,
+                "description": "Validated, backend-neutral execution request for a JARVIS pipeline.",
+                "properties": {
+                  "account": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "cpus_per_task": {
+                    "anyOf": [
+                      {
+                        "exclusiveMinimum": 0,
+                        "type": "integer"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "error": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "exclusive": {
+                    "anyOf": [
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "gpus": {
+                    "anyOf": [
+                      {
+                        "exclusiveMinimum": 0,
+                        "type": "integer"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "gpus_per_node": {
+                    "anyOf": [
+                      {
+                        "exclusiveMinimum": 0,
+                        "type": "integer"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "hostfile": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "hosts": {
+                    "anyOf": [
+                      {
+                        "items": {
+                          "type": "string"
+                        },
+                        "minItems": 1,
+                        "type": "array"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "job_name": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "mode": {
+                    "default": "auto",
+                    "enum": [
+                      "auto",
+                      "local",
+                      "direct",
+                      "cluster",
+                      "scheduler",
+                      "hostfile"
+                    ],
+                    "type": "string"
+                  },
+                  "nodes": {
+                    "anyOf": [
+                      {
+                        "exclusiveMinimum": 0,
+                        "type": "integer"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "output": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "partition": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "qos": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "tasks": {
+                    "anyOf": [
+                      {
+                        "exclusiveMinimum": 0,
+                        "type": "integer"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "tasks_per_node": {
+                    "anyOf": [
+                      {
+                        "exclusiveMinimum": 0,
+                        "type": "integer"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "walltime": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  }
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "pipeline_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "pipeline_id"
+        ],
+        "type": "object"
+      },
+      "name": "jarvis_create_pipeline",
+      "outputSchema": {
+        "additionalProperties": true,
+        "type": "object"
+      }
+    },
+    {
+      "_meta": {
+        "fastmcp": {
+          "tags": [
+            "jarvis",
+            "pipeline",
+            "user"
+          ]
+        }
+      },
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "readOnlyHint": true
+      },
+      "description": "Describe JARVIS packages, one package, a pipeline, or one pipeline step. For a named application, first use target='package' with its unique short name or fully qualified package name. Use target='package_search' for bounded discovery, then describe the selected canonical name. A package description returns package-owned configuration metadata and, when supported, a versioned deployment contract covering execution profiles, runtime requirements, readiness, and configuration rules. Package settings include only semantic parameters explicitly marked agent-visible. A setting may include a versioned input_binding descriptor for a declared local input that must be staged; callers must not infer file semantics from setting names or prose. Installer, scheduler, and other implementation controls remain owned by their dedicated contracts. target='packages' is an exhaustive legacy inventory with every agent-visible package setting and can be large; use it only when the complete installed catalog is explicitly required.",
+      "inputSchema": {
+        "additionalProperties": false,
+        "properties": {
+          "cursor": {
+            "anyOf": [
+              {
+                "maxLength": 1024,
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Opaque next-page cursor returned by an earlier package_search with the identical query."
+          },
+          "include_yaml": {
+            "default": true,
+            "description": "Include stored pipeline YAML only for target='pipeline'; ignored for package and package discovery targets.",
+            "type": "boolean"
+          },
+          "package_name": {
+            "anyOf": [
+              {
+                "maxLength": 512,
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Case-insensitive unique short name or fully qualified package name for target='package'. Ambiguous short names fail with canonical candidates."
+          },
+          "page_size": {
+            "default": 10,
+            "description": "Maximum summary matches returned by target='package_search'; bounded to 25.",
+            "maximum": 25,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "pipeline_id": {
+            "anyOf": [
+              {
+                "maxLength": 256,
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Pipeline identifier for target='pipeline' or target='step'."
+          },
+          "query": {
+            "anyOf": [
+              {
+                "maxLength": 256,
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Natural-language or package-name query required for target='package_search'."
+          },
+          "step_id": {
+            "anyOf": [
+              {
+                "maxLength": 256,
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Pipeline step identifier for target='step'."
+          },
+          "target": {
+            "description": "Object to describe. Prefer package for a named application and package_search for discovery; packages is exhaustive and unbounded.",
+            "enum": [
+              "packages",
+              "package_search",
+              "package",
+              "pipeline",
+              "step"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "target"
+        ],
+        "type": "object"
+      },
+      "name": "jarvis_describe",
+      "outputSchema": {
+        "properties": {
+          "result": {
+            "oneOf": [
+              {
+                "additionalProperties": false,
+                "description": "Exhaustive legacy package inventory result.",
+                "properties": {
+                  "packages": {
+                    "items": {
+                      "additionalProperties": false,
+                      "description": "Path-free package detail returned after selecting one canonical package.",
+                      "properties": {
+                        "deployment": {
+                          "anyOf": [
+                            {
+                              "additionalProperties": false,
+                              "description": "Versioned deployment and readiness contract supplied by JARVIS.",
+                              "properties": {
+                                "configuration_rules": {
+                                  "items": {
+                                    "additionalProperties": false,
+                                    "description": "Conditional requirement over canonical package configuration settings.",
+                                    "properties": {
+                                      "description": {
+                                        "type": "string"
+                                      },
+                                      "requires": {
+                                        "items": {
+                                          "additionalProperties": false,
+                                          "description": "One package-owned predicate over a canonical configuration setting.",
+                                          "properties": {
+                                            "operator": {
+                                              "enum": [
+                                                "equals",
+                                                "greater_than",
+                                                "is_empty",
+                                                "is_not_empty"
+                                              ],
+                                              "type": "string"
+                                            },
+                                            "parameter": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "string"
+                                                },
+                                                {
+                                                  "type": "integer"
+                                                },
+                                                {
+                                                  "type": "number"
+                                                },
+                                                {
+                                                  "type": "boolean"
+                                                },
+                                                {
+                                                  "type": "null"
+                                                }
+                                              ],
+                                              "default": null
+                                            }
+                                          },
+                                          "required": [
+                                            "parameter",
+                                            "operator"
+                                          ],
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "when": {
+                                        "items": {
+                                          "additionalProperties": false,
+                                          "description": "One package-owned predicate over a canonical configuration setting.",
+                                          "properties": {
+                                            "operator": {
+                                              "enum": [
+                                                "equals",
+                                                "greater_than",
+                                                "is_empty",
+                                                "is_not_empty"
+                                              ],
+                                              "type": "string"
+                                            },
+                                            "parameter": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "string"
+                                                },
+                                                {
+                                                  "type": "integer"
+                                                },
+                                                {
+                                                  "type": "number"
+                                                },
+                                                {
+                                                  "type": "boolean"
+                                                },
+                                                {
+                                                  "type": "null"
+                                                }
+                                              ],
+                                              "default": null
+                                            }
+                                          },
+                                          "required": [
+                                            "parameter",
+                                            "operator"
+                                          ],
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "required": [
+                                      "when",
+                                      "requires",
+                                      "description"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                "execution_profiles": {
+                                  "items": {
+                                    "additionalProperties": false,
+                                    "description": "Package-owned execution kind, applicability, requirements, and readiness.",
+                                    "properties": {
+                                      "description": {
+                                        "anyOf": [
+                                          {
+                                            "type": "string"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ],
+                                        "default": null
+                                      },
+                                      "execution_kind": {
+                                        "enum": [
+                                          "batch",
+                                          "service"
+                                        ],
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "readiness": {
+                                        "additionalProperties": false,
+                                        "description": "Observable condition that makes one execution profile ready.",
+                                        "properties": {
+                                          "capability": {
+                                            "anyOf": [
+                                              {
+                                                "type": "string"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ],
+                                            "default": null
+                                          },
+                                          "condition": {
+                                            "type": "string"
+                                          },
+                                          "mechanism": {
+                                            "enum": [
+                                              "process_exit",
+                                              "progress_event",
+                                              "service_runtime"
+                                            ],
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "mechanism",
+                                          "condition"
+                                        ],
+                                        "type": "object"
+                                      },
+                                      "runtime_requirements": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "when": {
+                                        "items": {
+                                          "additionalProperties": false,
+                                          "description": "One package-owned predicate over a canonical configuration setting.",
+                                          "properties": {
+                                            "operator": {
+                                              "enum": [
+                                                "equals",
+                                                "greater_than",
+                                                "is_empty",
+                                                "is_not_empty"
+                                              ],
+                                              "type": "string"
+                                            },
+                                            "parameter": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "string"
+                                                },
+                                                {
+                                                  "type": "integer"
+                                                },
+                                                {
+                                                  "type": "number"
+                                                },
+                                                {
+                                                  "type": "boolean"
+                                                },
+                                                {
+                                                  "type": "null"
+                                                }
+                                              ],
+                                              "default": null
+                                            }
+                                          },
+                                          "required": [
+                                            "parameter",
+                                            "operator"
+                                          ],
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "required": [
+                                      "name",
+                                      "execution_kind",
+                                      "when",
+                                      "runtime_requirements",
+                                      "readiness"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                "package": {
+                                  "type": "string"
+                                },
+                                "runtime_requirements": {
+                                  "items": {
+                                    "additionalProperties": false,
+                                    "description": "Runtime capabilities and provider resolutions owned by a package.",
+                                    "properties": {
+                                      "available_capabilities": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "description": {
+                                        "type": "string"
+                                      },
+                                      "id": {
+                                        "type": "string"
+                                      },
+                                      "provider_resolutions": {
+                                        "items": {
+                                          "additionalProperties": false,
+                                          "description": "One provider and query capable of resolving a runtime requirement.",
+                                          "properties": {
+                                            "provider": {
+                                              "type": "string"
+                                            },
+                                            "query": {
+                                              "additionalProperties": false,
+                                              "description": "Provider-neutral query that can resolve one runtime requirement.",
+                                              "properties": {
+                                                "kind": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "kind",
+                                                "value"
+                                              ],
+                                              "type": "object"
+                                            }
+                                          },
+                                          "required": [
+                                            "provider",
+                                            "query"
+                                          ],
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "required_capabilities": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "status": {
+                                        "additionalProperties": false,
+                                        "description": "Package observation of whether a runtime requirement can be used.",
+                                        "properties": {
+                                          "reason_code": {
+                                            "type": "string"
+                                          },
+                                          "state": {
+                                            "enum": [
+                                              "ready",
+                                              "unavailable",
+                                              "unknown"
+                                            ],
+                                            "type": "string"
+                                          },
+                                          "usable": {
+                                            "anyOf": [
+                                              {
+                                                "type": "boolean"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "required": [
+                                          "state",
+                                          "usable",
+                                          "reason_code"
+                                        ],
+                                        "type": "object"
+                                      }
+                                    },
+                                    "required": [
+                                      "id",
+                                      "description",
+                                      "required_capabilities",
+                                      "available_capabilities",
+                                      "status",
+                                      "provider_resolutions"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                "schema_version": {
+                                  "const": "jarvis.package-deployment.v1",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "schema_version",
+                                "package",
+                                "execution_profiles",
+                                "runtime_requirements",
+                                "configuration_rules"
+                              ],
+                              "type": "object"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "description": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "schema_version": {
+                          "const": "jarvis.package-description.v1",
+                          "type": "string"
+                        },
+                        "settings": {
+                          "anyOf": [
+                            {
+                              "items": {
+                                "additionalProperties": false,
+                                "description": "One package parser setting with truthful default and null semantics.",
+                                "properties": {
+                                  "aliases": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "choices": {
+                                    "items": {},
+                                    "type": "array"
+                                  },
+                                  "default": {},
+                                  "description": {
+                                    "type": "string"
+                                  },
+                                  "input_binding": {
+                                    "additionalProperties": false,
+                                    "description": "Declared client-local input that must be staged before package use.",
+                                    "properties": {
+                                      "kind": {
+                                        "const": "local_file",
+                                        "type": "string"
+                                      },
+                                      "schema_version": {
+                                        "const": "jarvis.configuration-input-binding.v1",
+                                        "type": "string"
+                                      },
+                                      "structure": {
+                                        "const": "regular_file",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "schema_version",
+                                      "kind",
+                                      "structure"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "nullable": {
+                                    "type": "boolean"
+                                  },
+                                  "required": {
+                                    "type": "boolean"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name",
+                                  "required",
+                                  "nullable"
+                                ],
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "short_name": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "schema_version",
+                        "name",
+                        "short_name",
+                        "description",
+                        "deployment"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "target": {
+                    "const": "packages",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "target",
+                  "packages"
+                ],
+                "type": "object"
+              },
+              {
+                "additionalProperties": false,
+                "description": "Bounded package search page.",
+                "properties": {
+                  "inventory_revision": {
+                    "type": "string"
+                  },
+                  "next_cursor": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "packages": {
+                    "items": {
+                      "additionalProperties": false,
+                      "description": "Bounded package identity returned during search.",
+                      "properties": {
+                        "description": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "repository": {
+                          "type": "string"
+                        },
+                        "short_name": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name",
+                        "short_name",
+                        "repository"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "query": {
+                    "type": "string"
+                  },
+                  "returned_count": {
+                    "type": "integer"
+                  },
+                  "schema_version": {
+                    "const": "jarvis.package-search.v1",
+                    "type": "string"
+                  },
+                  "target": {
+                    "const": "package_search",
+                    "type": "string"
+                  },
+                  "total_matches": {
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "schema_version",
+                  "target",
+                  "query",
+                  "inventory_revision",
+                  "packages",
+                  "total_matches",
+                  "returned_count",
+                  "next_cursor"
+                ],
+                "type": "object"
+              },
+              {
+                "additionalProperties": false,
+                "description": "Exact package description result.",
+                "properties": {
+                  "package": {
+                    "additionalProperties": false,
+                    "description": "Path-free package detail returned after selecting one canonical package.",
+                    "properties": {
+                      "deployment": {
+                        "anyOf": [
+                          {
+                            "additionalProperties": false,
+                            "description": "Versioned deployment and readiness contract supplied by JARVIS.",
+                            "properties": {
+                              "configuration_rules": {
+                                "items": {
+                                  "additionalProperties": false,
+                                  "description": "Conditional requirement over canonical package configuration settings.",
+                                  "properties": {
+                                    "description": {
+                                      "type": "string"
+                                    },
+                                    "requires": {
+                                      "items": {
+                                        "additionalProperties": false,
+                                        "description": "One package-owned predicate over a canonical configuration setting.",
+                                        "properties": {
+                                          "operator": {
+                                            "enum": [
+                                              "equals",
+                                              "greater_than",
+                                              "is_empty",
+                                              "is_not_empty"
+                                            ],
+                                            "type": "string"
+                                          },
+                                          "parameter": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "anyOf": [
+                                              {
+                                                "type": "string"
+                                              },
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "number"
+                                              },
+                                              {
+                                                "type": "boolean"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ],
+                                            "default": null
+                                          }
+                                        },
+                                        "required": [
+                                          "parameter",
+                                          "operator"
+                                        ],
+                                        "type": "object"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "when": {
+                                      "items": {
+                                        "additionalProperties": false,
+                                        "description": "One package-owned predicate over a canonical configuration setting.",
+                                        "properties": {
+                                          "operator": {
+                                            "enum": [
+                                              "equals",
+                                              "greater_than",
+                                              "is_empty",
+                                              "is_not_empty"
+                                            ],
+                                            "type": "string"
+                                          },
+                                          "parameter": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "anyOf": [
+                                              {
+                                                "type": "string"
+                                              },
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "number"
+                                              },
+                                              {
+                                                "type": "boolean"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ],
+                                            "default": null
+                                          }
+                                        },
+                                        "required": [
+                                          "parameter",
+                                          "operator"
+                                        ],
+                                        "type": "object"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "required": [
+                                    "when",
+                                    "requires",
+                                    "description"
+                                  ],
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "execution_profiles": {
+                                "items": {
+                                  "additionalProperties": false,
+                                  "description": "Package-owned execution kind, applicability, requirements, and readiness.",
+                                  "properties": {
+                                    "description": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ],
+                                      "default": null
+                                    },
+                                    "execution_kind": {
+                                      "enum": [
+                                        "batch",
+                                        "service"
+                                      ],
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "readiness": {
+                                      "additionalProperties": false,
+                                      "description": "Observable condition that makes one execution profile ready.",
+                                      "properties": {
+                                        "capability": {
+                                          "anyOf": [
+                                            {
+                                              "type": "string"
+                                            },
+                                            {
+                                              "type": "null"
+                                            }
+                                          ],
+                                          "default": null
+                                        },
+                                        "condition": {
+                                          "type": "string"
+                                        },
+                                        "mechanism": {
+                                          "enum": [
+                                            "process_exit",
+                                            "progress_event",
+                                            "service_runtime"
+                                          ],
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "mechanism",
+                                        "condition"
+                                      ],
+                                      "type": "object"
+                                    },
+                                    "runtime_requirements": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "when": {
+                                      "items": {
+                                        "additionalProperties": false,
+                                        "description": "One package-owned predicate over a canonical configuration setting.",
+                                        "properties": {
+                                          "operator": {
+                                            "enum": [
+                                              "equals",
+                                              "greater_than",
+                                              "is_empty",
+                                              "is_not_empty"
+                                            ],
+                                            "type": "string"
+                                          },
+                                          "parameter": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "anyOf": [
+                                              {
+                                                "type": "string"
+                                              },
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "number"
+                                              },
+                                              {
+                                                "type": "boolean"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ],
+                                            "default": null
+                                          }
+                                        },
+                                        "required": [
+                                          "parameter",
+                                          "operator"
+                                        ],
+                                        "type": "object"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "required": [
+                                    "name",
+                                    "execution_kind",
+                                    "when",
+                                    "runtime_requirements",
+                                    "readiness"
+                                  ],
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "package": {
+                                "type": "string"
+                              },
+                              "runtime_requirements": {
+                                "items": {
+                                  "additionalProperties": false,
+                                  "description": "Runtime capabilities and provider resolutions owned by a package.",
+                                  "properties": {
+                                    "available_capabilities": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "description": {
+                                      "type": "string"
+                                    },
+                                    "id": {
+                                      "type": "string"
+                                    },
+                                    "provider_resolutions": {
+                                      "items": {
+                                        "additionalProperties": false,
+                                        "description": "One provider and query capable of resolving a runtime requirement.",
+                                        "properties": {
+                                          "provider": {
+                                            "type": "string"
+                                          },
+                                          "query": {
+                                            "additionalProperties": false,
+                                            "description": "Provider-neutral query that can resolve one runtime requirement.",
+                                            "properties": {
+                                              "kind": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "kind",
+                                              "value"
+                                            ],
+                                            "type": "object"
+                                          }
+                                        },
+                                        "required": [
+                                          "provider",
+                                          "query"
+                                        ],
+                                        "type": "object"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "required_capabilities": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "status": {
+                                      "additionalProperties": false,
+                                      "description": "Package observation of whether a runtime requirement can be used.",
+                                      "properties": {
+                                        "reason_code": {
+                                          "type": "string"
+                                        },
+                                        "state": {
+                                          "enum": [
+                                            "ready",
+                                            "unavailable",
+                                            "unknown"
+                                          ],
+                                          "type": "string"
+                                        },
+                                        "usable": {
+                                          "anyOf": [
+                                            {
+                                              "type": "boolean"
+                                            },
+                                            {
+                                              "type": "null"
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "required": [
+                                        "state",
+                                        "usable",
+                                        "reason_code"
+                                      ],
+                                      "type": "object"
+                                    }
+                                  },
+                                  "required": [
+                                    "id",
+                                    "description",
+                                    "required_capabilities",
+                                    "available_capabilities",
+                                    "status",
+                                    "provider_resolutions"
+                                  ],
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "schema_version": {
+                                "const": "jarvis.package-deployment.v1",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "schema_version",
+                              "package",
+                              "execution_profiles",
+                              "runtime_requirements",
+                              "configuration_rules"
+                            ],
+                            "type": "object"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "description": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "schema_version": {
+                        "const": "jarvis.package-description.v1",
+                        "type": "string"
+                      },
+                      "settings": {
+                        "anyOf": [
+                          {
+                            "items": {
+                              "additionalProperties": false,
+                              "description": "One package parser setting with truthful default and null semantics.",
+                              "properties": {
+                                "aliases": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "choices": {
+                                  "items": {},
+                                  "type": "array"
+                                },
+                                "default": {},
+                                "description": {
+                                  "type": "string"
+                                },
+                                "input_binding": {
+                                  "additionalProperties": false,
+                                  "description": "Declared client-local input that must be staged before package use.",
+                                  "properties": {
+                                    "kind": {
+                                      "const": "local_file",
+                                      "type": "string"
+                                    },
+                                    "schema_version": {
+                                      "const": "jarvis.configuration-input-binding.v1",
+                                      "type": "string"
+                                    },
+                                    "structure": {
+                                      "const": "regular_file",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "schema_version",
+                                    "kind",
+                                    "structure"
+                                  ],
+                                  "type": "object"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "nullable": {
+                                  "type": "boolean"
+                                },
+                                "required": {
+                                  "type": "boolean"
+                                },
+                                "type": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name",
+                                "required",
+                                "nullable"
+                              ],
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ],
+                        "default": null
+                      },
+                      "short_name": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "schema_version",
+                      "name",
+                      "short_name",
+                      "description",
+                      "deployment"
+                    ],
+                    "type": "object"
+                  },
+                  "target": {
+                    "const": "package",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "target",
+                  "package"
+                ],
+                "type": "object"
+              },
+              {
+                "additionalProperties": false,
+                "description": "Stored pipeline snapshot result.",
+                "properties": {
+                  "pipeline": {
+                    "additionalProperties": true,
+                    "type": "object"
+                  },
+                  "target": {
+                    "const": "pipeline",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "target",
+                  "pipeline"
+                ],
+                "type": "object"
+              },
+              {
+                "additionalProperties": false,
+                "description": "Stored pipeline step and package configuration result.",
+                "properties": {
+                  "config": {
+                    "additionalProperties": true,
+                    "type": "object"
+                  },
+                  "step": {
+                    "additionalProperties": true,
+                    "type": "object"
+                  },
+                  "target": {
+                    "const": "step",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "target",
+                  "step",
+                  "config"
+                ],
+                "type": "object"
+              }
+            ]
+          }
+        },
+        "required": [
+          "result"
+        ],
+        "type": "object",
+        "x-fastmcp-wrap-result": true
+      }
+    },
+    {
+      "_meta": {
+        "fastmcp": {
+          "tags": [
+            "jarvis",
+            "pipeline",
+            "user"
+          ]
+        }
+      },
+      "annotations": {
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "readOnlyHint": false
+      },
+      "description": "Edit or remove a step in a JARVIS pipeline. Use operation='edit' with config, or operation='remove' without config.",
+      "inputSchema": {
+        "additionalProperties": false,
+        "properties": {
+          "config": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "operation": {
+            "default": "edit",
+            "enum": [
+              "edit",
+              "remove"
+            ],
+            "type": "string"
+          },
+          "pipeline_id": {
+            "type": "string"
+          },
+          "step_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "pipeline_id",
+          "step_id"
+        ],
+        "type": "object"
+      },
+      "name": "jarvis_edit_step",
+      "outputSchema": {
+        "additionalProperties": true,
+        "type": "object"
+      }
+    },
+    {
+      "_meta": {
+        "fastmcp": {
+          "tags": [
+            "execution",
+            "jarvis",
+            "pipeline",
+            "user"
+          ]
+        }
+      },
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "readOnlyHint": true
+      },
+      "description": "Query one JARVIS execution handle, durable lifecycle record, and runtime metadata. Progress is included by default and can be omitted. Set include_service_runtimes=true to include execution-owned network services; authenticated services expose only a non-secret bearer token SHA-256 fingerprint. Set artifacts to {} or filters to include one bounded artifact page; omit artifacts to avoid querying the artifact manifest.",
+      "inputSchema": {
+        "additionalProperties": false,
+        "properties": {
+          "artifacts": {
+            "anyOf": [
+              {
+                "additionalProperties": false,
+                "description": "Optional filters for one bounded page of execution artifacts.",
+                "properties": {
+                  "artifact_id": {
+                    "anyOf": [
+                      {
+                        "maxLength": 90,
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "Exact opaque JARVIS artifact ID filter."
+                  },
+                  "cursor": {
+                    "anyOf": [
+                      {
+                        "maxLength": 1024,
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "Opaque next-page cursor."
+                  },
+                  "package_id": {
+                    "anyOf": [
+                      {
+                        "maxLength": 256,
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "Exact JARVIS package alias filter."
+                  },
+                  "page_size": {
+                    "default": 50,
+                    "description": "Maximum artifacts to return in this page.",
+                    "maximum": 100,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "role": {
+                    "anyOf": [
+                      {
+                        "enum": [
+                          "intermediate",
+                          "output",
+                          "log",
+                          "checkpoint",
+                          "provenance",
+                          "validation"
+                        ],
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "state": {
+                    "anyOf": [
+                      {
+                        "enum": [
+                          "producing",
+                          "available",
+                          "finalized",
+                          "incomplete",
+                          "failed"
+                        ],
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  }
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "execution_id": {
+            "type": "string"
+          },
+          "include_progress": {
+            "default": true,
+            "type": "boolean"
+          },
+          "include_service_runtimes": {
+            "default": false,
+            "type": "boolean"
+          },
+          "pipeline_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "pipeline_id",
+          "execution_id"
+        ],
+        "type": "object"
+      },
+      "name": "jarvis_get_execution",
+      "outputSchema": {
+        "additionalProperties": false,
+        "description": "Frozen top-level result envelope for a selectable execution query.",
+        "properties": {
+          "artifact_page": {
+            "anyOf": [
+              {
+                "additionalProperties": false,
+                "description": "Bounded artifact page nested in a unified execution query.",
+                "properties": {
+                  "artifacts": {
+                    "items": {
+                      "additionalProperties": false,
+                      "description": "Current JARVIS-owned lifecycle observation for one generated artifact.",
+                      "properties": {
+                        "artifact_id": {
+                          "type": "string"
+                        },
+                        "checksum": {
+                          "type": "string"
+                        },
+                        "execution_id": {
+                          "type": "string"
+                        },
+                        "format": {
+                          "type": "string"
+                        },
+                        "kind": {
+                          "type": "string"
+                        },
+                        "location": {
+                          "additionalProperties": false,
+                          "description": "Transport-neutral location in a JARVIS artifact manifest.",
+                          "properties": {
+                            "kind": {
+                              "enum": [
+                                "execution_path",
+                                "cluster_path",
+                                "external_uri"
+                              ],
+                              "type": "string"
+                            },
+                            "value": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "value"
+                          ],
+                          "type": "object"
+                        },
+                        "logical_name": {
+                          "type": "string"
+                        },
+                        "media_type": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "metadata": {
+                          "additionalProperties": true,
+                          "type": "object"
+                        },
+                        "observed_at_epoch": {
+                          "type": "number"
+                        },
+                        "ownership": {
+                          "enum": [
+                            "execution",
+                            "external",
+                            "shared"
+                          ],
+                          "type": "string"
+                        },
+                        "package_id": {
+                          "type": "string"
+                        },
+                        "package_name": {
+                          "type": "string"
+                        },
+                        "revision": {
+                          "type": "integer"
+                        },
+                        "role": {
+                          "enum": [
+                            "intermediate",
+                            "output",
+                            "log",
+                            "checkpoint",
+                            "provenance",
+                            "validation"
+                          ],
+                          "type": "string"
+                        },
+                        "schema_version": {
+                          "const": "jarvis.artifact.v1",
+                          "type": "string"
+                        },
+                        "sequence": {
+                          "type": "integer"
+                        },
+                        "size_bytes": {
+                          "type": "integer"
+                        },
+                        "state": {
+                          "enum": [
+                            "producing",
+                            "available",
+                            "finalized",
+                            "incomplete",
+                            "failed"
+                          ],
+                          "type": "string"
+                        },
+                        "structure": {
+                          "enum": [
+                            "file",
+                            "directory",
+                            "collection",
+                            "stream"
+                          ],
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "schema_version",
+                        "package_name",
+                        "package_id",
+                        "execution_id",
+                        "artifact_id",
+                        "logical_name",
+                        "kind",
+                        "role",
+                        "structure",
+                        "ownership",
+                        "state",
+                        "revision",
+                        "sequence",
+                        "observed_at_epoch",
+                        "metadata"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "execution_id": {
+                    "type": "string"
+                  },
+                  "execution_state": {
+                    "enum": [
+                      "preparing",
+                      "scripted",
+                      "submitting",
+                      "submitted",
+                      "running",
+                      "completed",
+                      "failed",
+                      "canceled",
+                      "unknown"
+                    ],
+                    "type": "string"
+                  },
+                  "matching_artifact_count": {
+                    "type": "integer"
+                  },
+                  "next_cursor": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "pipeline_id": {
+                    "type": "string"
+                  },
+                  "producer_schema_version": {
+                    "const": "jarvis.execution.artifacts.v1",
+                    "type": "string"
+                  },
+                  "returned_artifact_count": {
+                    "type": "integer"
+                  },
+                  "terminal": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "producer_schema_version",
+                  "pipeline_id",
+                  "execution_id",
+                  "execution_state",
+                  "terminal",
+                  "artifacts",
+                  "matching_artifact_count",
+                  "returned_artifact_count",
+                  "next_cursor"
+                ],
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "execution_handle": {
+            "additionalProperties": false,
+            "description": "Stable JARVIS-CD execution-handle document.",
+            "properties": {
+              "cluster": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "execution_id": {
+                "type": "string"
+              },
+              "mode": {
+                "enum": [
+                  "direct",
+                  "scheduler"
+                ],
+                "type": "string"
+              },
+              "pipeline_id": {
+                "type": "string"
+              },
+              "scheduler_native_id": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "scheduler_provider": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "schema_version": {
+                "const": "jarvis.execution.handle.v1",
+                "type": "string"
+              }
+            },
+            "required": [
+              "schema_version",
+              "execution_id",
+              "pipeline_id",
+              "mode",
+              "scheduler_provider",
+              "scheduler_native_id",
+              "cluster"
+            ],
+            "type": "object"
+          },
+          "execution_id": {
+            "type": "string"
+          },
+          "execution_record": {
+            "additionalProperties": false,
+            "description": "Stable JARVIS-CD durable execution-record document.",
+            "properties": {
+              "cluster": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "created_at": {
+                "type": "string"
+              },
+              "error": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "execution_id": {
+                "type": "string"
+              },
+              "metadata": {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              "mode": {
+                "enum": [
+                  "direct",
+                  "scheduler"
+                ],
+                "type": "string"
+              },
+              "pipeline_id": {
+                "type": "string"
+              },
+              "pipeline_name": {
+                "type": "string"
+              },
+              "return_code": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "scheduler_native_id": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "scheduler_provider": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "schema_version": {
+                "const": "jarvis.execution.record.v1",
+                "type": "string"
+              },
+              "state": {
+                "enum": [
+                  "preparing",
+                  "scripted",
+                  "submitting",
+                  "submitted",
+                  "running",
+                  "completed",
+                  "failed",
+                  "canceled",
+                  "unknown"
+                ],
+                "type": "string"
+              },
+              "submitted": {
+                "type": "boolean"
+              },
+              "terminal": {
+                "type": "boolean"
+              },
+              "updated_at": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "schema_version",
+              "execution_id",
+              "pipeline_id",
+              "pipeline_name",
+              "mode",
+              "scheduler_provider",
+              "scheduler_native_id",
+              "cluster",
+              "state",
+              "submitted",
+              "terminal",
+              "created_at",
+              "updated_at",
+              "return_code",
+              "error",
+              "metadata"
+            ],
+            "type": "object"
+          },
+          "pipeline_id": {
+            "type": "string"
+          },
+          "progress": {
+            "anyOf": [
+              {
+                "additionalProperties": false,
+                "description": "Stable aggregate returned by JARVIS-CD's execution progress API.",
+                "properties": {
+                  "execution_id": {
+                    "maxLength": 256,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "execution_state": {
+                    "enum": [
+                      "preparing",
+                      "scripted",
+                      "submitting",
+                      "submitted",
+                      "running",
+                      "completed",
+                      "failed",
+                      "canceled",
+                      "unknown"
+                    ],
+                    "type": "string"
+                  },
+                  "packages": {
+                    "items": {
+                      "additionalProperties": false,
+                      "description": "Latest stable progress observation for one package alias.",
+                      "properties": {
+                        "event_count": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "latest": {
+                          "anyOf": [
+                            {
+                              "additionalProperties": false,
+                              "description": "One closed, JARVIS-owned package progress observation.",
+                              "properties": {
+                                "current": {
+                                  "anyOf": [
+                                    {
+                                      "minimum": 0,
+                                      "type": "number"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ],
+                                  "default": null
+                                },
+                                "determinate": {
+                                  "type": "boolean"
+                                },
+                                "execution_id": {
+                                  "maxLength": 256,
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "label": {
+                                  "maxLength": 256,
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "message": {
+                                  "anyOf": [
+                                    {
+                                      "maxLength": 4096,
+                                      "minLength": 1,
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ],
+                                  "default": null
+                                },
+                                "metadata": {
+                                  "additionalProperties": true,
+                                  "type": "object"
+                                },
+                                "observed_at_epoch": {
+                                  "minimum": 0,
+                                  "type": "number"
+                                },
+                                "package_id": {
+                                  "maxLength": 256,
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "package_name": {
+                                  "maxLength": 256,
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "schema_version": {
+                                  "const": "jarvis.progress.v1",
+                                  "type": "string"
+                                },
+                                "sequence": {
+                                  "minimum": 0,
+                                  "type": "integer"
+                                },
+                                "state": {
+                                  "enum": [
+                                    "pending",
+                                    "starting",
+                                    "running",
+                                    "ready",
+                                    "completed",
+                                    "failed",
+                                    "canceled"
+                                  ],
+                                  "type": "string"
+                                },
+                                "total": {
+                                  "anyOf": [
+                                    {
+                                      "exclusiveMinimum": 0,
+                                      "type": "number"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ],
+                                  "default": null
+                                },
+                                "unit": {
+                                  "anyOf": [
+                                    {
+                                      "maxLength": 256,
+                                      "minLength": 1,
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ],
+                                  "default": null
+                                }
+                              },
+                              "required": [
+                                "schema_version",
+                                "package_name",
+                                "package_id",
+                                "execution_id",
+                                "label",
+                                "state",
+                                "sequence",
+                                "observed_at_epoch",
+                                "determinate",
+                                "metadata"
+                              ],
+                              "type": "object"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "package_id": {
+                          "maxLength": 256,
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "package_name": {
+                          "maxLength": 256,
+                          "minLength": 1,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "package_id",
+                        "package_name",
+                        "event_count",
+                        "latest"
+                      ],
+                      "type": "object"
+                    },
+                    "maxItems": 4096,
+                    "type": "array"
+                  },
+                  "pipeline_id": {
+                    "maxLength": 256,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "schema_version": {
+                    "const": "jarvis.execution.progress.v1",
+                    "type": "string"
+                  },
+                  "terminal": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "schema_version",
+                  "execution_id",
+                  "pipeline_id",
+                  "execution_state",
+                  "terminal",
+                  "packages"
+                ],
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "runtime_metadata": {
+            "additionalProperties": true,
+            "type": "object"
+          },
+          "schema_version": {
+            "const": "clio-kit.jarvis-execution.v2",
+            "type": "string"
+          },
+          "service_runtimes": {
+            "anyOf": [
+              {
+                "additionalProperties": false,
+                "description": "Execution-bound current service runtimes returned by JARVIS.",
+                "properties": {
+                  "execution_id": {
+                    "maxLength": 256,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "execution_state": {
+                    "enum": [
+                      "preparing",
+                      "scripted",
+                      "submitting",
+                      "submitted",
+                      "running",
+                      "completed",
+                      "failed",
+                      "canceled",
+                      "unknown"
+                    ],
+                    "type": "string"
+                  },
+                  "pipeline_id": {
+                    "maxLength": 256,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "schema_version": {
+                    "const": "jarvis.execution.service-runtimes.v1",
+                    "type": "string"
+                  },
+                  "service_runtimes": {
+                    "items": {
+                      "oneOf": [
+                        {
+                          "additionalProperties": false,
+                          "description": "Released unauthenticated service-runtime v1 document.",
+                          "properties": {
+                            "command_path": {
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "dataset_descriptor": {
+                              "additionalProperties": false,
+                              "description": "Intrinsic, recipe-free dataset identity owned by JARVIS.",
+                              "properties": {
+                                "arrays": {
+                                  "items": {
+                                    "additionalProperties": false,
+                                    "description": "One intrinsic array exposed by a JARVIS-owned service.",
+                                    "properties": {
+                                      "association": {
+                                        "enum": [
+                                          "point",
+                                          "cell",
+                                          "field"
+                                        ],
+                                        "type": "string"
+                                      },
+                                      "components": {
+                                        "maximum": 64,
+                                        "minimum": 1,
+                                        "type": "integer"
+                                      },
+                                      "name": {
+                                        "maxLength": 512,
+                                        "minLength": 1,
+                                        "type": "string"
+                                      },
+                                      "units": {
+                                        "anyOf": [
+                                          {
+                                            "maxLength": 256,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ],
+                                        "default": null
+                                      }
+                                    },
+                                    "required": [
+                                      "name",
+                                      "association",
+                                      "components"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "maxItems": 256,
+                                  "type": "array"
+                                },
+                                "bounds": {
+                                  "anyOf": [
+                                    {
+                                      "items": {
+                                        "type": "number"
+                                      },
+                                      "maxItems": 6,
+                                      "minItems": 6,
+                                      "type": "array"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ],
+                                  "default": null
+                                },
+                                "dataset_id": {
+                                  "maxLength": 256,
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "fingerprint": {
+                                  "additionalProperties": false,
+                                  "description": "Canonical identity digest for one bounded dataset descriptor.",
+                                  "properties": {
+                                    "algorithm": {
+                                      "const": "sha256",
+                                      "type": "string"
+                                    },
+                                    "digest": {
+                                      "pattern": "^[0-9a-f]{64}$",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "algorithm",
+                                    "digest"
+                                  ],
+                                  "type": "object"
+                                },
+                                "format": {
+                                  "maxLength": 256,
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "kind": {
+                                  "maxLength": 256,
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "members": {
+                                  "items": {
+                                    "additionalProperties": false,
+                                    "description": "One ordered member in a JARVIS service dataset descriptor.",
+                                    "properties": {
+                                      "index": {
+                                        "minimum": 0,
+                                        "type": "integer"
+                                      },
+                                      "location": {
+                                        "maxLength": 4096,
+                                        "minLength": 1,
+                                        "type": "string"
+                                      },
+                                      "timestep": {
+                                        "anyOf": [
+                                          {
+                                            "type": "number"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ],
+                                        "default": null
+                                      }
+                                    },
+                                    "required": [
+                                      "index",
+                                      "location"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "maxItems": 512,
+                                  "minItems": 1,
+                                  "type": "array"
+                                },
+                                "schema_version": {
+                                  "const": "jarvis.dataset-descriptor.v1",
+                                  "type": "string"
+                                },
+                                "source_artifact": {
+                                  "anyOf": [
+                                    {
+                                      "additionalProperties": false,
+                                      "description": "Optional content identity of a JARVIS-generated source artifact.",
+                                      "properties": {
+                                        "artifact_id": {
+                                          "pattern": "^art_[A-Za-z0-9_-]{22,86}$",
+                                          "type": "string"
+                                        },
+                                        "sha256": {
+                                          "pattern": "^[0-9a-f]{64}$",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "artifact_id",
+                                        "sha256"
+                                      ],
+                                      "type": "object"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ]
+                                }
+                              },
+                              "required": [
+                                "schema_version",
+                                "dataset_id",
+                                "kind",
+                                "format",
+                                "members",
+                                "arrays",
+                                "fingerprint",
+                                "source_artifact"
+                              ],
+                              "type": "object"
+                            },
+                            "delivery_mode": {
+                              "const": "push",
+                              "type": "string"
+                            },
+                            "events_path": {
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "execution_id": {
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "health_path": {
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "host": {
+                              "maxLength": 255,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "lifecycle": {
+                              "enum": [
+                                "starting",
+                                "ready",
+                                "degraded",
+                                "stopping",
+                                "stopped",
+                                "failed"
+                              ],
+                              "type": "string"
+                            },
+                            "live_data_path": {
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "message": {
+                              "anyOf": [
+                                {
+                                  "maxLength": 4096,
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ],
+                              "default": null
+                            },
+                            "observed_at_epoch": {
+                              "minimum": 0,
+                              "type": "number"
+                            },
+                            "package_id": {
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "package_name": {
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "port": {
+                              "maximum": 65535,
+                              "minimum": 1,
+                              "type": "integer"
+                            },
+                            "protocol": {
+                              "enum": [
+                                "http",
+                                "https"
+                              ],
+                              "type": "string"
+                            },
+                            "revision": {
+                              "minimum": 1,
+                              "type": "integer"
+                            },
+                            "schema_version": {
+                              "const": "jarvis.service-runtime.v1",
+                              "type": "string"
+                            },
+                            "service_instance_id": {
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "state_path": {
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "execution_id",
+                            "package_name",
+                            "package_id",
+                            "service_instance_id",
+                            "revision",
+                            "lifecycle",
+                            "host",
+                            "port",
+                            "protocol",
+                            "health_path",
+                            "live_data_path",
+                            "events_path",
+                            "state_path",
+                            "command_path",
+                            "delivery_mode",
+                            "dataset_descriptor",
+                            "observed_at_epoch",
+                            "schema_version"
+                          ],
+                          "type": "object"
+                        },
+                        {
+                          "additionalProperties": false,
+                          "description": "Service-runtime v2 document with a non-secret capability fingerprint.",
+                          "properties": {
+                            "authorization": {
+                              "additionalProperties": false,
+                              "description": "Non-secret fingerprint for an execution-owned runtime capability.",
+                              "properties": {
+                                "scheme": {
+                                  "const": "bearer",
+                                  "type": "string"
+                                },
+                                "token_sha256": {
+                                  "maxLength": 64,
+                                  "minLength": 64,
+                                  "pattern": "^[0-9a-f]{64}$",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "scheme",
+                                "token_sha256"
+                              ],
+                              "type": "object"
+                            },
+                            "command_path": {
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "dataset_descriptor": {
+                              "additionalProperties": false,
+                              "description": "Intrinsic, recipe-free dataset identity owned by JARVIS.",
+                              "properties": {
+                                "arrays": {
+                                  "items": {
+                                    "additionalProperties": false,
+                                    "description": "One intrinsic array exposed by a JARVIS-owned service.",
+                                    "properties": {
+                                      "association": {
+                                        "enum": [
+                                          "point",
+                                          "cell",
+                                          "field"
+                                        ],
+                                        "type": "string"
+                                      },
+                                      "components": {
+                                        "maximum": 64,
+                                        "minimum": 1,
+                                        "type": "integer"
+                                      },
+                                      "name": {
+                                        "maxLength": 512,
+                                        "minLength": 1,
+                                        "type": "string"
+                                      },
+                                      "units": {
+                                        "anyOf": [
+                                          {
+                                            "maxLength": 256,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ],
+                                        "default": null
+                                      }
+                                    },
+                                    "required": [
+                                      "name",
+                                      "association",
+                                      "components"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "maxItems": 256,
+                                  "type": "array"
+                                },
+                                "bounds": {
+                                  "anyOf": [
+                                    {
+                                      "items": {
+                                        "type": "number"
+                                      },
+                                      "maxItems": 6,
+                                      "minItems": 6,
+                                      "type": "array"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ],
+                                  "default": null
+                                },
+                                "dataset_id": {
+                                  "maxLength": 256,
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "fingerprint": {
+                                  "additionalProperties": false,
+                                  "description": "Canonical identity digest for one bounded dataset descriptor.",
+                                  "properties": {
+                                    "algorithm": {
+                                      "const": "sha256",
+                                      "type": "string"
+                                    },
+                                    "digest": {
+                                      "pattern": "^[0-9a-f]{64}$",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "algorithm",
+                                    "digest"
+                                  ],
+                                  "type": "object"
+                                },
+                                "format": {
+                                  "maxLength": 256,
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "kind": {
+                                  "maxLength": 256,
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "members": {
+                                  "items": {
+                                    "additionalProperties": false,
+                                    "description": "One ordered member in a JARVIS service dataset descriptor.",
+                                    "properties": {
+                                      "index": {
+                                        "minimum": 0,
+                                        "type": "integer"
+                                      },
+                                      "location": {
+                                        "maxLength": 4096,
+                                        "minLength": 1,
+                                        "type": "string"
+                                      },
+                                      "timestep": {
+                                        "anyOf": [
+                                          {
+                                            "type": "number"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ],
+                                        "default": null
+                                      }
+                                    },
+                                    "required": [
+                                      "index",
+                                      "location"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "maxItems": 512,
+                                  "minItems": 1,
+                                  "type": "array"
+                                },
+                                "schema_version": {
+                                  "const": "jarvis.dataset-descriptor.v1",
+                                  "type": "string"
+                                },
+                                "source_artifact": {
+                                  "anyOf": [
+                                    {
+                                      "additionalProperties": false,
+                                      "description": "Optional content identity of a JARVIS-generated source artifact.",
+                                      "properties": {
+                                        "artifact_id": {
+                                          "pattern": "^art_[A-Za-z0-9_-]{22,86}$",
+                                          "type": "string"
+                                        },
+                                        "sha256": {
+                                          "pattern": "^[0-9a-f]{64}$",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "artifact_id",
+                                        "sha256"
+                                      ],
+                                      "type": "object"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ]
+                                }
+                              },
+                              "required": [
+                                "schema_version",
+                                "dataset_id",
+                                "kind",
+                                "format",
+                                "members",
+                                "arrays",
+                                "fingerprint",
+                                "source_artifact"
+                              ],
+                              "type": "object"
+                            },
+                            "delivery_mode": {
+                              "const": "push",
+                              "type": "string"
+                            },
+                            "events_path": {
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "execution_id": {
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "health_path": {
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "host": {
+                              "maxLength": 255,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "lifecycle": {
+                              "enum": [
+                                "starting",
+                                "ready",
+                                "degraded",
+                                "stopping",
+                                "stopped",
+                                "failed"
+                              ],
+                              "type": "string"
+                            },
+                            "live_data_path": {
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "message": {
+                              "anyOf": [
+                                {
+                                  "maxLength": 4096,
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ],
+                              "default": null
+                            },
+                            "observed_at_epoch": {
+                              "minimum": 0,
+                              "type": "number"
+                            },
+                            "package_id": {
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "package_name": {
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "port": {
+                              "maximum": 65535,
+                              "minimum": 1,
+                              "type": "integer"
+                            },
+                            "protocol": {
+                              "enum": [
+                                "http",
+                                "https"
+                              ],
+                              "type": "string"
+                            },
+                            "revision": {
+                              "minimum": 1,
+                              "type": "integer"
+                            },
+                            "schema_version": {
+                              "const": "jarvis.service-runtime.v2",
+                              "type": "string"
+                            },
+                            "service_instance_id": {
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "state_path": {
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "execution_id",
+                            "package_name",
+                            "package_id",
+                            "service_instance_id",
+                            "revision",
+                            "lifecycle",
+                            "host",
+                            "port",
+                            "protocol",
+                            "health_path",
+                            "live_data_path",
+                            "events_path",
+                            "state_path",
+                            "command_path",
+                            "delivery_mode",
+                            "dataset_descriptor",
+                            "observed_at_epoch",
+                            "schema_version",
+                            "authorization"
+                          ],
+                          "type": "object"
+                        }
+                      ]
+                    },
+                    "maxItems": 4096,
+                    "type": "array"
+                  },
+                  "terminal": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "schema_version",
+                  "execution_id",
+                  "pipeline_id",
+                  "execution_state",
+                  "terminal",
+                  "service_runtimes"
+                ],
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "schema_version",
+          "pipeline_id",
+          "execution_id",
+          "execution_handle",
+          "execution_record",
+          "runtime_metadata",
+          "progress",
+          "artifact_page",
+          "service_runtimes"
+        ],
+        "type": "object"
+      }
+    },
+    {
+      "_meta": {
+        "fastmcp": {
+          "tags": [
+            "jarvis",
+            "pipeline",
+            "user"
+          ]
+        }
+      },
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "readOnlyHint": false
+      },
+      "description": "Start a configured JARVIS pipeline and return its durable execution handle without waiting for workload completion. Optional execution intent selects local, cluster, or hostfile mode without exposing scheduler internals. For each runtime resolved with Spack, copy spack_locate.output.load_spec unchanged into one element of jarvis_run.input.spack_specs; do not derive an executable path from the Spack prefix. JARVIS resolves those specs into a filtered environment and persists it before direct or scheduler execution. Use jarvis_get_execution with the returned pipeline_id and execution_id to query lifecycle, progress, artifacts, and execution-owned service runtimes.",
+      "inputSchema": {
+        "additionalProperties": false,
+        "properties": {
+          "execution": {
+            "anyOf": [
+              {
+                "additionalProperties": false,
+                "description": "Validated, backend-neutral execution request for a JARVIS pipeline.",
+                "properties": {
+                  "account": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "cpus_per_task": {
+                    "anyOf": [
+                      {
+                        "exclusiveMinimum": 0,
+                        "type": "integer"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "error": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "exclusive": {
+                    "anyOf": [
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "gpus": {
+                    "anyOf": [
+                      {
+                        "exclusiveMinimum": 0,
+                        "type": "integer"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "gpus_per_node": {
+                    "anyOf": [
+                      {
+                        "exclusiveMinimum": 0,
+                        "type": "integer"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "hostfile": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "hosts": {
+                    "anyOf": [
+                      {
+                        "items": {
+                          "type": "string"
+                        },
+                        "minItems": 1,
+                        "type": "array"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "job_name": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "mode": {
+                    "default": "auto",
+                    "enum": [
+                      "auto",
+                      "local",
+                      "direct",
+                      "cluster",
+                      "scheduler",
+                      "hostfile"
+                    ],
+                    "type": "string"
+                  },
+                  "nodes": {
+                    "anyOf": [
+                      {
+                        "exclusiveMinimum": 0,
+                        "type": "integer"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "output": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "partition": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "qos": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "tasks": {
+                    "anyOf": [
+                      {
+                        "exclusiveMinimum": 0,
+                        "type": "integer"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "tasks_per_node": {
+                    "anyOf": [
+                      {
+                        "exclusiveMinimum": 0,
+                        "type": "integer"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "walltime": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  }
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "execution_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "pipeline_id": {
+            "type": "string"
+          },
+          "spack_specs": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Runtime identities supplied by Spack. Copy each spack_locate.output.load_spec unchanged into this list; do not pass spack_locate.output.prefix or an inferred executable path. JARVIS persists the resolved environment for the execution."
+          },
+          "submit": {
+            "default": true,
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "pipeline_id"
+        ],
+        "type": "object"
+      },
+      "name": "jarvis_run",
+      "outputSchema": {
+        "description": "Frozen top-level result envelope for ``jarvis_run``.",
+        "properties": {
+          "execution_handle": {
+            "description": "Stable JARVIS-CD execution-handle document.",
+            "properties": {
+              "cluster": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "execution_id": {
+                "type": "string"
+              },
+              "mode": {
+                "enum": [
+                  "direct",
+                  "scheduler"
+                ],
+                "type": "string"
+              },
+              "pipeline_id": {
+                "type": "string"
+              },
+              "scheduler_native_id": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "scheduler_provider": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "schema_version": {
+                "const": "jarvis.execution.handle.v1",
+                "type": "string"
+              }
+            },
+            "required": [
+              "schema_version",
+              "execution_id",
+              "pipeline_id",
+              "mode",
+              "scheduler_provider",
+              "scheduler_native_id",
+              "cluster"
+            ],
+            "type": "object"
+          },
+          "execution_id": {
+            "type": "string"
+          },
+          "execution_record": {
+            "description": "Stable JARVIS-CD durable execution-record document.",
+            "properties": {
+              "cluster": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "created_at": {
+                "type": "string"
+              },
+              "error": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "execution_id": {
+                "type": "string"
+              },
+              "metadata": {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              "mode": {
+                "enum": [
+                  "direct",
+                  "scheduler"
+                ],
+                "type": "string"
+              },
+              "pipeline_id": {
+                "type": "string"
+              },
+              "pipeline_name": {
+                "type": "string"
+              },
+              "return_code": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "scheduler_native_id": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "scheduler_provider": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "schema_version": {
+                "const": "jarvis.execution.record.v1",
+                "type": "string"
+              },
+              "state": {
+                "enum": [
+                  "preparing",
+                  "scripted",
+                  "submitting",
+                  "submitted",
+                  "running",
+                  "completed",
+                  "failed",
+                  "canceled",
+                  "unknown"
+                ],
+                "type": "string"
+              },
+              "submitted": {
+                "type": "boolean"
+              },
+              "terminal": {
+                "type": "boolean"
+              },
+              "updated_at": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "schema_version",
+              "execution_id",
+              "pipeline_id",
+              "pipeline_name",
+              "mode",
+              "scheduler_provider",
+              "scheduler_native_id",
+              "cluster",
+              "state",
+              "submitted",
+              "terminal",
+              "created_at",
+              "updated_at",
+              "return_code",
+              "error",
+              "metadata"
+            ],
+            "type": "object"
+          },
+          "mode": {
+            "enum": [
+              "direct",
+              "scheduler"
+            ],
+            "type": "string"
+          },
+          "pipeline_id": {
+            "type": "string"
+          },
+          "progress": {
+            "additionalProperties": false,
+            "description": "Stable aggregate returned by JARVIS-CD's execution progress API.",
+            "properties": {
+              "execution_id": {
+                "maxLength": 256,
+                "minLength": 1,
+                "type": "string"
+              },
+              "execution_state": {
+                "enum": [
+                  "preparing",
+                  "scripted",
+                  "submitting",
+                  "submitted",
+                  "running",
+                  "completed",
+                  "failed",
+                  "canceled",
+                  "unknown"
+                ],
+                "type": "string"
+              },
+              "packages": {
+                "items": {
+                  "additionalProperties": false,
+                  "description": "Latest stable progress observation for one package alias.",
+                  "properties": {
+                    "event_count": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "latest": {
+                      "anyOf": [
+                        {
+                          "additionalProperties": false,
+                          "description": "One closed, JARVIS-owned package progress observation.",
+                          "properties": {
+                            "current": {
+                              "anyOf": [
+                                {
+                                  "minimum": 0,
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ],
+                              "default": null
+                            },
+                            "determinate": {
+                              "type": "boolean"
+                            },
+                            "execution_id": {
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "label": {
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "message": {
+                              "anyOf": [
+                                {
+                                  "maxLength": 4096,
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ],
+                              "default": null
+                            },
+                            "metadata": {
+                              "additionalProperties": true,
+                              "type": "object"
+                            },
+                            "observed_at_epoch": {
+                              "minimum": 0,
+                              "type": "number"
+                            },
+                            "package_id": {
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "package_name": {
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "schema_version": {
+                              "const": "jarvis.progress.v1",
+                              "type": "string"
+                            },
+                            "sequence": {
+                              "minimum": 0,
+                              "type": "integer"
+                            },
+                            "state": {
+                              "enum": [
+                                "pending",
+                                "starting",
+                                "running",
+                                "ready",
+                                "completed",
+                                "failed",
+                                "canceled"
+                              ],
+                              "type": "string"
+                            },
+                            "total": {
+                              "anyOf": [
+                                {
+                                  "exclusiveMinimum": 0,
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ],
+                              "default": null
+                            },
+                            "unit": {
+                              "anyOf": [
+                                {
+                                  "maxLength": 256,
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ],
+                              "default": null
+                            }
+                          },
+                          "required": [
+                            "schema_version",
+                            "package_name",
+                            "package_id",
+                            "execution_id",
+                            "label",
+                            "state",
+                            "sequence",
+                            "observed_at_epoch",
+                            "determinate",
+                            "metadata"
+                          ],
+                          "type": "object"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "package_id": {
+                      "maxLength": 256,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "package_name": {
+                      "maxLength": 256,
+                      "minLength": 1,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "package_id",
+                    "package_name",
+                    "event_count",
+                    "latest"
+                  ],
+                  "type": "object"
+                },
+                "maxItems": 4096,
+                "type": "array"
+              },
+              "pipeline_id": {
+                "maxLength": 256,
+                "minLength": 1,
+                "type": "string"
+              },
+              "schema_version": {
+                "const": "jarvis.execution.progress.v1",
+                "type": "string"
+              },
+              "terminal": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "schema_version",
+              "execution_id",
+              "pipeline_id",
+              "execution_state",
+              "terminal",
+              "packages"
+            ],
+            "type": "object"
+          },
+          "runtime_metadata": {
+            "additionalProperties": true,
+            "type": "object"
+          },
+          "scheduler": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "schema_version": {
+            "const": "clio-kit.jarvis-run.v1",
+            "type": "string"
+          },
+          "script_path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "status": {
+            "enum": [
+              "preparing",
+              "scripted",
+              "submitting",
+              "submitted",
+              "running",
+              "completed",
+              "failed",
+              "canceled",
+              "unknown"
+            ],
+            "type": "string"
+          },
+          "wait": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "schema_version",
+          "pipeline_id",
+          "execution_id",
+          "status",
+          "mode",
+          "scheduler",
+          "script_path",
+          "wait",
+          "execution_handle",
+          "execution_record",
+          "progress",
+          "runtime_metadata"
+        ],
+        "type": "object"
+      }
+    }
+  ],
+  "wire_sha256": "c69db36bda5d1cc97043d7b7cee88cabcf044d506865046537e0fb17ab0b2023"
+}

--- a/src/clio_kit/_mcp_contracts/spack-user-v2.1.json
+++ b/src/clio_kit/_mcp_contracts/spack-user-v2.1.json
@@ -1,7 +1,7 @@
 {
   "canonicalization": "json-sort-keys-compact-utf8-v1",
   "contract_id": "clio-kit-spack-user-v2.1",
-  "contract_sha256": "cc90789227aa0baea99d0e0379b320811c1dbd40c7fa66877d372309201be1c2",
+  "contract_sha256": "f1a62d96179012975f763402446571146e04e519f98df30583f9800f233216fc",
   "profile": "user",
   "projection": "mcp-agent-tool-schema-v1",
   "schema_version": "clio-kit.mcp-user-contract.v1",
@@ -311,7 +311,7 @@
         "openWorldHint": false,
         "readOnlyHint": true
       },
-      "description": "Resolve one unique installed Spack spec and return its exact prefix. An absent package returns the structured not_installed error.",
+      "description": "Resolve one unique installed Spack spec. Copy spack_locate.output.load_spec unchanged into one element of jarvis_run.input.spack_specs; do not derive or pass an executable path from the returned prefix. An absent package returns the structured not_installed error.",
       "inputSchema": {
         "additionalProperties": false,
         "properties": {
@@ -330,6 +330,7 @@
         "description": "Unique installed package and its exact prefix.",
         "properties": {
           "load_spec": {
+            "description": "Exact runtime identity for JARVIS. Copy this value unchanged from spack_locate.output.load_spec into one element of jarvis_run.input.spack_specs.",
             "type": "string"
           },
           "operation": {
@@ -416,5 +417,5 @@
       }
     }
   ],
-  "wire_sha256": "5f1d3aaf1d7311df84d9b25a66c3ed1987f3b84799658eaf8d9ccbbb79485ed2"
+  "wire_sha256": "e06bfa71153e19ea44f03ed55f03873bc643f42b4b25b96788c02892df719da8"
 }

--- a/src/clio_kit/mcp_contracts.py
+++ b/src/clio_kit/mcp_contracts.py
@@ -810,9 +810,19 @@ def _validate_required_surface(spec: UserContractSpec, tools: Sequence[JSON]) ->
             raise ContractGenerationError("spack_locate must publish outputSchema")
         properties = locate_output.get("properties")
         required = locate_output.get("required")
+        load_spec = (
+            properties.get("load_spec") if isinstance(properties, dict) else None
+        )
+        load_spec_description = (
+            load_spec.get("description") if isinstance(load_spec, dict) else None
+        )
         if (
             not isinstance(properties, dict)
-            or properties.get("load_spec") != {"type": "string"}
+            or not isinstance(load_spec, dict)
+            or load_spec.get("type") != "string"
+            or not isinstance(load_spec_description, str)
+            or "spack_locate.output.load_spec" not in load_spec_description
+            or "jarvis_run.input.spack_specs" not in load_spec_description
             or not isinstance(required, list)
             or "load_spec" not in required
         ):

--- a/src/clio_kit/mcp_contracts.py
+++ b/src/clio_kit/mcp_contracts.py
@@ -112,8 +112,8 @@ class UserContractSpec:
 
 USER_CONTRACT_SPECS: Final = (
     UserContractSpec(
-        contract_id="clio-kit-jarvis-user-v3.5",
-        artifact_name="jarvis-user-v3.5.json",
+        contract_id="clio-kit-jarvis-user-v3.6",
+        artifact_name="jarvis-user-v3.6.json",
         server_name="jarvis",
         distribution_name="jarvis-mcp",
         entry_command="jarvis-mcp",
@@ -176,6 +176,7 @@ HISTORICAL_USER_CONTRACT_ARTIFACTS: Final = (
     "jarvis-user-v3.2.json",
     "jarvis-user-v3.3.json",
     "jarvis-user-v3.4.json",
+    "jarvis-user-v3.5.json",
     "scientific-catalog-user-v1.json",
     "spack-user-v2.json",
 )

--- a/tests/test_generate_server_json_contract.py
+++ b/tests/test_generate_server_json_contract.py
@@ -152,7 +152,7 @@ def test_jarvis_current_contract_matches_registry_package_and_capability() -> No
         r"clio-kit-jarvis-user-v(?P<major>\d+)\.(?P<minor>\d+)",
         current_contract["contract_id"],
     )
-    assert current_contract["contract_id"] == "clio-kit-jarvis-user-v3.5"
+    assert current_contract["contract_id"] == "clio-kit-jarvis-user-v3.6"
     assert contract_match is not None
     contract_major_minor = (
         int(contract_match.group("major")),

--- a/tests/test_mcp_user_contracts.py
+++ b/tests/test_mcp_user_contracts.py
@@ -74,7 +74,7 @@ def test_contract_probe_uses_a_fresh_isolated_child_environment(
     ("contract_id", "expected_names"),
     [
         (
-            "clio-kit-jarvis-user-v3.5",
+            "clio-kit-jarvis-user-v3.6",
             {
                 "jarvis_create_pipeline",
                 "jarvis_describe",
@@ -124,25 +124,30 @@ def test_shipped_contract_digest_covers_exact_user_surface(
 
 def test_previous_jarvis_contracts_remain_loadable_by_exact_identity() -> None:
     """JARVIS contract revisions do not erase released evidence."""
-    previous = load_mcp_user_contract("clio-kit-jarvis-user-v3.4")
+    previous = load_mcp_user_contract("clio-kit-jarvis-user-v3.5")
 
-    assert previous["contract_id"] == "clio-kit-jarvis-user-v3.4"
+    assert previous["contract_id"] == "clio-kit-jarvis-user-v3.5"
     assert previous["contract_sha256"] == (
+        "9933815ca7ee913d56a7cb1081d7702474bc984efcc97bf16434980172d0469d"
+    )
+    older = load_mcp_user_contract("clio-kit-jarvis-user-v3.4")
+    assert older["contract_id"] == "clio-kit-jarvis-user-v3.4"
+    assert older["contract_sha256"] == (
         "52bfe1d416e674d120f200e502ded2197ee27219c26891a22c6c33ba917d5696"
     )
-    older = load_mcp_user_contract("clio-kit-jarvis-user-v3.3")
-    assert older["contract_id"] == "clio-kit-jarvis-user-v3.3"
-    assert older["contract_sha256"] == (
+    even_older = load_mcp_user_contract("clio-kit-jarvis-user-v3.3")
+    assert even_older["contract_id"] == "clio-kit-jarvis-user-v3.3"
+    assert even_older["contract_sha256"] == (
         "0993ee9b2ee9b3c2b021a3967d9221199c3a6be50d726d4b125812e6b1148115"
     )
-    even_older = load_mcp_user_contract("clio-kit-jarvis-user-v3.2")
-    assert even_older["contract_id"] == "clio-kit-jarvis-user-v3.2"
-    assert even_older["contract_sha256"] == (
+    earlier = load_mcp_user_contract("clio-kit-jarvis-user-v3.2")
+    assert earlier["contract_id"] == "clio-kit-jarvis-user-v3.2"
+    assert earlier["contract_sha256"] == (
         "12f6d349c9d44d8ce3594943dcd4018ec9b6e01ebb0e59d468bb1bb783a1ad5d"
     )
-    earlier = load_mcp_user_contract("clio-kit-jarvis-user-v3.1")
-    assert earlier["contract_id"] == "clio-kit-jarvis-user-v3.1"
-    assert earlier["contract_sha256"] == (
+    oldest_minor = load_mcp_user_contract("clio-kit-jarvis-user-v3.1")
+    assert oldest_minor["contract_id"] == "clio-kit-jarvis-user-v3.1"
+    assert oldest_minor["contract_sha256"] == (
         "adc7756025fbcc90b0695bd4eaac00bda5c6cff4eb2f248fd7be263bd90b9b8b"
     )
     oldest = load_mcp_user_contract("clio-kit-jarvis-user-v3")
@@ -268,7 +273,7 @@ def test_spack_install_contract_exposes_explicit_concretization_modes() -> None:
 
 def test_jarvis_contract_combines_mutations_and_execution_observation() -> None:
     """JARVIS gives agents one mutation and one durable observation semantic."""
-    artifact = load_mcp_user_contract("clio-kit-jarvis-user-v3.5")
+    artifact = load_mcp_user_contract("clio-kit-jarvis-user-v3.6")
     tools = {
         cast(str, tool["name"]): cast(JSON, tool)
         for tool in cast(list[JSON], artifact["tools"])
@@ -306,6 +311,33 @@ def test_jarvis_contract_combines_mutations_and_execution_observation() -> None:
     assert describe_properties["query"]["description"].endswith(
         "target='package_search'."
     )
+    describe_output = cast(JSON, describe["outputSchema"])
+    describe_result = cast(JSON, describe_output["properties"])["result"]
+    describe_variants = cast(list[JSON], cast(JSON, describe_result)["oneOf"])
+    package_variant = next(
+        variant
+        for variant in describe_variants
+        if cast(JSON, variant["properties"])["target"]
+        == {"const": "package", "type": "string"}
+    )
+    package_schema = cast(JSON, cast(JSON, package_variant["properties"])["package"])
+    package_properties = cast(JSON, package_schema["properties"])
+    settings_options = cast(
+        list[JSON], cast(JSON, package_properties["settings"])["anyOf"]
+    )
+    settings = next(option for option in settings_options if "items" in option)
+    setting = cast(JSON, settings["items"])
+    input_binding = cast(JSON, cast(JSON, setting["properties"])["input_binding"])
+    assert input_binding["additionalProperties"] is False
+    assert input_binding["required"] == ["schema_version", "kind", "structure"]
+    assert input_binding["properties"] == {
+        "kind": {"const": "local_file", "type": "string"},
+        "schema_version": {
+            "const": "jarvis.configuration-input-binding.v1",
+            "type": "string",
+        },
+        "structure": {"const": "regular_file", "type": "string"},
+    }
     add_step = cast(JSON, tools["jarvis_add_step"])
     add_input = cast(JSON, add_step["inputSchema"])
     add_properties = cast(JSON, add_input["properties"])
@@ -633,6 +665,7 @@ def test_contract_cli_lists_and_prints_verified_artifacts() -> None:
     shown = runner.invoke(main, ["mcp-contract", "clio-kit-spack-user-v2.1"])
 
     assert listed.exit_code == 0, listed.output
+    assert "clio-kit-jarvis-user-v3.6" in listed.output
     assert "clio-kit-jarvis-user-v3.5" in listed.output
     assert "clio-kit-jarvis-user-v3.4" in listed.output
     assert "clio-kit-jarvis-user-v3.3" in listed.output

--- a/tests/test_mcp_user_contracts.py
+++ b/tests/test_mcp_user_contracts.py
@@ -185,6 +185,35 @@ def test_spack_contract_requires_load_spec_without_exposing_load() -> None:
     assert "load_spec" in cast(list[str], output_schema["required"])
 
 
+def test_spack_surface_validator_accepts_described_required_load_spec() -> None:
+    """A handoff description must not make the required string schema noncanonical."""
+
+    spec = next(spec for spec in USER_CONTRACT_SPECS if spec.server_name == "spack")
+    load_spec_description = (
+        "Copy spack_locate.output.load_spec unchanged into one element of "
+        "jarvis_run.input.spack_specs."
+    )
+    tools: list[JSON] = [
+        {"name": "spack_find"},
+        {"name": "spack_install"},
+        {
+            "name": "spack_locate",
+            "outputSchema": {
+                "type": "object",
+                "properties": {
+                    "load_spec": {
+                        "type": "string",
+                        "description": load_spec_description,
+                    }
+                },
+                "required": ["load_spec"],
+            },
+        },
+    ]
+
+    mcp_contracts._validate_required_surface(spec, tools)
+
+
 def test_scientific_catalog_contract_separates_discovery_from_scene_control() -> None:
     """Catalog tools expose exact descriptors without paths or scene inputs."""
     artifact = load_mcp_user_contract("clio-kit-scientific-catalog-user-v1.1")

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -19,11 +19,11 @@ QUALITY_WORKFLOW = (
     REPOSITORY_ROOT / ".github" / "workflows" / "quality_control.yml"
 ).read_text(encoding="utf-8")
 EXPECTED_JARVIS_RELEASE_URL = (
-    "https://github.com/grc-iit/jarvis-cd/releases/download/v1.4.8/"
-    "jarvis_cd-1.4.8-py3-none-any.whl"
+    "https://github.com/grc-iit/jarvis-cd/releases/download/v1.6.0/"
+    "jarvis_cd-1.6.0-py3-none-any.whl"
 )
 EXPECTED_JARVIS_RELEASE_SHA256 = (
-    "ebf5e5f375b921f20c79075d461926431a5a017ca8b45e598878a89b229b3935"
+    "c4853138f3263715e806fcd794233d89f4aa58161e3c5fbab59e7f96d24f0e98"
 )
 
 
@@ -304,7 +304,7 @@ def test_ares_probe_exercises_persistent_uv_tool_installation() -> None:
     assert '"paraview_description": paraview_description' in probe
     assert 'assert "%" not in log_path.name' in probe
     assert "assert log_path.is_file()" in probe
-    assert probe_module["EXPECTED_JARVIS_VERSION"] == "1.4.8"
+    assert probe_module["EXPECTED_JARVIS_VERSION"] == "1.6.0"
     assert probe_module["EXPECTED_JARVIS_URL"] == EXPECTED_JARVIS_RELEASE_URL
     assert probe_module["EXPECTED_JARVIS_SHA256"] == EXPECTED_JARVIS_RELEASE_SHA256
     assert "uvx" not in probe
@@ -345,8 +345,8 @@ def test_wheel_smoke_binds_jarvis_artifacts_to_exact_release_wheel() -> None:
     )
     match = re.fullmatch(
         r"jarvis-cd @ "
-        r"(https://github\.com/grc-iit/jarvis-cd/releases/download/v1\.4\.8/"
-        r"jarvis_cd-1\.4\.8-py3-none-any\.whl)"
+        r"(https://github\.com/grc-iit/jarvis-cd/releases/download/v1\.6\.0/"
+        r"jarvis_cd-1\.6\.0-py3-none-any\.whl)"
         r"#sha256=([0-9a-f]{64})",
         dependency,
     )
@@ -360,7 +360,7 @@ def test_wheel_smoke_binds_jarvis_artifacts_to_exact_release_wheel() -> None:
     jarvis_package = next(
         package for package in jarvis_lock["package"] if package["name"] == "jarvis-cd"
     )
-    assert jarvis_package["version"] == "1.4.8"
+    assert jarvis_package["version"] == "1.6.0"
     assert jarvis_package["source"] == {"url": expected_url}
     assert jarvis_package["wheels"] == [
         {"url": expected_url, "hash": f"sha256:{expected_digest}"}
@@ -375,6 +375,7 @@ def test_wheel_smoke_binds_jarvis_artifacts_to_exact_release_wheel() -> None:
     start = WORKFLOW.index("    - name: Smoke installed root wheel")
     end = WORKFLOW.index("    - name: Attest release distributions", start)
     smoke_block = WORKFLOW[start:end]
+    assert "mcp-contract clio-kit-jarvis-user-v3.6" in smoke_block
     assert "mcp-contract clio-kit-jarvis-user-v3.5" in smoke_block
     assert "mcp-contract clio-kit-jarvis-user-v3.4" in smoke_block
     assert '"jarvis_get_execution"' in smoke_block
@@ -382,12 +383,12 @@ def test_wheel_smoke_binds_jarvis_artifacts_to_exact_release_wheel() -> None:
     assert '"jarvis_get_execution_artifacts"' not in smoke_block
     assert 'get_servers_path() / "jarvis"' in smoke_block
     assert 'distribution("jarvis-cd")' in smoke_block
-    assert 'installed.version == "1.4.8"' in smoke_block
+    assert 'installed.version == "1.6.0"' in smoke_block
     assert expected_url in smoke_block
     assert expected_digest in smoke_block
     assert "expected_requirement in project" in smoke_block
     assert 'package["name"] == "jarvis-cd"' in smoke_block
-    assert 'jarvis_package["version"] == "1.4.8"' in smoke_block
+    assert 'jarvis_package["version"] == "1.6.0"' in smoke_block
     assert 'jarvis_package["source"] == {"url": expected_url}' in smoke_block
     assert '"hash": f"sha256:{expected_digest}"' in smoke_block
     assert 'package["name"] == "jarvis-mcp"' in smoke_block
@@ -439,6 +440,7 @@ def test_release_regenerates_and_smokes_shipped_user_contracts() -> None:
     )
     smoke_block = WORKFLOW[smoke_start:smoke_end]
     assert '"$clio_kit" mcp-contracts' in smoke_block
+    assert "mcp-contract clio-kit-jarvis-user-v3.6" in smoke_block
     assert "mcp-contract clio-kit-jarvis-user-v3.5" in smoke_block
     assert "mcp-contract clio-kit-jarvis-user-v3.4" in smoke_block
     assert "mcp-contract clio-kit-jarvis-user-v3.3" in smoke_block
@@ -450,6 +452,7 @@ def test_release_regenerates_and_smokes_shipped_user_contracts() -> None:
     assert "mcp-contract clio-kit-slurm-user-v3" in smoke_block
     assert "mcp-contract clio-kit-spack-user-v2.1" in smoke_block
     assert "mcp-contract clio-kit-spack-user-v2" in smoke_block
+    assert "clio-kit-jarvis-user-v3.6" in smoke_block
     assert "clio-kit-jarvis-user-v3.5" in smoke_block
     assert "clio-kit-jarvis-user-v3.4" in smoke_block
 

--- a/uv.lock
+++ b/uv.lock
@@ -61,7 +61,7 @@ wheels = [
 
 [[package]]
 name = "clio-kit"
-version = "2.5.23"
+version = "2.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- expose package-owned deployment contracts and explicit configuration-input bindings through the compact JARVIS MCP surface
- preserve optional profile descriptions and verify JARVIS-owned durable input materialization instead of comparing transport paths
- support an isolated `--jarvis-root` across user/admin/server entry points
- publish JARVIS MCP contract 3.6.0 in clio-kit 2.6.0, pinned to the exact JARVIS 1.6.0 wheel digest
- keep all unrelated MCP contract versions unchanged; regenerate the updated Spack v2.1 schema artifact

## Local verification

- root contract/release surface: 50 tests exercised; corrected failures rerun clean
- JARVIS focused contract/input/CLI tests: 20 + 8 passed
- exact locked stdio contract probe: JARVIS v3.6 and Spack v2.1 match committed artifacts
- Ruff clean, targeted Mypy clean, `git diff --check` clean