### PR TITLE
feat(web): add self-hosted SearXNG provider

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "CLIO Kit - MCP Servers for Scientific Computing and HPC",
-    "version": "2.7.2",
+    "version": "2.8.0",
     "pluginRoot": "./clio-kit-mcp-servers"
   },
   "plugins": [
@@ -327,7 +327,7 @@
       "name": "clio-web",
       "source": "./clio-kit-mcp-servers/web",
       "description": "Web MCP server providing curated fetch + search tools for agentic web access",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "category": "development",
       "keywords": [],
       "license": "BSD-3-Clause",

--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ distinct `not_installed` semantic, while real Spack failures remain errors.
 | **`slurm`** | 3.0.0 | HPC | Job submission and management | `clio-kit mcp-server slurm` |
 | **`spack`** | 2.1.0 | Package Management | Structured package discovery, installation, and location | `clio-kit mcp-server spack` |
 | **`terrain`** | 2.2.3 | Geospatial | Analyze DEMs and terrain point clouds | `clio-kit mcp-server terrain` |
-| **`web`** | 1.0.0 | Web | Fetch a URL to Markdown and search the web | `clio-kit mcp-server web` |
+| **`web`** | 1.1.0 | Web | Fetch a URL to Markdown and search the web | `clio-kit mcp-server web` |
 
 </div>
 

--- a/clio-kit-mcp-servers/adios/server.json
+++ b/clio-kit-mcp-servers/adios/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.2",
+      "version": "2.8.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/arxiv/server.json
+++ b/clio-kit-mcp-servers/arxiv/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.2",
+      "version": "2.8.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/chronolog/server.json
+++ b/clio-kit-mcp-servers/chronolog/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.2",
+      "version": "2.8.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/compression/server.json
+++ b/clio-kit-mcp-servers/compression/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.2",
+      "version": "2.8.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/darshan/server.json
+++ b/clio-kit-mcp-servers/darshan/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.2",
+      "version": "2.8.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/geo/server.json
+++ b/clio-kit-mcp-servers/geo/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.2",
+      "version": "2.8.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/geojson/server.json
+++ b/clio-kit-mcp-servers/geojson/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.2",
+      "version": "2.8.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/hdf5/server.json
+++ b/clio-kit-mcp-servers/hdf5/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.2",
+      "version": "2.8.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/jarvis/server.json
+++ b/clio-kit-mcp-servers/jarvis/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.2",
+      "version": "2.8.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/lmod/server.json
+++ b/clio-kit-mcp-servers/lmod/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.2",
+      "version": "2.8.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/ndp/server.json
+++ b/clio-kit-mcp-servers/ndp/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.2",
+      "version": "2.8.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/node-hardware/server.json
+++ b/clio-kit-mcp-servers/node-hardware/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.2",
+      "version": "2.8.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/pandas/server.json
+++ b/clio-kit-mcp-servers/pandas/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.2",
+      "version": "2.8.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/parallel-sort/server.json
+++ b/clio-kit-mcp-servers/parallel-sort/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.2",
+      "version": "2.8.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/paraview/server.json
+++ b/clio-kit-mcp-servers/paraview/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.2",
+      "version": "2.8.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/parquet/server.json
+++ b/clio-kit-mcp-servers/parquet/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.2",
+      "version": "2.8.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/plot/server.json
+++ b/clio-kit-mcp-servers/plot/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.2",
+      "version": "2.8.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/sac/server.json
+++ b/clio-kit-mcp-servers/sac/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.2",
+      "version": "2.8.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/scientific-catalog/server.json
+++ b/clio-kit-mcp-servers/scientific-catalog/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.2",
+      "version": "2.8.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/seismic/server.json
+++ b/clio-kit-mcp-servers/seismic/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.2",
+      "version": "2.8.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/slurm/server.json
+++ b/clio-kit-mcp-servers/slurm/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.2",
+      "version": "2.8.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/spack/server.json
+++ b/clio-kit-mcp-servers/spack/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.2",
+      "version": "2.8.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/terrain/server.json
+++ b/clio-kit-mcp-servers/terrain/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.2",
+      "version": "2.8.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/web/.claude-plugin/plugin.json
+++ b/clio-kit-mcp-servers/web/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "clio-web",
   "description": "Web MCP server providing curated fetch + search tools for agentic web access",
-  "version": "1.0.0"
+  "version": "1.1.0"
 }

--- a/clio-kit-mcp-servers/web/README.md
+++ b/clio-kit-mcp-servers/web/README.md
@@ -38,9 +38,14 @@ Query a configurable web-search provider and return ranked results.
   `search` and gets back a small list of `{title, url, snippet}` rows to triage
   and then `fetch`.
 - **Providers:** keyless **DuckDuckGo** (`ddg`, default, via the `ddgs`
-  package); optional BYO-key **Brave** and **Tavily**. Selecting a keyed
-  provider without its key raises a typed error naming the missing config — it
-  never silently falls back to `ddg`.
+  package); self-hosted **SearXNG** (`searxng`); optional BYO-key **Brave** and
+  **Tavily**. Selecting an unconfigured provider raises a typed error naming
+  the missing config — it never silently falls back to `ddg`.
+- **SearXNG selectors:** `category` (`general` / `science` / `it`), exact
+  `engines`, `language`, `time_range`, `pageno`, and `safesearch`. These are
+  rejected for other providers instead of being silently discarded. An exact
+  `engines` list takes precedence over `category`, because SearXNG otherwise
+  treats the two selectors as a broader union.
 - **Returns:** `{ok, provider, query, results: [{title, url, snippet}], count}`.
 
 ## Configuration
