### PR TITLE
fix(spack): sync registry handoff description

### DIFF
--- a/clio-kit-mcp-servers/spack/server.json
+++ b/clio-kit-mcp-servers/spack/server.json
@@ -35,7 +35,7 @@
     },
     {
       "name": "spack_locate",
-      "description": "Resolve one unique installed Spack spec and return its exact prefix. An absent package returns the structured not_installed error."
+      "description": "Resolve one unique installed Spack spec. Copy spack_locate.output.load_spec unchanged into one element of jarvis_run.input.spack_specs; do not derive or pass an executable path from the returned prefix. An absent package returns the structured not_installed error."
     },
     {
       "name": "spack_install",


### PR DESCRIPTION
## What changed

Synchronize the committed Spack registry metadata with the live `spack_locate` tool description, including the exact `load_spec` handoff into JARVIS.

## Root cause

The 2.6.1 release candidate fixed the underlying contract and its unit assertion, but the generated `server.json` description still contained the previous prefix-only wording. Deterministic release regeneration correctly rejected that drift before publication.

## Validation

- live Spack MCP metadata extraction exactly matches the committed description
- two focused contract/manifest tests passed
- Ruff check and format check passed
- `git diff --check`