@@ -51,7 +56,8 @@ recommended path is a single source of config with clear defaults.
 
 | Field | Env var | Default | Meaning |
 | --- | --- | --- | --- |
-| `search_provider` | `WEB_SEARCH_PROVIDER` | `"ddg"` | Active search provider (`ddg` / `brave` / `tavily`). |
+| `search_provider` | `WEB_SEARCH_PROVIDER` | `"ddg"` | Active search provider (`ddg` / `searxng` / `brave` / `tavily`). |
+| `searxng_base_url` | `WEB_SEARXNG_BASE_URL` | `None` | Root URL of the self-hosted SearXNG instance (required for `searxng`). |
 | `brave_api_key` | `WEB_BRAVE_API_KEY` | `None` | Brave Search API key (required for `brave`). |
 | `tavily_api_key` | `WEB_TAVILY_API_KEY` | `None` | Tavily API key (required for `tavily`). |
 | `max_bytes` | `WEB_MAX_BYTES` | `5242880` | Fetch size cap in bytes (5 MiB). |
@@ -85,3 +91,15 @@ Real-network checks are opt-in and skipped by default:
 ```bash
 WEB_MCP_LIVE=1 uv run pytest -m integration
 ```
+
+To make the self-hosted instance the active backend:
+
+```bash
+WEB_SEARCH_PROVIDER=searxng \
+WEB_SEARXNG_BASE_URL=http://10.0.0.102:8088 \
+uv run web-mcp
+```
+
+No paid-provider credential is needed for SearXNG. The server forwards native
+selectors to the deployment and returns `engines_answered` plus normalized
+`unresponsive_engines` alongside the stable `{title, url, snippet}` rows.

--- a/clio-kit-mcp-servers/web/docs/web_tools.md
+++ b/clio-kit-mcp-servers/web/docs/web_tools.md
@@ -21,14 +21,26 @@ inline `content`, or — with `to_file=True` — writes it under the artifacts r
 - **`(url, prompt)` extraction** is the agent's job (an MCP server has no model access): use
   `to_file=True` and pipe the saved file through the agent's own model.
 
-## `search(query, *, provider=None, count=5)`
+## `search(query, *, provider=None, count=5, category=None, engines=None, language=None, time_range=None, pageno=None, safesearch=None)`
 
-Search via a configurable provider. Keyless **DuckDuckGo** (`ddg`) by default; BYO-key **Brave**
-(`WEB_BRAVE_API_KEY`) / **Tavily** (`WEB_TAVILY_API_KEY`). Selecting a keyed provider without its
-key is a typed error — never a silent fallback to `ddg`. `count` is capped at 25. Returns
+Search via a configurable provider. Keyless **DuckDuckGo** (`ddg`) is the default;
+self-hosted **SearXNG** (`searxng`) uses `WEB_SEARXNG_BASE_URL`; optional **Brave**
+and **Tavily** retain their BYO-key configuration. Selecting an unconfigured provider is a
+typed error — never a silent fallback to `ddg`. `count` is capped at 25. Returns
 `{title, url, snippet}` results.
+
+SearXNG accepts native `category` (`general`, `science`, or `it`), exact `engines`,
+`language`, `time_range` (`day`, `month`, or `year`), `pageno` (1 through 3), and
+`safesearch` (0 through 2) selectors. Its response also includes `engines_answered` and
+normalized `unresponsive_engines`. An explicit `engines` list takes precedence over
+`category`, avoiding SearXNG's broader union of both selectors. Passing these selectors to
+another provider is an error.
 
 ## Configuration (`WEB_`-prefixed env or a `.env`)
 
-`WEB_SEARCH_PROVIDER`, `WEB_BRAVE_API_KEY`, `WEB_TAVILY_API_KEY`, `WEB_MAX_BYTES`,
-`WEB_CONNECT_TIMEOUT_S`, `WEB_READ_TIMEOUT_S`, `WEB_ARTIFACTS_ROOT`, `WEB_ALLOW_PRIVATE_HOSTS`.
+`WEB_SEARCH_PROVIDER`, `WEB_SEARXNG_BASE_URL`, `WEB_BRAVE_API_KEY`, `WEB_TAVILY_API_KEY`,
+`WEB_MAX_BYTES`, `WEB_CONNECT_TIMEOUT_S`, `WEB_READ_TIMEOUT_S`, `WEB_ARTIFACTS_ROOT`,
+`WEB_ALLOW_PRIVATE_HOSTS`.
+
+For the LAN deployment, set `WEB_SEARCH_PROVIDER=searxng` and
+`WEB_SEARXNG_BASE_URL=http://10.0.0.102:8088`. No paid-provider credential is required.

--- a/clio-kit-mcp-servers/web/pyproject.toml
+++ b/clio-kit-mcp-servers/web/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "web-mcp"
-version = "1.0.0"
+version = "1.1.0"
 description = "Web MCP server providing curated fetch + search tools for agentic web access"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/clio-kit-mcp-servers/web/server.json
+++ b/clio-kit-mcp-servers/web/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.iowarp/web-mcp",
   "title": "CLIO Web",
   "description": "Web MCP server providing curated fetch + search tools for agentic web access",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "repository": {
     "url": "https://github.com/iowarp/clio-kit",
     "source": "github"
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.2",
+      "version": "2.8.0",
       "transport": {
         "type": "stdio"
       },
@@ -35,7 +35,7 @@
     },
     {
       "name": "search",
-      "description": "Search the web via a configurable provider (keyless DuckDuckGo by default; optional BYO-key Brave or Tavily) and return ranked results."
+      "description": "Search the web via a configurable provider (keyless DuckDuckGo by default; self-hosted SearXNG; optional BYO-key Brave or Tavily) and return ranked results. SearXNG supports category, engine, language, time-range, page, and safe-search selectors."
     }
   ],
   "resources": [

--- a/clio-kit-mcp-servers/web/src/web_mcp/__init__.py
+++ b/clio-kit-mcp-servers/web/src/web_mcp/__init__.py
@@ -9,4 +9,4 @@ It is the seed of CLIO's web tooling and the test instrument for the sandbox
 campaign's egress recording.
 """
 
-__version__ = "1.0.0"
+__version__ = "1.1.0"

--- a/clio-kit-mcp-servers/web/src/web_mcp/searxng.py
+++ b/clio-kit-mcp-servers/web/src/web_mcp/searxng.py
@@ -1,0 +1,125 @@
+"""Self-hosted SearXNG JSON API adapter for the web MCP server."""
+
+from __future__ import annotations
+
+from typing import Any
+from urllib.parse import urlparse
+
+import httpx
+from fastmcp.exceptions import ToolError
+
+
+def _search_endpoint(base_url: str | None) -> str:
+    """Return the configured SearXNG search endpoint or raise a typed error."""
+    value = (base_url or "").strip()
+    parsed = urlparse(value)
+    if not value:
+        raise ToolError(
+            "search provider 'searxng' requires its deployment URL. "
+            "Set WEB_SEARXNG_BASE_URL (Settings.searxng_base_url)."
+        )
+    if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+        raise ToolError(f"WEB_SEARXNG_BASE_URL must be an absolute http(s) URL; got {value!r}.")
+    if parsed.query or parsed.fragment:
+        raise ToolError("WEB_SEARXNG_BASE_URL must not contain a query string or fragment.")
+    return f"{value.rstrip('/')}/search"
+
+
+def _normalize_unresponsive_engines(value: Any) -> list[dict[str, str]]:
+    """Normalize SearXNG's ``[engine, reason]`` pairs for MCP callers."""
+    if not isinstance(value, list):
+        return []
+    normalized: list[dict[str, str]] = []
+    for item in value:
+        if isinstance(item, (list, tuple)) and len(item) >= 2:
+            normalized.append({"engine": str(item[0]), "reason": str(item[1])})
+        elif isinstance(item, dict) and item.get("engine"):
+            normalized.append(
+                {
+                    "engine": str(item["engine"]),
+                    "reason": str(item.get("reason") or "unknown"),
+                }
+            )
+    return normalized
+
+
+async def search_searxng(
+    query: str,
+    count: int,
+    *,
+    base_url: str | None,
+    connect_timeout_s: float,
+    read_timeout_s: float,
+    category: str | None,
+    engines: list[str] | None,
+    language: str | None,
+    time_range: str | None,
+    pageno: int,
+    safesearch: int | None,
+) -> tuple[list[dict[str, str]], list[str], list[dict[str, str]]]:
+    """Search a configured self-hosted SearXNG instance via its JSON API."""
+    endpoint = _search_endpoint(base_url)
+    params: dict[str, str | int] = {"q": query, "format": "json"}
+    selected_engines = [name.strip() for name in engines or [] if name.strip()]
+    if selected_engines:
+        params["engines"] = ",".join(selected_engines)
+    elif category:
+        params["categories"] = category
+    if language and language.strip():
+        params["language"] = language.strip()
+    if time_range:
+        params["time_range"] = time_range
+    params["pageno"] = pageno
+    if safesearch is not None:
+        params["safesearch"] = safesearch
+
+    timeout = httpx.Timeout(read_timeout_s, connect=connect_timeout_s)
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            response = await client.get(endpoint, params=params)
+    except httpx.HTTPError as exc:
+        raise ToolError(f"Could not query SearXNG at {endpoint}: {exc}") from exc
+
+    if response.status_code == 403:
+        raise ToolError(
+            "SearXNG returned HTTP 403 for its JSON API. Ensure 'json' is enabled "
+            "under search.formats in settings.yml."
+        )
+    try:
+        response.raise_for_status()
+    except httpx.HTTPStatusError as exc:
+        raise ToolError(
+            f"SearXNG search failed with HTTP {response.status_code} at {endpoint}."
+        ) from exc
+    try:
+        payload = response.json()
+    except ValueError as exc:
+        raise ToolError(
+            "SearXNG did not return JSON. Ensure the JSON format is enabled and "
+            "WEB_SEARXNG_BASE_URL points to the instance root."
+        ) from exc
+    if not isinstance(payload, dict) or not isinstance(payload.get("results"), list):
+        raise ToolError("SearXNG returned malformed JSON: expected a results list.")
+
+    results: list[dict[str, str]] = []
+    engines_answered: set[str] = set()
+    for item in payload["results"]:
+        if not isinstance(item, dict):
+            continue
+        item_engines = item.get("engines")
+        if isinstance(item_engines, list):
+            engines_answered.update(str(name) for name in item_engines if name)
+        elif item.get("engine"):
+            engines_answered.add(str(item["engine"]))
+        results.append(
+            {
+                "title": str(item.get("title") or ""),
+                "url": str(item.get("url") or ""),
+                "snippet": str(item.get("content") or item.get("snippet") or ""),
+            }
+        )
+        if len(results) >= count:
+            break
+
+    unresponsive = _normalize_unresponsive_engines(payload.get("unresponsive_engines"))
+    return results, sorted(engines_answered), unresponsive

--- a/clio-kit-mcp-servers/web/src/web_mcp/server.py
+++ b/clio-kit-mcp-servers/web/src/web_mcp/server.py
@@ -6,7 +6,7 @@ This is a proper v1 web-tooling surface for CLIO. Two tools are exposed:
   convert HTML to Markdown (trafilatura -> readability -> plain-text strip),
   and either return the content inline or write it to a local file.
 * ``search`` -- query a configurable web-search provider (keyless DuckDuckGo by
-  default, optional BYO-key Brave / Tavily).
+  default, self-hosted SearXNG, or optional BYO-key Brave / Tavily).
 
 Documented extension points (NOT implemented in v1 -- honest, typed gaps, never
 a silent fallback):
@@ -27,7 +27,7 @@ import ipaddress
 import os
 import re
 from pathlib import Path
-from typing import Annotated, Any
+from typing import Annotated, Any, Literal
 from urllib.parse import urlparse
 
 import httpx
@@ -39,6 +39,8 @@ from fastmcp.prompts import Message
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from readability import Document as ReadabilityDocument
+
+from web_mcp.searxng import search_searxng
 
 # Environment setup
 load_dotenv()
@@ -61,8 +63,10 @@ class Settings(BaseSettings):
     model_config = SettingsConfigDict(env_prefix="WEB_", env_file=".env", extra="ignore")
 
     # Search provider selection. Keyless "ddg" is the default so search works
-    # out of the box; "brave"/"tavily" are opt-in and require their own key.
+    # out of the box; self-hosted "searxng" requires its deployment URL, while
+    # "brave"/"tavily" are opt-in and require their own key.
     search_provider: str = "ddg"
+    searxng_base_url: str | None = None
     brave_api_key: str | None = None
     tavily_api_key: str | None = None
 
@@ -650,18 +654,38 @@ async def _search_tavily(query: str, count: int) -> list[dict[str, str]]:
     title="Search Web",
     description=(
         "Search the web via a configurable provider (keyless DuckDuckGo by "
-        "default; optional BYO-key Brave or Tavily) and return ranked results."
+        "default; self-hosted SearXNG; optional BYO-key Brave or Tavily) and "
+        "return ranked results. SearXNG supports category, engine, language, "
+        "time-range, page, and safe-search selectors."
     ),
     annotations={"readOnlyHint": True, "destructiveHint": False, "idempotentHint": False},
     tags={"web", "search"},
 )
 async def search(
     query: Annotated[str, Field(description="The search query.")],
-    provider: Annotated[
-        str | None,
-        Field(description="Override the configured provider: 'ddg', 'brave', or 'tavily'."),
-    ] = None,
+    provider: Annotated[str | None, Field(description="Search provider override.")] = None,
     count: Annotated[int, Field(description="Maximum number of results to return.")] = 5,
+    category: Annotated[
+        Literal["general", "science", "it"] | None,
+        Field(description="SearXNG category: general, science, or it."),
+    ] = None,
+    engines: Annotated[
+        list[str] | None,
+        Field(description="Exact SearXNG engines; takes precedence over category."),
+    ] = None,
+    language: Annotated[str | None, Field(description="SearXNG result language.")] = None,
+    time_range: Annotated[
+        Literal["day", "month", "year"] | None,
+        Field(description="SearXNG recency: day, month, or year."),
+    ] = None,
+    pageno: Annotated[
+        int | None,
+        Field(description="SearXNG-only result page, 1 through 3.", ge=1, le=3),
+    ] = None,
+    safesearch: Annotated[
+        int | None,
+        Field(description="SearXNG safe-search level, 0 through 2.", ge=0, le=2),
+    ] = None,
 ) -> dict[str, Any]:
     """Search the web and return ``{title, url, snippet}`` results.
 
@@ -674,25 +698,60 @@ async def search(
         raise ToolError("A non-empty query is required.")
     effective_count = min(count if count and count > 0 else 5, _MAX_SEARCH_COUNT)
     selected = (provider or settings.search_provider or "ddg").lower()
+    has_searxng_selectors = any(
+        (
+            category is not None,
+            bool(engines),
+            bool(language and language.strip()),
+            time_range is not None,
+            pageno is not None,
+            safesearch is not None,
+        )
+    )
+    if selected != "searxng" and has_searxng_selectors:
+        raise ToolError(
+            "category, engines, language, time_range, pageno, and safesearch are "
+            "only supported by provider 'searxng'."
+        )
 
+    engines_answered: list[str] = []
+    unresponsive_engines: list[dict[str, str]] = []
     if selected == "ddg":
         results = await _search_ddg(text, effective_count)
     elif selected == "brave":
         results = await _search_brave(text, effective_count)
     elif selected == "tavily":
         results = await _search_tavily(text, effective_count)
+    elif selected == "searxng":
+        results, engines_answered, unresponsive_engines = await search_searxng(
+            text,
+            effective_count,
+            base_url=settings.searxng_base_url,
+            connect_timeout_s=settings.connect_timeout_s,
+            read_timeout_s=settings.read_timeout_s,
+            category=category,
+            engines=engines,
+            language=language,
+            time_range=time_range,
+            pageno=pageno or 1,
+            safesearch=safesearch,
+        )
     else:
         raise ToolError(
-            f"Unknown search provider {selected!r}. Supported: 'ddg', 'brave', 'tavily'."
+            f"Unknown search provider {selected!r}. Supported: 'ddg', 'searxng', 'brave', 'tavily'."
         )
 
-    return {
+    response: dict[str, Any] = {
         "ok": True,
         "provider": selected,
         "query": text,
         "results": results,
         "count": len(results),
     }
+    if selected == "searxng":
+        response["engines_answered"] = engines_answered
+        response["unresponsive_engines"] = unresponsive_engines
+    return response
 
 
 @mcp.resource("web://providers")
@@ -700,8 +759,9 @@ def search_providers() -> dict[str, Any]:
     """The active + available web-search providers and current fetch limits."""
     return {
         "active_provider": settings.search_provider,
-        "available_providers": ["ddg", "brave", "tavily"],
+        "available_providers": ["ddg", "searxng", "brave", "tavily"],
         "keyless_default": "ddg",
+        "searxng_configured": bool((settings.searxng_base_url or "").strip()),
         "max_bytes": settings.max_bytes,
         "allow_private_hosts": settings.allow_private_hosts,
     }

--- a/clio-kit-mcp-servers/web/tests/test_init.py
+++ b/clio-kit-mcp-servers/web/tests/test_init.py
@@ -18,7 +18,7 @@ class TestPackageMetadata:
 
     def test_version_value(self):
         """Test that version has expected value."""
-        assert web_mcp.__version__ == "1.0.0"
+        assert web_mcp.__version__ == "1.1.0"
 
     def test_docstring_exists(self):
         """Test that package has a docstring."""

--- a/clio-kit-mcp-servers/web/tests/test_integration.py
+++ b/clio-kit-mcp-servers/web/tests/test_integration.py
@@ -13,11 +13,13 @@ import os
 import pytest
 from fastmcp import Client
 
-from web_mcp.server import mcp
+from web_mcp import server
+from web_mcp.server import Settings, mcp
 
 from .helpers import parse_result
 
 _LIVE = os.getenv("WEB_MCP_LIVE") == "1"
+_SEARXNG_URL = os.getenv("WEB_SEARXNG_BASE_URL")
 
 pytestmark = [
     pytest.mark.integration,
@@ -44,3 +46,36 @@ async def test_live_search_ddg() -> None:
     data = parse_result(result)
     assert data["ok"] is True
     assert data["provider"] == "ddg"
+
+
+@pytest.mark.skipif(
+    not _SEARXNG_URL,
+    reason="set WEB_SEARXNG_BASE_URL to run the live SearXNG integration test",
+)
+@pytest.mark.asyncio
+async def test_live_search_searxng(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Exercise category and engine selectors against the deployed instance."""
+    monkeypatch.setattr(
+        server,
+        "settings",
+        Settings(search_provider="searxng", searxng_base_url=_SEARXNG_URL),
+    )
+    async with Client(mcp) as client:
+        result = await client.call_tool(
+            "search",
+            {
+                "query": "parallel I/O",
+                "count": 3,
+                "category": "science",
+                "engines": ["arxiv", "crossref"],
+                "language": "en",
+                "safesearch": 0,
+            },
+        )
+    data = parse_result(result)
+    assert data["ok"] is True
+    assert data["provider"] == "searxng"
+    assert data["count"] > 0
+    assert data["results"]
+    assert "engines_answered" in data
+    assert "unresponsive_engines" in data

--- a/clio-kit-mcp-servers/web/tests/test_registration.py
+++ b/clio-kit-mcp-servers/web/tests/test_registration.py
@@ -7,7 +7,8 @@ import json
 import pytest
 from fastmcp import Client
 
-from web_mcp.server import mcp
+from web_mcp import server
+from web_mcp.server import Settings, mcp
 
 
 @pytest.mark.asyncio
@@ -28,3 +29,26 @@ async def test_providers_resource_reports_active_backend() -> None:
     payload = json.loads(result[0].text)  # resource contents expose .text (JSON)
     assert payload["active_provider"] == "ddg"  # keyless default
     assert "brave" in payload["available_providers"] and "tavily" in payload["available_providers"]
+    assert "searxng" in payload["available_providers"]
+    assert payload["searxng_configured"] is False
+
+
+@pytest.mark.asyncio
+async def test_providers_resource_reports_configured_searxng(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Discovery reports SearXNG readiness without exposing its deployment URL."""
+    monkeypatch.setattr(
+        server,
+        "settings",
+        Settings(
+            search_provider="searxng",
+            searxng_base_url="http://10.0.0.102:8088",
+        ),
+    )
+    async with Client(mcp) as client:
+        result = await client.read_resource("web://providers")
+    payload = json.loads(result[0].text)
+    assert payload["active_provider"] == "searxng"
+    assert payload["searxng_configured"] is True
+    assert "10.0.0.102" not in result[0].text

--- a/clio-kit-mcp-servers/web/tests/test_search.py
+++ b/clio-kit-mcp-servers/web/tests/test_search.py
@@ -132,6 +132,122 @@ async def test_search_tavily_without_key_raises(monkeypatch: pytest.MonkeyPatch)
 
 
 @pytest.mark.asyncio
+async def test_search_searxng_maps_results_and_native_selectors(
+    monkeypatch: pytest.MonkeyPatch, httpx_mock: HTTPXMock
+) -> None:
+    """SearXNG receives native selectors and exposes engine provenance."""
+    monkeypatch.setattr(
+        server,
+        "settings",
+        Settings(search_provider="searxng", searxng_base_url="http://10.0.0.102:8088"),
+    )
+    httpx_mock.add_response(
+        url=(
+            "http://10.0.0.102:8088/search?q=parallel+io&format=json"
+            "&engines=arxiv%2Ccrossref&language=en"
+            "&time_range=year&pageno=2&safesearch=0"
+        ),
+        json={
+            "results": [
+                {
+                    "title": "Parallel I/O Paper",
+                    "url": "https://example.org/paper",
+                    "content": "A scientific result.",
+                    "engines": ["arxiv", "crossref"],
+                },
+                {
+                    "title": "Second Result",
+                    "url": "https://example.org/second",
+                    "content": "Not returned because count is one.",
+                    "engine": "arxiv",
+                },
+            ],
+            "unresponsive_engines": [["semantic scholar", "timeout"]],
+        },
+    )
+
+    async with Client(mcp) as client:
+        result = await client.call_tool(
+            "search",
+            {
+                "query": "parallel io",
+                "count": 1,
+                "category": "science",
+                "engines": ["arxiv", "crossref"],
+                "language": "en",
+                "time_range": "year",
+                "pageno": 2,
+                "safesearch": 0,
+            },
+        )
+    data = parse_result(result)
+
+    assert data["provider"] == "searxng"
+    assert data["count"] == 1
+    assert data["results"] == [
+        {
+            "title": "Parallel I/O Paper",
+            "url": "https://example.org/paper",
+            "snippet": "A scientific result.",
+        }
+    ]
+    assert data["engines_answered"] == ["arxiv", "crossref"]
+    assert data["unresponsive_engines"] == [{"engine": "semantic scholar", "reason": "timeout"}]
+
+
+@pytest.mark.asyncio
+async def test_search_searxng_requires_base_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Selecting SearXNG without its deployment URL fails explicitly."""
+    monkeypatch.setattr(server, "settings", Settings(search_provider="searxng"))
+    async with Client(mcp) as client:
+        with pytest.raises(Exception) as excinfo:
+            await client.call_tool("search", {"query": "anything"})
+    assert "WEB_SEARXNG_BASE_URL" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_search_searxng_reports_disabled_json(
+    monkeypatch: pytest.MonkeyPatch, httpx_mock: HTTPXMock
+) -> None:
+    """A 403 identifies the disabled SearXNG JSON API instead of falling back."""
+    monkeypatch.setattr(
+        server,
+        "settings",
+        Settings(search_provider="searxng", searxng_base_url="http://10.0.0.102:8088"),
+    )
+    httpx_mock.add_response(status_code=403)
+    async with Client(mcp) as client:
+        with pytest.raises(Exception) as excinfo:
+            await client.call_tool("search", {"query": "anything"})
+    assert "JSON" in str(excinfo.value)
+    assert "403" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("provider", ["ddg", "brave", "tavily"])
+@pytest.mark.parametrize(
+    "selector",
+    [
+        {"category": "science"},
+        {"engines": ["arxiv"]},
+        {"language": "en"},
+        {"time_range": "year"},
+        {"pageno": 1},
+        {"safesearch": 0},
+    ],
+)
+async def test_searxng_selectors_rejected_for_other_providers(
+    monkeypatch: pytest.MonkeyPatch, provider: str, selector: dict[str, Any]
+) -> None:
+    """Provider-specific selectors are never silently discarded."""
+    monkeypatch.setattr(server, "settings", Settings(search_provider=provider))
+    async with Client(mcp) as client:
+        with pytest.raises(Exception) as excinfo:
+            await client.call_tool("search", {"query": "x", **selector})
+    assert "only supported by provider 'searxng'" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
 async def test_search_provider_override_beats_config(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/clio-kit-mcp-servers/web/tests/test_searxng.py
+++ b/clio-kit-mcp-servers/web/tests/test_searxng.py
@@ -1,0 +1,120 @@
+"""Focused unit coverage for the self-hosted SearXNG adapter."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+from fastmcp.exceptions import ToolError
+from pytest_httpx import HTTPXMock
+
+from web_mcp.searxng import (
+    _normalize_unresponsive_engines,
+    _search_endpoint,
+    search_searxng,
+)
+
+
+async def _search(
+    *, category: str | None = None
+) -> tuple[list[dict[str, str]], list[str], list[dict[str, str]]]:
+    """Call the adapter with deterministic defaults."""
+    return await search_searxng(
+        "query",
+        3,
+        base_url="http://10.0.0.102:8088",
+        connect_timeout_s=1.0,
+        read_timeout_s=2.0,
+        category=category,
+        engines=None,
+        language=None,
+        time_range=None,
+        pageno=1,
+        safesearch=None,
+    )
+
+
+@pytest.mark.parametrize(
+    ("url", "message"),
+    [
+        ("not-a-url", r"absolute http\(s\) URL"),
+        ("http://10.0.0.102:8088?bad=1", "query string or fragment"),
+    ],
+)
+def test_search_endpoint_rejects_invalid_roots(url: str, message: str) -> None:
+    """The configured root must be an absolute URL without query state."""
+    with pytest.raises(ToolError, match=message):
+        _search_endpoint(url)
+
+
+def test_normalize_unresponsive_engines_handles_dicts_and_other_values() -> None:
+    """Dict-form failures are normalized and non-list payloads are ignored."""
+    assert _normalize_unresponsive_engines(None) == []
+    assert _normalize_unresponsive_engines(
+        [{"engine": "arxiv"}, {"engine": "crossref", "reason": "timeout"}, {}]
+    ) == [
+        {"engine": "arxiv", "reason": "unknown"},
+        {"engine": "crossref", "reason": "timeout"},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_search_category_maps_single_engine_and_skips_invalid_rows(
+    httpx_mock: HTTPXMock,
+) -> None:
+    """Category-only calls are forwarded and alternate result fields are mapped."""
+    httpx_mock.add_response(
+        url=("http://10.0.0.102:8088/search?q=query&format=json&categories=it&pageno=1"),
+        json={
+            "results": [
+                "invalid",
+                {
+                    "title": "Repository",
+                    "url": "https://github.com/iowarp/clio-agent",
+                    "snippet": "Fallback snippet.",
+                    "engine": "github",
+                },
+            ]
+        },
+    )
+    results, engines, unresponsive = await _search(category="it")
+    assert results == [
+        {
+            "title": "Repository",
+            "url": "https://github.com/iowarp/clio-agent",
+            "snippet": "Fallback snippet.",
+        }
+    ]
+    assert engines == ["github"]
+    assert unresponsive == []
+
+
+@pytest.mark.asyncio
+async def test_search_reports_transport_failure(httpx_mock: HTTPXMock) -> None:
+    """Connection failures become typed SearXNG errors."""
+    httpx_mock.add_exception(httpx.ConnectError("offline"))
+    with pytest.raises(ToolError, match="Could not query SearXNG"):
+        await _search()
+
+
+@pytest.mark.asyncio
+async def test_search_reports_non_403_http_failure(httpx_mock: HTTPXMock) -> None:
+    """Non-403 HTTP failures retain the status code in a typed error."""
+    httpx_mock.add_response(status_code=500)
+    with pytest.raises(ToolError, match="HTTP 500"):
+        await _search()
+
+
+@pytest.mark.asyncio
+async def test_search_reports_non_json_response(httpx_mock: HTTPXMock) -> None:
+    """HTML or text responses cannot masquerade as a successful search."""
+    httpx_mock.add_response(text="not json", headers={"content-type": "text/plain"})
+    with pytest.raises(ToolError, match="did not return JSON"):
+        await _search()
+
+
+@pytest.mark.asyncio
+async def test_search_reports_malformed_json(httpx_mock: HTTPXMock) -> None:
+    """JSON without a result list is rejected explicitly."""
+    httpx_mock.add_response(json={"results": {}})
+    with pytest.raises(ToolError, match="malformed JSON"):
+        await _search()

--- a/clio-kit-mcp-servers/web/tests/test_settings.py
+++ b/clio-kit-mcp-servers/web/tests/test_settings.py
@@ -18,6 +18,7 @@ class TestSettingsDefaults:
         cfg = Settings()
         assert cfg.brave_api_key is None
         assert cfg.tavily_api_key is None
+        assert cfg.searxng_base_url is None
 
     def test_default_max_bytes_is_5_mib(self):
         cfg = Settings()
@@ -40,6 +41,7 @@ class TestSettingsOverride:
         cfg = Settings(
             search_provider="brave",
             brave_api_key="secret",
+            searxng_base_url="http://10.0.0.102:8088",
             max_bytes=123,
             connect_timeout_s=1.5,
             read_timeout_s=9.0,
@@ -47,6 +49,7 @@ class TestSettingsOverride:
         )
         assert cfg.search_provider == "brave"
         assert cfg.brave_api_key == "secret"
+        assert cfg.searxng_base_url == "http://10.0.0.102:8088"
         assert cfg.max_bytes == 123
         assert cfg.connect_timeout_s == 1.5
         assert cfg.read_timeout_s == 9.0
@@ -54,7 +57,9 @@ class TestSettingsOverride:
 
     def test_override_via_env_prefix(self, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.setenv("WEB_SEARCH_PROVIDER", "tavily")
+        monkeypatch.setenv("WEB_SEARXNG_BASE_URL", "http://10.0.0.102:8088")
         monkeypatch.setenv("WEB_MAX_BYTES", "2048")
         cfg = Settings()
         assert cfg.search_provider == "tavily"
+        assert cfg.searxng_base_url == "http://10.0.0.102:8088"
         assert cfg.max_bytes == 2048

--- a/clio-kit-mcp-servers/web/uv.lock
+++ b/clio-kit-mcp-servers/web/uv.lock
@@ -2895,7 +2895,7 @@ wheels = [
 
 [[package]]
 name = "web-mcp"
-version = "1.0.0"
+version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "ddgs" },

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "clio-kit",
-  "version": "2.7.2",
+  "version": "2.8.0",
   "mcpServers": {
     "clio-adios": {
       "command": "clio-kit",

--- a/mcp-server-versions.toml
+++ b/mcp-server-versions.toml
@@ -8,12 +8,12 @@ schema-version = 1
 # change, add it here WITH a real version bump under [servers] in the same
 # PR, then remove it again once published.
 [mcp-registry-release]
-publish = []
+publish = ["web"]
 
 # Generated website metadata must not depend on the wall clock. Advance this
 # date intentionally whenever current contract metadata is regenerated.
 [documentation]
-updated = "2026-07-22"
+updated = "2026-08-11"
 
 # MCP Registry server versions describe each agent-facing contract. They are
 # intentionally independent of the clio-kit PyPI distribution version, which
@@ -42,4 +42,4 @@ seismic = "2.2.3"
 slurm = "3.0.0"
 spack = "2.1.0"
 terrain = "2.2.3"
-web = "1.0.0"
+web = "1.1.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "clio-kit"
-version = "2.7.2"
+version = "2.8.0"
 description = "CLIO Kit - MCP Servers, Clients, and Tools for AI Agents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_generate_server_json_contract.py
+++ b/tests/test_generate_server_json_contract.py
@@ -99,7 +99,7 @@ def test_every_committed_server_has_an_agent_runnable_package_coordinate() -> No
     assert manifests == [project / "server.json" for project in projects]
     assert list(expected_server_versions) == sorted(expected_server_versions)
     assert set(expected_server_versions) == {project.name for project in projects}
-    assert publish_servers == ()
+    assert publish_servers == ("web",)
     assert marketplace["metadata"]["version"] == expected_version
     assert set(marketplace_plugins) == set(expected_server_versions)
     assert gemini_extension["version"] == expected_version

--- a/uv.lock
+++ b/uv.lock
@@ -61,7 +61,7 @@ wheels = [
 
 [[package]]
 name = "clio-kit"
-version = "2.7.2"
+version = "2.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## What changed

- add a self-hosted SearXNG backend to the existing web MCP provider abstraction
- expose SearXNG-only category, exact-engine, language, recency, page, and safe-search selectors
- surface responding and unresponsive engine provenance without silent fallback
- keep DDG, Brave, and Tavily behavior intact
- advance the web contract to 1.1.0 and the containing CLIO Kit wheel to 2.8.0
- queue only web 1.1.0 for MCP Registry publication

## Why

CLIO needs a local, keyless search provider that can run on a LAN-only homelab deployment without paid-provider credentials. Explicit engines override categories because SearXNG otherwise treats both inputs as a broader union. Every SearXNG-only selector is rejected for other providers.

## Verification

- web offline suite: 86 passed, 3 live tests deselected; 100% line coverage for the SearXNG adapter and 93% for the web package
- web live suite: 3 passed, zero skips
- root suite: 153 passed, zero skips
- Ruff and mypy clean; file-size ratchet clean (`server.py` 799 lines)
- deterministic manifests regenerated for wheel 2.8.0
- constrained wheel and sdist pass Twine 6.2.0
- installed the built wheel into a fresh uv tool environment and called `clio-kit mcp-server web` over stdio against the live SearXNG deployment; returned real GitHub results

## Deployment evidence

The LAN-only SearXNG service is healthy at `10.0.0.102:8088`, digest-pinned, limited to one container and 13 keyless engines, with no Valkey, no paid credentials, and no public binding.
