### PR TITLE
release: CLIO Kit 2.8.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "CLIO Kit - MCP Servers for Scientific Computing and HPC",
-    "version": "2.7.2",
+    "version": "2.8.0",
     "pluginRoot": "./clio-kit-mcp-servers"
   },
   "plugins": [
@@ -327,7 +327,7 @@
       "name": "clio-web",
       "source": "./clio-kit-mcp-servers/web",
       "description": "Web MCP server providing curated fetch + search tools for agentic web access",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "category": "development",
       "keywords": [],
       "license": "BSD-3-Clause",

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,11 +4,13 @@ on:
   pull_request:
     branches:
       - main
+      - develop
     paths:
       - '.github/workflows/publish.yml'
       - 'src/**'
       - 'tests/**'
       - 'scripts/**'
+      - 'build-constraints.txt'
       - 'mcp-server-versions.toml'
       - 'pyproject.toml'
       - 'uv.lock'
@@ -20,10 +22,12 @@ on:
   push:
     branches:
       - main  # Validate release artifacts on main commits
+      - develop
     paths:
       - 'src/**'
       - 'tests/**'
       - 'scripts/**'
+      - 'build-constraints.txt'
       - 'mcp-server-versions.toml'
       - 'pyproject.toml'
       - 'uv.lock'
@@ -74,7 +78,9 @@ jobs:
           scripts/generate_mcp_user_contracts.py \
           scripts/extract_mcp_metadata.py scripts/verify_pypi_release.py \
           scripts/release_authorization.py \
-          scripts/verify_mcp_registry_release.py src
+          scripts/verify_mcp_registry_release.py scripts/check_file_size.py \
+          scripts/check_baseline_diff.py src
+        python scripts/check_file_size.py
         uv run pytest -q tests --junitxml="$RUNNER_TEMP/root-junit.xml"
         python scripts/assert_no_skipped_tests.py "$RUNNER_TEMP/root-junit.xml"
         uv run --with 'pip-audit==2.10.1' pip-audit
@@ -133,6 +139,8 @@ jobs:
 
     - name: Build every root-wheel server package
       shell: bash
+      env:
+        UV_BUILD_CONSTRAINT: ${{ github.workspace }}/build-constraints.txt
       run: |
         server_dist="$(mktemp -d)"
         trap 'rm -rf "$server_dist"' EXIT
@@ -229,6 +237,8 @@ jobs:
         grep "version =" pyproject.toml
     
     - name: Build package
+      env:
+        UV_BUILD_CONSTRAINT: ${{ github.workspace }}/build-constraints.txt
       run: |
         uv build
         uvx --from 'twine==6.2.0' twine check dist/*

--- a/.github/workflows/quality_control.yml
+++ b/.github/workflows/quality_control.yml
@@ -2,9 +2,9 @@ name: Quality Control
 
 on:
   push:
-    branches: [ main, dev ]
+    branches: [ main, dev, develop ]
   pull_request:
-    branches: [ main, dev ]
+    branches: [ main, dev, develop ]
 
 # Chronolog MCP tests are handled in dedicated workflow
 
@@ -88,6 +88,49 @@ jobs:
           echo "search_changed=true" >> $GITHUB_OUTPUT
         else
           echo "search_changed=false" >> $GITHUB_OUTPUT
+        fi
+
+  file-size-ratchet:
+    name: File size ratchet
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+    - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+      with:
+        python-version: '3.11'
+
+    - name: Check per-file size ratchet (campaign #362)
+      run: python scripts/check_file_size.py
+
+  ratchet-baseline-diff-guard:
+    name: Ratchet baseline diff guard (PR)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      with:
+        fetch-depth: 0  # need full history to compute the merge-base
+
+    - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+      with:
+        python-version: '3.11'
+
+    - name: Diff RATCHET_BASELINE against the PR's merge-base
+      shell: bash
+      run: |
+        # check_file_size.py's static checker only ever sees ONE tree, so it
+        # cannot catch a same-commit "grow the file AND its baseline entry to
+        # match" bump, or a rename that mints a fresh baseline entry and sheds
+        # the file's history (#364 review finding 4, round 2). This step
+        # closes both by diffing the embedded RATCHET_BASELINE dict between
+        # the PR head and the merge-base with the target branch.
+        merge_base="$(git merge-base HEAD "origin/${{ github.base_ref }}")"
+        echo "merge-base: $merge_base"
+        if git show "$merge_base:scripts/check_file_size.py" > /tmp/base_check_file_size.py 2>/dev/null; then
+          python scripts/check_baseline_diff.py /tmp/base_check_file_size.py scripts/check_file_size.py
+        else
+          echo "OK: scripts/check_file_size.py did not exist at the merge-base ($merge_base) -- nothing to diff, guard inactive for this PR."
         fi
 
   ruff:

--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ distinct `not_installed` semantic, while real Spack failures remain errors.
 | **`slurm`** | 3.0.0 | HPC | Job submission and management | `clio-kit mcp-server slurm` |
 | **`spack`** | 2.1.0 | Package Management | Structured package discovery, installation, and location | `clio-kit mcp-server spack` |
 | **`terrain`** | 2.2.3 | Geospatial | Analyze DEMs and terrain point clouds | `clio-kit mcp-server terrain` |
-| **`web`** | 1.0.0 | Web | Fetch a URL to Markdown and search the web | `clio-kit mcp-server web` |
+| **`web`** | 1.1.0 | Web | Fetch a URL to Markdown and search the web | `clio-kit mcp-server web` |
 
 </div>
 

--- a/build-constraints.txt
+++ b/build-constraints.txt
@@ -1,0 +1,17 @@
+# Build-time constraints for `uv build` (passed via --build-constraints),
+# NOT a runtime/dependency constraint -- see .github/workflows/publish.yml.
+#
+# hatchling 1.32.0 (released 2026-08-11) bumped its default emitted wheel
+# Metadata-Version from 2.4 to 2.5:
+# https://github.com/pypa/hatch/blob/master/docs/history/hatchling.md
+# The `twine==6.2.0` version pinned for `twine check` in publish.yml bundles
+# pkginfo 1.12.1.2 (the latest published pkginfo as of this pin), which does
+# not recognize Metadata-Version 2.5 and rejects every wheel hatchling>=1.32.0
+# produces with `InvalidDistribution: Invalid distribution metadata: '2.5' is
+# not a valid metadata version`. No released twine/pkginfo understands 2.5 yet
+# (verified against the latest published versions of both, 2026-08-11).
+#
+# Pin hatchling below the breaking release until pkginfo adds Metadata-Version
+# 2.5 support (https://pypi.org/project/pkginfo/) and twine picks it up, then
+# delete this file and the --build-constraints flags that reference it.
+hatchling<1.32.0

--- a/clio-kit-mcp-servers/adios/server.json
+++ b/clio-kit-mcp-servers/adios/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.2",
+      "version": "2.8.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/arxiv/server.json
+++ b/clio-kit-mcp-servers/arxiv/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.2",
+      "version": "2.8.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/arxiv/src/arxiv_mcp/capabilities/arxiv_base.py
+++ b/clio-kit-mcp-servers/arxiv/src/arxiv_mcp/capabilities/arxiv_base.py
@@ -2,12 +2,31 @@
 Base utilities for ArXiv search capabilities.
 """
 
+import asyncio
 import httpx
+import math
 import xml.etree.ElementTree as ET
 from typing import Dict, List, Any, Union, cast
 import logging
 
 logger = logging.getLogger(__name__)
+
+# ArXiv's public API rate-limits aggressively under concurrent load (HTTP 429).
+# A well-behaved client retries a 429 with backoff rather than failing the
+# caller's request outright -- this is standard practice for this API, not a
+# test-only accommodation. Bounded (a few seconds worst case) so a genuinely
+# sustained block still surfaces as a real failure instead of hanging.
+#
+# `Retry-After` is untrusted external input: a misconfigured or hostile server
+# response naming an enormous or non-finite value (86400, inf, nan) must never
+# make this hang -- _RATE_LIMIT_MAX_DELAY_SECONDS caps every individual sleep
+# regardless of source (server-supplied or our own exponential backoff), and
+# _RATE_LIMIT_TOTAL_BUDGET_SECONDS caps the SUM of all sleeps across the whole
+# retry loop as an independent, defense-in-depth ceiling.
+_RATE_LIMIT_MAX_ATTEMPTS = 4
+_RATE_LIMIT_BACKOFF_SECONDS = 1.0
+_RATE_LIMIT_MAX_DELAY_SECONDS = 10.0
+_RATE_LIMIT_TOTAL_BUDGET_SECONDS = 20.0
 
 
 def parse_arxiv_entry(
@@ -95,10 +114,7 @@ async def execute_arxiv_query(
     base_url = "https://export.arxiv.org/api/query"
 
     try:
-        async with httpx.AsyncClient(timeout=30.0) as client:
-            logger.info(f"Executing ArXiv query with params: {params}")
-            response = await client.get(base_url, params=params)
-            response.raise_for_status()
+        response = await _get_with_rate_limit_retry(base_url, params)
 
         # Parse XML response
         root = ET.fromstring(response.content)
@@ -126,6 +142,81 @@ async def execute_arxiv_query(
     except Exception as e:
         logger.error(f"Unexpected error in ArXiv query: {str(e)}")
         raise Exception(f"ArXiv query failed: {str(e)}")
+
+
+async def _get_with_rate_limit_retry(
+    base_url: str, params: Dict[str, Any]
+) -> httpx.Response:
+    """Issue the ArXiv API GET, retrying a 429 response with bounded backoff.
+
+    Every other outcome (success, timeout, a non-429 HTTP error, a connection
+    error) is returned or raised on the first attempt unchanged -- only a 429
+    is treated as transient and retried, honoring ``Retry-After`` when the API
+    sends one. Every sleep is clamped to ``_RATE_LIMIT_MAX_DELAY_SECONDS`` and
+    the loop stops early once ``_RATE_LIMIT_TOTAL_BUDGET_SECONDS`` of
+    cumulative sleep has been spent, so an oversized or non-finite
+    ``Retry-After`` (86400, inf, nan) can never make this hang.
+    """
+    last_error: httpx.HTTPStatusError | None = None
+    total_slept = 0.0
+    for attempt in range(_RATE_LIMIT_MAX_ATTEMPTS):
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            logger.info(f"Executing ArXiv query with params: {params}")
+            response = await client.get(base_url, params=params)
+            if response.status_code != 429:
+                response.raise_for_status()
+                return response
+            last_error = httpx.HTTPStatusError(
+                f"Client error '429 Too Many Requests' for url '{response.url}'",
+                request=response.request,
+                response=response,
+            )
+        if attempt + 1 >= _RATE_LIMIT_MAX_ATTEMPTS:
+            break
+        remaining_budget = _RATE_LIMIT_TOTAL_BUDGET_SECONDS - total_slept
+        if remaining_budget <= 0:
+            logger.warning(
+                "ArXiv API rate-limited (429); retry time budget "
+                f"({_RATE_LIMIT_TOTAL_BUDGET_SECONDS:.0f}s) exhausted, giving up"
+            )
+            break
+        retry_after = _parse_retry_after(response.headers.get("Retry-After"))
+        requested_delay = (
+            retry_after
+            if retry_after is not None
+            else (_RATE_LIMIT_BACKOFF_SECONDS * (2**attempt))
+        )
+        delay = max(
+            0.0, min(requested_delay, _RATE_LIMIT_MAX_DELAY_SECONDS, remaining_budget)
+        )
+        logger.warning(
+            f"ArXiv API rate-limited (429); retrying in {delay:.1f}s "
+            f"(attempt {attempt + 1}/{_RATE_LIMIT_MAX_ATTEMPTS})"
+        )
+        await asyncio.sleep(delay)
+        total_slept += delay
+    assert last_error is not None
+    raise last_error
+
+
+def _parse_retry_after(value: str | None) -> float | None:
+    """Parse a numeric ``Retry-After`` header value in seconds, if present.
+
+    ``Retry-After`` is untrusted external input. ``inf``/``nan`` parse
+    successfully as floats in Python but are rejected here explicitly --
+    callers still clamp the result to ``_RATE_LIMIT_MAX_DELAY_SECONDS``
+    regardless, but a non-finite value should never reach that clamp as a
+    seemingly legitimate number in the first place.
+    """
+    if value is None:
+        return None
+    try:
+        parsed = float(value)
+    except ValueError:
+        return None
+    if not math.isfinite(parsed):
+        return None
+    return max(0.0, parsed)
 
 
 def generate_bibtex(

--- a/clio-kit-mcp-servers/arxiv/tests/test_arxiv_base.py
+++ b/clio-kit-mcp-servers/arxiv/tests/test_arxiv_base.py
@@ -2,11 +2,16 @@
 Tests for ArXiv base utilities.
 """
 
+import math
 import pytest
 import xml.etree.ElementTree as ET
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from arxiv_mcp.capabilities.arxiv_base import (
+    _RATE_LIMIT_BACKOFF_SECONDS,
+    _RATE_LIMIT_MAX_DELAY_SECONDS,
+    _RATE_LIMIT_TOTAL_BUDGET_SECONDS,
+    _parse_retry_after,
     parse_arxiv_entry,
     execute_arxiv_query,
     generate_bibtex,
@@ -391,3 +396,270 @@ class TestGenerateBibtex:
             assert (
                 f"@article{{{expected_id}," in result or "@article{unknown," in result
             )
+
+
+class TestRateLimitRetry:
+    """execute_arxiv_query retries a 429 with bounded backoff (real ArXiv
+    rate-limit behavior, not a test-only accommodation -- see arxiv_base.py's
+    _get_with_rate_limit_retry). asyncio.sleep is patched to a no-op so these
+    stay instant; the retry COUNT and terminal behavior are what's verified.
+    """
+
+    @staticmethod
+    def _feed_response() -> MagicMock:
+        content = """
+        <feed xmlns="http://www.w3.org/2005/Atom">
+            <entry>
+                <id>http://arxiv.org/abs/2401.12345v1</id>
+                <title>Test Paper</title>
+            </entry>
+        </feed>
+        """
+        response = MagicMock()
+        response.status_code = 200
+        response.content = content.encode()
+        response.raise_for_status.return_value = None
+        return response
+
+    @staticmethod
+    def _rate_limited_response() -> MagicMock:
+        response = MagicMock()
+        response.status_code = 429
+        response.url = "https://export.arxiv.org/api/query"
+        response.request = MagicMock()
+        response.headers = {}
+        return response
+
+    @pytest.mark.asyncio
+    @patch("arxiv_mcp.capabilities.arxiv_base.asyncio.sleep", new_callable=AsyncMock)
+    async def test_retries_once_on_429_then_succeeds(self, mock_sleep):
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client.get.side_effect = [
+                self._rate_limited_response(),
+                self._feed_response(),
+            ]
+            mock_client_class.return_value.__aenter__.return_value = mock_client
+            mock_client_class.return_value.__aexit__.return_value = None
+
+            result = await execute_arxiv_query(
+                {"search_query": "test", "max_results": 1}
+            )
+
+            assert len(result) == 1
+            assert mock_client.get.call_count == 2
+            mock_sleep.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    @patch("arxiv_mcp.capabilities.arxiv_base.asyncio.sleep", new_callable=AsyncMock)
+    async def test_exhausts_retries_and_raises_429(self, mock_sleep):
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client.get.side_effect = [
+                self._rate_limited_response() for _ in range(4)
+            ]
+            mock_client_class.return_value.__aenter__.return_value = mock_client
+            mock_client_class.return_value.__aexit__.return_value = None
+
+            with pytest.raises(Exception, match="ArXiv API error: 429"):
+                await execute_arxiv_query({"search_query": "test", "max_results": 1})
+
+            assert mock_client.get.call_count == 4
+            assert mock_sleep.await_count == 3
+
+    @pytest.mark.asyncio
+    @patch("arxiv_mcp.capabilities.arxiv_base.asyncio.sleep", new_callable=AsyncMock)
+    async def test_honors_retry_after_header(self, mock_sleep):
+        rate_limited = self._rate_limited_response()
+        rate_limited.headers = {"Retry-After": "2.5"}
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client.get.side_effect = [rate_limited, self._feed_response()]
+            mock_client_class.return_value.__aenter__.return_value = mock_client
+            mock_client_class.return_value.__aexit__.return_value = None
+
+            await execute_arxiv_query({"search_query": "test", "max_results": 1})
+
+            mock_sleep.assert_awaited_once_with(2.5)
+
+    @pytest.mark.asyncio
+    @patch("arxiv_mcp.capabilities.arxiv_base.asyncio.sleep", new_callable=AsyncMock)
+    async def test_non_429_status_is_not_retried(self, mock_sleep):
+        """A non-429 error fails immediately -- only 429 is treated as transient."""
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            error_response = MagicMock()
+            error_response.status_code = 500
+
+            from httpx import HTTPStatusError, Request
+
+            error_response.raise_for_status.side_effect = HTTPStatusError(
+                "Server Error",
+                request=MagicMock(spec=Request),
+                response=error_response,
+            )
+            mock_client.get.return_value = error_response
+            mock_client_class.return_value.__aenter__.return_value = mock_client
+            mock_client_class.return_value.__aexit__.return_value = None
+
+            with pytest.raises(Exception, match="ArXiv API error: 500"):
+                await execute_arxiv_query({"search_query": "test", "max_results": 1})
+
+            assert mock_client.get.call_count == 1
+            mock_sleep.assert_not_awaited()
+
+    # -- PR #364 review round 2, finding 2: Retry-After is untrusted input and
+    # must never be allowed to produce an unbounded or non-finite sleep. --
+
+    def test_parse_retry_after_rejects_oversized_values(self):
+        """A malicious/misconfigured server naming a day-long delay is not
+        trusted verbatim; parsing succeeds (it's a real number) but bounding
+        it is the caller's job -- see test_oversized_retry_after_is_capped.
+        """
+        assert _parse_retry_after("86400") == 86400.0
+
+    def test_parse_retry_after_rejects_non_finite_values(self):
+        """inf/nan parse as valid floats in Python but must not be treated as
+        a legitimate delay -- an inf Retry-After must never reach
+        asyncio.sleep as a seemingly normal number.
+        """
+        assert _parse_retry_after("inf") is None
+        assert _parse_retry_after("Infinity") is None
+        assert _parse_retry_after("-inf") is None
+        assert _parse_retry_after("nan") is None
+
+    def test_parse_retry_after_rejects_negative_values(self):
+        assert _parse_retry_after("-5") == 0.0
+
+    def test_parse_retry_after_ignores_non_numeric_garbage(self):
+        """A malformed Retry-After (not a number, not a recognized date) must
+        parse to None -- never raise -- so the caller falls back to the
+        default exponential backoff instead of crashing the retry loop.
+        """
+        assert _parse_retry_after("banana") is None
+        assert _parse_retry_after("") is None
+        assert _parse_retry_after("12abc") is None
+
+    def test_parse_retry_after_ignores_http_date_form(self):
+        """Retry-After may legally be an HTTP-date (RFC 9110 10.2.3) instead
+        of a delay-seconds integer, e.g. 'Wed, 21 Oct 2026 07:28:00 GMT'.
+        This parser only understands delay-seconds; a date form must parse
+        to None (never raise), falling back to the default backoff -- exactly
+        like any other value it doesn't understand.
+        """
+        assert _parse_retry_after("Wed, 21 Oct 2026 07:28:00 GMT") is None
+
+    @pytest.mark.asyncio
+    @patch("arxiv_mcp.capabilities.arxiv_base.asyncio.sleep", new_callable=AsyncMock)
+    async def test_malformed_retry_after_falls_back_to_default_backoff(
+        self, mock_sleep
+    ):
+        """End-to-end: a 429 with a garbage Retry-After header must not raise
+        or hang -- it retries using the default exponential backoff, exactly
+        as if no Retry-After header had been sent at all.
+        """
+        malformed = self._rate_limited_response()
+        malformed.headers = {"Retry-After": "banana"}
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client.get.side_effect = [malformed, self._feed_response()]
+            mock_client_class.return_value.__aenter__.return_value = mock_client
+            mock_client_class.return_value.__aexit__.return_value = None
+
+            result = await execute_arxiv_query(
+                {"search_query": "test", "max_results": 1}
+            )
+
+            assert len(result) == 1
+            mock_sleep.assert_awaited_once_with(_RATE_LIMIT_BACKOFF_SECONDS)
+
+    @pytest.mark.asyncio
+    @patch("arxiv_mcp.capabilities.arxiv_base.asyncio.sleep", new_callable=AsyncMock)
+    async def test_http_date_retry_after_falls_back_to_default_backoff(
+        self, mock_sleep
+    ):
+        """Same as above, for the HTTP-date form specifically."""
+        dated = self._rate_limited_response()
+        dated.headers = {"Retry-After": "Wed, 21 Oct 2026 07:28:00 GMT"}
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client.get.side_effect = [dated, self._feed_response()]
+            mock_client_class.return_value.__aenter__.return_value = mock_client
+            mock_client_class.return_value.__aexit__.return_value = None
+
+            result = await execute_arxiv_query(
+                {"search_query": "test", "max_results": 1}
+            )
+
+            assert len(result) == 1
+            mock_sleep.assert_awaited_once_with(_RATE_LIMIT_BACKOFF_SECONDS)
+
+    @pytest.mark.asyncio
+    @patch("arxiv_mcp.capabilities.arxiv_base.asyncio.sleep", new_callable=AsyncMock)
+    async def test_oversized_retry_after_is_capped(self, mock_sleep):
+        """Retry-After: 86400 (a day) must sleep for seconds, not a day."""
+        oversized = self._rate_limited_response()
+        oversized.headers = {"Retry-After": "86400"}
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client.get.side_effect = [oversized, self._feed_response()]
+            mock_client_class.return_value.__aenter__.return_value = mock_client
+            mock_client_class.return_value.__aexit__.return_value = None
+
+            await execute_arxiv_query({"search_query": "test", "max_results": 1})
+
+            mock_sleep.assert_awaited_once()
+            (slept,) = mock_sleep.await_args.args
+            assert slept <= _RATE_LIMIT_MAX_DELAY_SECONDS
+
+    @pytest.mark.asyncio
+    @patch("arxiv_mcp.capabilities.arxiv_base.asyncio.sleep", new_callable=AsyncMock)
+    async def test_infinite_retry_after_is_capped(self, mock_sleep):
+        """Retry-After: inf must not hang forever -- falls back to backoff,
+        itself bounded, never an unbounded/non-finite sleep.
+        """
+        infinite = self._rate_limited_response()
+        infinite.headers = {"Retry-After": "inf"}
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client.get.side_effect = [infinite, self._feed_response()]
+            mock_client_class.return_value.__aenter__.return_value = mock_client
+            mock_client_class.return_value.__aexit__.return_value = None
+
+            await execute_arxiv_query({"search_query": "test", "max_results": 1})
+
+            mock_sleep.assert_awaited_once()
+            (slept,) = mock_sleep.await_args.args
+            assert math.isfinite(slept)
+            assert slept <= _RATE_LIMIT_MAX_DELAY_SECONDS
+
+    @pytest.mark.asyncio
+    @patch("arxiv_mcp.capabilities.arxiv_base.asyncio.sleep", new_callable=AsyncMock)
+    async def test_total_retry_budget_is_bounded(self, mock_sleep):
+        """Even with every attempt requesting a large Retry-After, the SUM of
+        every sleep across the whole retry loop never exceeds
+        _RATE_LIMIT_TOTAL_BUDGET_SECONDS -- independent of the per-attempt cap.
+        """
+
+        def _rate_limited_15s() -> MagicMock:
+            response = self._rate_limited_response()
+            response.headers = {"Retry-After": "15"}
+            return response
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            # Every attempt (up to the max) is rate-limited with a large ask.
+            mock_client.get.side_effect = [_rate_limited_15s() for _ in range(4)]
+            mock_client_class.return_value.__aenter__.return_value = mock_client
+            mock_client_class.return_value.__aexit__.return_value = None
+
+            with pytest.raises(Exception, match="ArXiv API error: 429"):
+                await execute_arxiv_query({"search_query": "test", "max_results": 1})
+
+            total_slept = sum(call.args[0] for call in mock_sleep.await_args_list)
+            assert total_slept <= _RATE_LIMIT_TOTAL_BUDGET_SECONDS
+            for call in mock_sleep.await_args_list:
+                assert call.args[0] <= _RATE_LIMIT_MAX_DELAY_SECONDS
+            # The budget being exhausted stops the loop before every possible
+            # attempt is spent retrying -- fewer GET calls than the max.
+            assert mock_client.get.call_count < 4

--- a/clio-kit-mcp-servers/chronolog/server.json
+++ b/clio-kit-mcp-servers/chronolog/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.2",
+      "version": "2.8.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/compression/server.json
+++ b/clio-kit-mcp-servers/compression/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.2",
+      "version": "2.8.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/darshan/server.json
+++ b/clio-kit-mcp-servers/darshan/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.2",
+      "version": "2.8.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/geo/server.json
+++ b/clio-kit-mcp-servers/geo/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.2",
+      "version": "2.8.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/geojson/server.json
+++ b/clio-kit-mcp-servers/geojson/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.2",
+      "version": "2.8.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/hdf5/server.json
+++ b/clio-kit-mcp-servers/hdf5/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.2",
+      "version": "2.8.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/jarvis/server.json
+++ b/clio-kit-mcp-servers/jarvis/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.2",
+      "version": "2.8.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/jarvis/src/jarvis_mcp/models/__init__.py
+++ b/clio-kit-mcp-servers/jarvis/src/jarvis_mcp/models/__init__.py
@@ -1,0 +1,21 @@
+"""Wire-facing data models for the jarvis MCP server, grouped by concern.
+
+Split out of ``jarvis_mcp.server`` (clio-kit campaign #362, Slice 1) so the
+44 Pydantic/TypedDict/dataclass models that previously lived inline in the
+3109-line ``server.py`` have owner modules. Tool registration (the
+``@mcp.tool`` surface) stays thin in ``server.py``, importing from here.
+
+Submodules, by concern:
+
+- ``_base``: the shared ``_ClosedDocument`` base (``extra="forbid"``).
+- ``compat``: the JARVIS-CD manager compatibility adapter.
+- ``packages``: package inventory/description/deployment/settings documents.
+- ``describe``: the ``jarvis_describe`` discriminated result union.
+- ``execution``: execution handle/record/run-result documents, and the
+  ``ExecutionIntent`` request model with its validation/conversion helpers.
+- ``progress``: package progress event/snapshot documents.
+- ``artifact_documents``: artifact location/document/page documents and the
+  ``ExecutionArtifactQuery`` request filter.
+- ``datasets``: the JARVIS-owned dataset descriptor documents.
+- ``service_runtime``: execution-owned service-runtime documents.
+"""

--- a/clio-kit-mcp-servers/jarvis/src/jarvis_mcp/models/_base.py
+++ b/clio-kit-mcp-servers/jarvis/src/jarvis_mcp/models/_base.py
@@ -1,0 +1,11 @@
+"""Shared base for every closed (``extra="forbid"``) agent-visible document."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+
+class _ClosedDocument(BaseModel):
+    """Base for agent-visible documents with no undeclared fields."""
+
+    model_config = ConfigDict(extra="forbid")

--- a/clio-kit-mcp-servers/jarvis/src/jarvis_mcp/models/artifact_documents.py
+++ b/clio-kit-mcp-servers/jarvis/src/jarvis_mcp/models/artifact_documents.py
@@ -1,0 +1,124 @@
+"""Artifact location/document/page documents and the artifact query filter."""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from typing_extensions import NotRequired, TypedDict
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class JarvisArtifactLocationDocument(TypedDict):
+    """Transport-neutral location in a JARVIS artifact manifest."""
+
+    kind: Literal["execution_path", "cluster_path", "external_uri"]
+    value: str
+
+
+class JarvisArtifactDocument(TypedDict):
+    """Current JARVIS-owned lifecycle observation for one generated artifact."""
+
+    schema_version: Literal["jarvis.artifact.v1"]
+    package_name: str
+    package_id: str
+    execution_id: str
+    artifact_id: str
+    logical_name: str
+    kind: str
+    role: Literal[
+        "intermediate",
+        "output",
+        "log",
+        "checkpoint",
+        "provenance",
+        "validation",
+    ]
+    structure: Literal["file", "directory", "collection", "stream"]
+    ownership: Literal["execution", "external", "shared"]
+    state: Literal["producing", "available", "finalized", "incomplete", "failed"]
+    revision: int
+    sequence: int
+    observed_at_epoch: float
+    metadata: dict[str, Any]
+    location: NotRequired[JarvisArtifactLocationDocument]
+    media_type: NotRequired[str]
+    format: NotRequired[str]
+    size_bytes: NotRequired[int]
+    checksum: NotRequired[str]
+    message: NotRequired[str]
+
+
+class JarvisExecutionArtifactPageDocument(BaseModel):
+    """Bounded artifact page nested in a unified execution query."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    producer_schema_version: Literal["jarvis.execution.artifacts.v1"]
+    pipeline_id: str
+    execution_id: str
+    execution_state: Literal[
+        "preparing",
+        "scripted",
+        "submitting",
+        "submitted",
+        "running",
+        "completed",
+        "failed",
+        "canceled",
+        "unknown",
+    ]
+    terminal: bool
+    artifacts: list[JarvisArtifactDocument]
+    matching_artifact_count: int
+    returned_artifact_count: int
+    next_cursor: str | None
+
+
+class ExecutionArtifactQuery(BaseModel):
+    """Optional filters for one bounded page of execution artifacts."""
+
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+    package_id: str | None = Field(
+        default=None,
+        description="Exact JARVIS package alias filter.",
+        max_length=256,
+    )
+    role: (
+        Literal[
+            "intermediate",
+            "output",
+            "log",
+            "checkpoint",
+            "provenance",
+            "validation",
+        ]
+        | None
+    ) = None
+    state: (
+        Literal[
+            "producing",
+            "available",
+            "finalized",
+            "incomplete",
+            "failed",
+        ]
+        | None
+    ) = None
+    artifact_id: str | None = Field(
+        default=None,
+        description="Exact opaque JARVIS artifact ID filter.",
+        max_length=90,
+    )
+    page_size: int = Field(
+        default=50,
+        description="Maximum artifacts to return in this page.",
+        ge=1,
+        le=100,
+    )
+    cursor: str | None = Field(
+        default=None,
+        description="Opaque next-page cursor.",
+        max_length=1024,
+    )

--- a/clio-kit-mcp-servers/jarvis/src/jarvis_mcp/models/compat.py
+++ b/clio-kit-mcp-servers/jarvis/src/jarvis_mcp/models/compat.py
@@ -1,0 +1,143 @@
+"""Compatibility adapter over the current JARVIS-CD ``Jarvis`` singleton."""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+from typing import Any, Optional
+
+
+class _CurrentJarvisManager:
+    """Compatibility adapter over the current JARVIS-CD Jarvis singleton."""
+
+    @classmethod
+    def get_instance(cls) -> "_CurrentJarvisManager":
+        jarvis_module = importlib.import_module("jarvis_cd.core.config")
+        return cls(jarvis_module.Jarvis.get_instance())
+
+    def __init__(self, jarvis: Any) -> None:
+        self.jarvis = jarvis
+
+    def create(
+        self, config_dir: str, private_dir: str, shared_dir: Optional[str] = None
+    ) -> "_CurrentJarvisManager":
+        self.jarvis.initialize(
+            config_dir=config_dir,
+            private_dir=private_dir,
+            shared_dir=shared_dir or private_dir,
+        )
+        return self
+
+    def load(self) -> "_CurrentJarvisManager":
+        _ = self.jarvis.config
+        return self
+
+    def save(self) -> "_CurrentJarvisManager":
+        if getattr(self.jarvis, "_config", None) is not None:
+            self.jarvis.save_config(self.jarvis.config)
+        if getattr(self.jarvis, "_repos", None) is not None:
+            self.jarvis.save_repos(self.jarvis.repos)
+        return self
+
+    def set_hostfile(self, path: str) -> "_CurrentJarvisManager":
+        self.jarvis.set_hostfile(path)
+        return self
+
+    def bootstrap_from(self, machine: str) -> "_CurrentJarvisManager":
+        raise NotImplementedError(
+            f"bootstrap templates are not exposed by current JARVIS-CD: {machine}"
+        )
+
+    def bootstrap_list(self) -> list[str]:
+        return []
+
+    def reset(self) -> "_CurrentJarvisManager":
+        raise NotImplementedError(
+            "reset is not exposed through the compatibility adapter"
+        )
+
+    def list_pipelines(self) -> list[str]:
+        pipelines_dir = self.jarvis.get_pipelines_dir()
+        if not pipelines_dir.exists():
+            return []
+        return sorted(path.name for path in pipelines_dir.iterdir() if path.is_dir())
+
+    def cd(self, pipeline_id: str) -> "_CurrentJarvisManager":
+        self.jarvis.set_current_pipeline(pipeline_id)
+        return self
+
+    def list_repos(self) -> list[str]:
+        return list(self.jarvis.repos.get("repos", []))
+
+    def add_repo(self, path: str, force: bool = False) -> "_CurrentJarvisManager":
+        self.jarvis.add_repo(path, force=force)
+        return self
+
+    def remove_repo(self, repo_name: str) -> "_CurrentJarvisManager":
+        repo_paths = list(self.jarvis.repos.get("repos", []))
+        matches = [
+            repo_path
+            for repo_path in repo_paths
+            if repo_path == repo_name or Path(repo_path).name == repo_name
+        ]
+        if not matches:
+            self.jarvis.remove_repo(repo_name)
+        for repo_path in matches:
+            self.jarvis.remove_repo(repo_path)
+        return self
+
+    def promote_repo(self, repo_name: str) -> "_CurrentJarvisManager":
+        repos = self.jarvis.repos.copy()
+        repo_paths = list(repos.get("repos", []))
+        matches = [
+            repo_path
+            for repo_path in repo_paths
+            if repo_path == repo_name or Path(repo_path).name == repo_name
+        ]
+        if not matches:
+            raise ValueError(f"repository not found: {repo_name}")
+        for repo_path in reversed(matches):
+            repo_paths.remove(repo_path)
+            repo_paths.insert(0, repo_path)
+        repos["repos"] = repo_paths
+        self.jarvis.save_repos(repos)
+        return self
+
+    def get_repo(self, repo_name: str) -> dict[str, Any] | None:
+        for index, repo_path in enumerate(self.jarvis.repos.get("repos", []), start=1):
+            if repo_path == repo_name or Path(repo_path).name == repo_name:
+                return {
+                    "index": index,
+                    "name": Path(repo_path).name,
+                    "path": repo_path,
+                    "exists": Path(repo_path).exists(),
+                }
+        return None
+
+    def construct_pkg(self, pkg_type: str) -> Any:
+        raise NotImplementedError(
+            f"package construction is not exposed by current JARVIS-CD: {pkg_type}"
+        )
+
+    def resource_graph_show(self) -> dict[str, Any]:
+        return self.jarvis.resource_graph
+
+    def resource_graph_build(self, net_sleep: float) -> dict[str, Any]:
+        _ = net_sleep
+        raise NotImplementedError(
+            "resource graph build is not exposed through the compatibility adapter"
+        )
+
+    def resource_graph_modify(self, net_sleep: float) -> dict[str, Any]:
+        _ = net_sleep
+        raise NotImplementedError(
+            "resource graph modify is not exposed through the compatibility adapter"
+        )
+
+
+def _load_jarvis_manager_class() -> Any:
+    try:
+        module = importlib.import_module("jarvis_cd.basic.jarvis_manager")
+        return module.JarvisManager
+    except ModuleNotFoundError:
+        return _CurrentJarvisManager

--- a/clio-kit-mcp-servers/jarvis/src/jarvis_mcp/models/datasets.py
+++ b/clio-kit-mcp-servers/jarvis/src/jarvis_mcp/models/datasets.py
@@ -1,0 +1,142 @@
+"""JARVIS-owned dataset descriptor documents."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import PurePosixPath
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+
+class JarvisDatasetMemberDocument(BaseModel):
+    """One ordered member in a JARVIS service dataset descriptor."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+    index: int = Field(ge=0)
+    location: str = Field(min_length=1, max_length=4096)
+    timestep: float | None = Field(default=None, allow_inf_nan=False)
+
+    @field_validator("location")
+    @classmethod
+    def validate_cluster_location(cls, value: str) -> str:
+        """Require the normalized absolute POSIX path emitted by JARVIS."""
+        path = PurePosixPath(value)
+        if (
+            "\\" in value
+            or not path.is_absolute()
+            or path.as_posix() != value
+            or ".." in path.parts
+        ):
+            raise ValueError(
+                "dataset member location must be a normalized absolute path"
+            )
+        return value
+
+
+class JarvisDatasetArrayDocument(BaseModel):
+    """One intrinsic array exposed by a JARVIS-owned service."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+    name: str = Field(min_length=1, max_length=512)
+    association: Literal["point", "cell", "field"]
+    components: int = Field(ge=1, le=64)
+    units: str | None = Field(default=None, min_length=1, max_length=256)
+
+
+class JarvisDatasetFingerprintDocument(BaseModel):
+    """Canonical identity digest for one bounded dataset descriptor."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+    algorithm: Literal["sha256"]
+    digest: str = Field(pattern=r"^[0-9a-f]{64}$")
+
+
+class JarvisDatasetSourceArtifactDocument(BaseModel):
+    """Optional content identity of a JARVIS-generated source artifact."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+    artifact_id: str = Field(pattern=r"^art_[A-Za-z0-9_-]{22,86}$")
+    sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+
+
+class JarvisDatasetDescriptorDocument(BaseModel):
+    """Intrinsic, recipe-free dataset identity owned by JARVIS."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+    schema_version: Literal["jarvis.dataset-descriptor.v1"]
+    dataset_id: str = Field(min_length=1, max_length=256)
+    kind: str = Field(min_length=1, max_length=256)
+    format: str = Field(min_length=1, max_length=256)
+    members: list[JarvisDatasetMemberDocument] = Field(min_length=1, max_length=512)
+    arrays: list[JarvisDatasetArrayDocument] = Field(max_length=256)
+    bounds: list[float] | None = Field(default=None, min_length=6, max_length=6)
+    fingerprint: JarvisDatasetFingerprintDocument
+    source_artifact: JarvisDatasetSourceArtifactDocument | None
+
+    @model_validator(mode="after")
+    def validate_intrinsic_identity(self) -> "JarvisDatasetDescriptorDocument":
+        """Reject ambiguous ordering and verify the canonical fingerprint."""
+        if [member.index for member in self.members] != list(range(len(self.members))):
+            raise ValueError("dataset member indexes must be contiguous and ordered")
+        locations = [member.location for member in self.members]
+        if len(locations) != len(set(locations)):
+            raise ValueError("dataset member locations must be unique")
+        array_keys = [(array.association, array.name) for array in self.arrays]
+        if len(array_keys) != len(set(array_keys)):
+            raise ValueError("dataset array identities must be unique")
+        if self.bounds is not None:
+            for lower, upper in zip(self.bounds[::2], self.bounds[1::2]):
+                if lower > upper:
+                    raise ValueError("dataset bounds must be ordered")
+        members: list[dict[str, Any]] = []
+        for member in self.members:
+            value: dict[str, Any] = {
+                "index": member.index,
+                "location": member.location,
+            }
+            if member.timestep is not None:
+                value["timestep"] = member.timestep
+            members.append(value)
+        arrays: list[dict[str, Any]] = []
+        for array in self.arrays:
+            value = {
+                "name": array.name,
+                "association": array.association,
+                "components": array.components,
+            }
+            if array.units is not None:
+                value["units"] = array.units
+            arrays.append(value)
+        canonical = {
+            "schema_version": self.schema_version,
+            "dataset_id": self.dataset_id,
+            "kind": self.kind,
+            "format": self.format,
+            "members": members,
+            "arrays": arrays,
+            "bounds": list(self.bounds) if self.bounds is not None else None,
+            "source_artifact": (
+                self.source_artifact.model_dump(mode="json")
+                if self.source_artifact is not None
+                else None
+            ),
+        }
+        digest = hashlib.sha256(
+            json.dumps(
+                canonical,
+                allow_nan=False,
+                ensure_ascii=False,
+                separators=(",", ":"),
+                sort_keys=True,
+            ).encode("utf-8")
+        ).hexdigest()
+        if digest != self.fingerprint.digest:
+            raise ValueError("dataset fingerprint did not match its descriptor")
+        return self

--- a/clio-kit-mcp-servers/jarvis/src/jarvis_mcp/models/describe.py
+++ b/clio-kit-mcp-servers/jarvis/src/jarvis_mcp/models/describe.py
@@ -1,0 +1,65 @@
+"""The ``jarvis_describe`` discriminated result union."""
+
+from __future__ import annotations
+
+from typing import Annotated, Any, Literal
+
+from pydantic import Field
+
+from ._base import _ClosedDocument
+from .packages import JarvisPackageDescriptionDocument, JarvisPackageSummaryDocument
+
+PACKAGE_SEARCH_SCHEMA = "jarvis.package-search.v1"
+PACKAGE_SEARCH_CURSOR_SCHEMA = "clio-kit.jarvis-package-search-cursor.v1"
+
+
+class JarvisDescribePackagesResult(_ClosedDocument):
+    """Exhaustive legacy package inventory result."""
+
+    target: Literal["packages"]
+    packages: list[JarvisPackageDescriptionDocument]
+
+
+class JarvisDescribePackageSearchResult(_ClosedDocument):
+    """Bounded package search page."""
+
+    schema_version: Literal["jarvis.package-search.v1"]
+    target: Literal["package_search"]
+    query: str
+    inventory_revision: str
+    packages: list[JarvisPackageSummaryDocument]
+    total_matches: int
+    returned_count: int
+    next_cursor: str | None
+
+
+class JarvisDescribePackageResult(_ClosedDocument):
+    """Exact package description result."""
+
+    target: Literal["package"]
+    package: JarvisPackageDescriptionDocument
+
+
+class JarvisDescribePipelineResult(_ClosedDocument):
+    """Stored pipeline snapshot result."""
+
+    target: Literal["pipeline"]
+    pipeline: dict[str, Any]
+
+
+class JarvisDescribeStepResult(_ClosedDocument):
+    """Stored pipeline step and package configuration result."""
+
+    target: Literal["step"]
+    step: dict[str, Any]
+    config: dict[str, Any]
+
+
+JarvisDescribeResult = Annotated[
+    JarvisDescribePackagesResult
+    | JarvisDescribePackageSearchResult
+    | JarvisDescribePackageResult
+    | JarvisDescribePipelineResult
+    | JarvisDescribeStepResult,
+    Field(discriminator="target"),
+]

--- a/clio-kit-mcp-servers/jarvis/src/jarvis_mcp/models/execution.py
+++ b/clio-kit-mcp-servers/jarvis/src/jarvis_mcp/models/execution.py
@@ -1,0 +1,359 @@
+"""Execution handle/record/run-result documents and the execution intent request model.
+
+Bundles ``ExecutionIntent`` with its validation/conversion helpers
+(``_validated_execution_intent``, ``_execution_intent_to_pipeline_config``,
+``_detect_scheduler_name``) as one concern: the request-side execution intent
+and the response-side execution documents it drives. The tool functions that
+call these helpers (``jarvis_run_tool``, ``jarvis_create_pipeline_tool``) stay
+in ``server.py``; only the pure validation/conversion logic lives here.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from typing import Any, Literal
+
+from typing_extensions import TypedDict
+
+from fastmcp.exceptions import ToolError
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    ValidationError,
+    field_validator,
+    model_validator,
+)
+
+from .artifact_documents import JarvisExecutionArtifactPageDocument
+from .progress import JarvisProgressSnapshotDocument
+from .service_runtime import JarvisServiceRuntimeSnapshotDocument
+
+
+class JarvisExecutionHandleDocument(TypedDict):
+    """Stable JARVIS-CD execution-handle document."""
+
+    schema_version: Literal["jarvis.execution.handle.v1"]
+    execution_id: str
+    pipeline_id: str
+    mode: Literal["direct", "scheduler"]
+    scheduler_provider: str | None
+    scheduler_native_id: str | None
+    cluster: str | None
+
+
+class JarvisExecutionRecordDocument(TypedDict):
+    """Stable JARVIS-CD durable execution-record document."""
+
+    schema_version: Literal["jarvis.execution.record.v1"]
+    execution_id: str
+    pipeline_id: str
+    pipeline_name: str
+    mode: Literal["direct", "scheduler"]
+    scheduler_provider: str | None
+    scheduler_native_id: str | None
+    cluster: str | None
+    state: Literal[
+        "preparing",
+        "scripted",
+        "submitting",
+        "submitted",
+        "running",
+        "completed",
+        "failed",
+        "canceled",
+        "unknown",
+    ]
+    submitted: bool
+    terminal: bool
+    created_at: str
+    updated_at: str
+    return_code: int | None
+    error: str | None
+    metadata: dict[str, Any]
+
+
+class JarvisRunResult(TypedDict):
+    """Frozen top-level result envelope for ``jarvis_run``."""
+
+    schema_version: Literal["clio-kit.jarvis-run.v1"]
+    pipeline_id: str
+    execution_id: str
+    status: Literal[
+        "preparing",
+        "scripted",
+        "submitting",
+        "submitted",
+        "running",
+        "completed",
+        "failed",
+        "canceled",
+        "unknown",
+    ]
+    mode: Literal["direct", "scheduler"]
+    scheduler: dict[str, Any] | None
+    script_path: str | None
+    wait: bool
+    execution_handle: JarvisExecutionHandleDocument
+    execution_record: JarvisExecutionRecordDocument
+    progress: JarvisProgressSnapshotDocument
+    runtime_metadata: dict[str, Any]
+
+
+class JarvisExecutionResult(BaseModel):
+    """Frozen top-level result envelope for a selectable execution query."""
+
+    model_config = ConfigDict(
+        extra="forbid",
+        frozen=True,
+        hide_input_in_errors=True,
+    )
+
+    schema_version: Literal["clio-kit.jarvis-execution.v2"]
+    pipeline_id: str
+    execution_id: str
+    execution_handle: JarvisExecutionHandleDocument
+    execution_record: JarvisExecutionRecordDocument
+    runtime_metadata: dict[str, Any]
+    progress: JarvisProgressSnapshotDocument | None
+    artifact_page: JarvisExecutionArtifactPageDocument | None
+    service_runtimes: JarvisServiceRuntimeSnapshotDocument | None
+
+
+_EXECUTION_MODES = {
+    "auto",
+    "local",
+    "direct",
+    "cluster",
+    "scheduler",
+    "hostfile",
+}
+_SCHEDULER_EXECUTION_FIELDS = {
+    "job_name",
+    "nodes",
+    "tasks",
+    "tasks_per_node",
+    "cpus_per_task",
+    "walltime",
+    "partition",
+    "account",
+    "qos",
+    "output",
+    "error",
+    "exclusive",
+    "gpus",
+    "gpus_per_node",
+}
+_SCHEDULER_TOKEN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:@%+,-]{0,255}$")
+_HOST_ENTRY = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,252}$")
+
+
+def _bounded_single_line(value: str, *, field: str, limit: int = 4096) -> str:
+    """Reject control characters and unbounded scheduler/path text."""
+    if not value or len(value.encode("utf-8")) > limit:
+        raise ValueError(f"execution.{field} must be a non-empty bounded string")
+    if any(ord(character) < 32 or ord(character) == 127 for character in value):
+        raise ValueError(f"execution.{field} cannot contain control characters")
+    return value
+
+
+class ExecutionIntent(BaseModel):
+    """Validated, backend-neutral execution request for a JARVIS pipeline."""
+
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+    mode: Literal["auto", "local", "direct", "cluster", "scheduler", "hostfile"] = (
+        "auto"
+    )
+    hostfile: str | None = None
+    hosts: list[str] | None = Field(default=None, min_length=1)
+    job_name: str | None = None
+    nodes: int | None = Field(default=None, gt=0)
+    tasks: int | None = Field(default=None, gt=0)
+    tasks_per_node: int | None = Field(default=None, gt=0)
+    cpus_per_task: int | None = Field(default=None, gt=0)
+    walltime: str | None = None
+    partition: str | None = None
+    account: str | None = None
+    qos: str | None = None
+    output: str | None = None
+    error: str | None = None
+    exclusive: bool | None = None
+    gpus: int | None = Field(default=None, gt=0)
+    gpus_per_node: int | None = Field(default=None, gt=0)
+
+    @field_validator("mode", mode="before")
+    @classmethod
+    def normalize_mode(cls, value: object) -> object:
+        """Normalize a textual mode while preserving strict rejection of other types."""
+        if isinstance(value, str):
+            return value.strip().lower()
+        return value
+
+    @field_validator("hostfile", mode="after")
+    @classmethod
+    def validate_hostfile(cls, value: str | None) -> str | None:
+        """Validate a hostfile path without forbidding platform separators."""
+        if value is None:
+            return None
+        return _bounded_single_line(value, field="hostfile")
+
+    @field_validator("output", "error", mode="after")
+    @classmethod
+    def validate_scheduler_path(cls, value: str | None, info: Any) -> str | None:
+        """Require a single printable directive path token."""
+        if value is None:
+            return None
+        rendered = _bounded_single_line(value, field=info.field_name)
+        if any(character.isspace() for character in rendered) or "#" in rendered:
+            raise ValueError(
+                f"execution.{info.field_name} must be one printable path token"
+            )
+        return rendered
+
+    @field_validator(
+        "job_name",
+        "walltime",
+        "partition",
+        "account",
+        "qos",
+        mode="after",
+    )
+    @classmethod
+    def validate_scheduler_token(cls, value: str | None, info: Any) -> str | None:
+        """Reject whitespace/control injection in scheduler directive values."""
+        if value is None:
+            return None
+        rendered = _bounded_single_line(value, field=info.field_name, limit=256)
+        if _SCHEDULER_TOKEN.fullmatch(rendered) is None:
+            raise ValueError(
+                f"execution.{info.field_name} is not a valid scheduler token"
+            )
+        return rendered
+
+    @field_validator("hosts", mode="after")
+    @classmethod
+    def validate_hosts(cls, value: list[str] | None) -> list[str] | None:
+        """Validate semantic host names before writing a scheduler hostfile."""
+        if value is None:
+            return None
+        if len(value) > 4096:
+            raise ValueError("execution.hosts cannot contain more than 4096 entries")
+        if any(_HOST_ENTRY.fullmatch(host) is None for host in value):
+            raise ValueError("execution.hosts contains an invalid host name")
+        return value
+
+    @model_validator(mode="after")
+    def validate_mode_fields(self) -> "ExecutionIntent":
+        """Reject fields that cannot be represented by the selected execution mode."""
+        populated = self.model_fields_set
+        scheduler_fields = sorted(populated & _SCHEDULER_EXECUTION_FIELDS)
+        host_fields = sorted(populated & {"hostfile", "hosts"})
+
+        if self.mode in {"local", "direct"} and (scheduler_fields or host_fields):
+            incompatible = ", ".join(scheduler_fields + host_fields)
+            raise ValueError(
+                f"execution.mode='{self.mode}' does not accept fields: {incompatible}"
+            )
+        if self.mode == "hostfile":
+            if scheduler_fields:
+                raise ValueError(
+                    "execution.mode='hostfile' does not accept scheduler fields: "
+                    + ", ".join(scheduler_fields)
+                )
+            if (self.hostfile is None) == (self.hosts is None):
+                raise ValueError(
+                    "execution.hostfile requires exactly one of hostfile or hosts "
+                    "when execution.mode='hostfile'"
+                )
+        elif host_fields:
+            raise ValueError(
+                f"execution.mode='{self.mode}' does not accept fields: "
+                + ", ".join(host_fields)
+            )
+        return self
+
+
+def _validated_execution_intent(
+    execution: ExecutionIntent | dict[str, Any],
+) -> ExecutionIntent:
+    if isinstance(execution, ExecutionIntent):
+        return execution
+    raw_mode = execution.get("mode", "auto")
+    if (
+        not isinstance(raw_mode, str)
+        or raw_mode.strip().lower() not in _EXECUTION_MODES
+    ):
+        raise ToolError(
+            "execution.mode must be one of: auto, local, direct, cluster, scheduler, hostfile"
+        )
+    try:
+        return ExecutionIntent.model_validate(execution)
+    except ValidationError as error:
+        details = []
+        for item in error.errors(include_url=False, include_context=False):
+            location = ".".join(str(part) for part in item["loc"])
+            prefix = f"{location}: " if location else ""
+            details.append(f"{prefix}{item['msg']}")
+        raise ToolError("invalid execution intent: " + "; ".join(details)) from error
+
+
+def _execution_intent_to_pipeline_config(
+    execution: ExecutionIntent | dict[str, Any],
+) -> dict[str, Any]:
+    intent = _validated_execution_intent(execution)
+    values = intent.model_dump(exclude_none=True)
+    mode = intent.mode
+    if mode in {"local", "direct"}:
+        return {"scheduler": None, "hostfile": None}
+    if mode == "hostfile":
+        if intent.hostfile is not None:
+            return {"scheduler": None, "hostfile": intent.hostfile}
+        if intent.hosts is not None:
+            return {
+                "scheduler": None,
+                "hostfile_entries": intent.hosts,
+            }
+        raise AssertionError("validated hostfile intent has no target")
+    if mode in {"cluster", "scheduler", "auto"}:
+        scheduler_name = _detect_scheduler_name()
+        if scheduler_name is None:
+            if mode == "auto" and set(values) <= {"mode"}:
+                return {}
+            raise ToolError("no supported cluster scheduler detected on this machine")
+        if mode == "auto" and set(values) <= {"mode"}:
+            return {}
+        scheduler: dict[str, Any] = {"name": scheduler_name}
+        mapping = {
+            "job_name": "job_name",
+            "nodes": "nodes",
+            "tasks": "ntasks",
+            "tasks_per_node": "ntasks_per_node",
+            "cpus_per_task": "cpus_per_task",
+            "walltime": "time",
+            "partition": "partition",
+            "account": "account",
+            "qos": "qos",
+            "output": "output",
+            "error": "error",
+            "exclusive": "exclusive",
+            "gpus": "gpus",
+            "gpus_per_node": "gpus_per_node",
+        }
+        for public_key, scheduler_key in mapping.items():
+            if public_key in values:
+                scheduler[scheduler_key] = values[public_key]
+        return {"scheduler": scheduler}
+    raise AssertionError(f"validated execution intent has unsupported mode: {mode}")
+
+
+def _detect_scheduler_name() -> str | None:
+    configured = os.getenv("JARVIS_MCP_SCHEDULER") or os.getenv("JARVIS_SCHEDULER")
+    if configured:
+        return configured.strip().lower()
+    from shutil import which
+
+    if which("sbatch") is not None:
+        return "slurm"
+    return None

--- a/clio-kit-mcp-servers/jarvis/src/jarvis_mcp/models/packages.py
+++ b/clio-kit-mcp-servers/jarvis/src/jarvis_mcp/models/packages.py
@@ -1,0 +1,211 @@
+"""Package inventory, description, deployment, and settings documents."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal
+
+from typing_extensions import NotRequired, TypedDict
+
+from ._base import _ClosedDocument
+
+PACKAGE_DESCRIPTION_SCHEMA = "jarvis.package-description.v1"
+PACKAGE_DEPLOYMENT_SCHEMA = "jarvis.package-deployment.v1"
+CONFIGURATION_INPUT_BINDING_SCHEMA = "jarvis.configuration-input-binding.v1"
+PACKAGE_SEARCH_MAX_DESCRIPTION_BYTES = 4096
+
+
+@dataclass(frozen=True)
+class _PackageInventoryEntry:
+    """Lightweight package identity discovered from one registered repository."""
+
+    name: str
+    short_name: str
+    repository: str
+    description: str | None
+    repo: Path
+    package_file: Path
+
+    def summary(self) -> dict[str, Any]:
+        """Return the bounded search representation without package settings."""
+
+        summary: dict[str, Any] = {
+            "name": self.name,
+            "short_name": self.short_name,
+            "repository": self.repository,
+            "description": _bounded_package_search_description(self.description),
+        }
+        return {key: value for key, value in summary.items() if value is not None}
+
+
+def _bounded_package_search_description(value: str | None) -> str | None:
+    """Truncate only search summaries to their documented UTF-8 byte ceiling."""
+
+    if value is None:
+        return None
+    encoded = value.encode("utf-8")
+    if len(encoded) <= PACKAGE_SEARCH_MAX_DESCRIPTION_BYTES:
+        return value
+    suffix = "..."
+    budget = PACKAGE_SEARCH_MAX_DESCRIPTION_BYTES - len(suffix)
+    prefix = encoded[:budget]
+    while prefix:
+        try:
+            return prefix.decode("utf-8") + suffix
+        except UnicodeDecodeError:
+            prefix = prefix[:-1]
+    return suffix
+
+
+@dataclass(frozen=True)
+class _PackageAgentMetadata:
+    """Package-owned metadata safe to return through the user MCP surface."""
+
+    settings: list[dict[str, Any]] | None
+    deployment: dict[str, Any] | None
+
+
+class JarvisPackageConditionDocument(_ClosedDocument):
+    """One package-owned predicate over a canonical configuration setting."""
+
+    parameter: str
+    operator: Literal["equals", "greater_than", "is_empty", "is_not_empty"]
+    value: str | int | float | bool | None = None
+
+
+class JarvisPackageReadinessDocument(_ClosedDocument):
+    """Observable condition that makes one execution profile ready."""
+
+    mechanism: Literal["process_exit", "progress_event", "service_runtime"]
+    condition: str
+    capability: str | None = None
+
+
+class JarvisPackageExecutionProfileDocument(_ClosedDocument):
+    """Package-owned execution kind, applicability, requirements, and readiness."""
+
+    name: str
+    execution_kind: Literal["batch", "service"]
+    when: list[JarvisPackageConditionDocument]
+    runtime_requirements: list[str]
+    readiness: JarvisPackageReadinessDocument
+    description: str | None = None
+
+
+class JarvisConfigurationInputBindingDocument(_ClosedDocument):
+    """Declared client-local input that must be staged before package use."""
+
+    schema_version: Literal["jarvis.configuration-input-binding.v1"]
+    kind: Literal["local_file"]
+    structure: Literal["regular_file"]
+
+
+class JarvisRuntimeRequirementStatusDocument(_ClosedDocument):
+    """Package observation of whether a runtime requirement can be used."""
+
+    state: Literal["ready", "unavailable", "unknown"]
+    usable: bool | None
+    reason_code: str
+
+
+class JarvisProviderQueryDocument(_ClosedDocument):
+    """Provider-neutral query that can resolve one runtime requirement."""
+
+    kind: str
+    value: str
+
+
+class JarvisProviderResolutionDocument(_ClosedDocument):
+    """One provider and query capable of resolving a runtime requirement."""
+
+    provider: str
+    query: JarvisProviderQueryDocument
+
+
+class JarvisRuntimeRequirementDocument(_ClosedDocument):
+    """Runtime capabilities and provider resolutions owned by a package."""
+
+    id: str
+    description: str
+    required_capabilities: list[str]
+    available_capabilities: list[str]
+    status: JarvisRuntimeRequirementStatusDocument
+    provider_resolutions: list[JarvisProviderResolutionDocument]
+
+
+class JarvisPackageConfigurationRuleDocument(_ClosedDocument):
+    """Conditional requirement over canonical package configuration settings."""
+
+    when: list[JarvisPackageConditionDocument]
+    requires: list[JarvisPackageConditionDocument]
+    description: str
+
+
+class JarvisPackageDeploymentDocument(_ClosedDocument):
+    """Versioned deployment and readiness contract supplied by JARVIS."""
+
+    schema_version: Literal["jarvis.package-deployment.v1"]
+    package: str
+    execution_profiles: list[JarvisPackageExecutionProfileDocument]
+    runtime_requirements: list[JarvisRuntimeRequirementDocument]
+    configuration_rules: list[JarvisPackageConfigurationRuleDocument]
+
+
+class JarvisPackageSettingDocument(TypedDict):
+    """One package parser setting with truthful default and null semantics."""
+
+    name: str
+    description: NotRequired[str]
+    type: NotRequired[str]
+    default: NotRequired[Any]
+    choices: NotRequired[list[Any]]
+    required: bool
+    nullable: bool
+    aliases: NotRequired[list[str]]
+    input_binding: NotRequired[JarvisConfigurationInputBindingDocument]
+
+
+class JarvisPackageDescriptionDocument(_ClosedDocument):
+    """Path-free package detail returned after selecting one canonical package."""
+
+    schema_version: Literal["jarvis.package-description.v1"]
+    name: str
+    short_name: str
+    description: str | None
+    deployment: JarvisPackageDeploymentDocument | None
+    settings: list[JarvisPackageSettingDocument] | None = None
+
+
+class JarvisPackageSummaryDocument(_ClosedDocument):
+    """Bounded package identity returned during search."""
+
+    name: str
+    short_name: str
+    repository: str
+    description: str | None = None
+
+
+# Re-exported for readability at call sites that build Field(...) bounds from it.
+__all__ = [
+    "PACKAGE_DESCRIPTION_SCHEMA",
+    "PACKAGE_DEPLOYMENT_SCHEMA",
+    "CONFIGURATION_INPUT_BINDING_SCHEMA",
+    "PACKAGE_SEARCH_MAX_DESCRIPTION_BYTES",
+    "_PackageInventoryEntry",
+    "_PackageAgentMetadata",
+    "_bounded_package_search_description",
+    "JarvisPackageConditionDocument",
+    "JarvisPackageReadinessDocument",
+    "JarvisPackageExecutionProfileDocument",
+    "JarvisConfigurationInputBindingDocument",
+    "JarvisRuntimeRequirementStatusDocument",
+    "JarvisProviderQueryDocument",
+    "JarvisProviderResolutionDocument",
+    "JarvisRuntimeRequirementDocument",
+    "JarvisPackageConfigurationRuleDocument",
+    "JarvisPackageDeploymentDocument",
+    "JarvisPackageSettingDocument",
+    "JarvisPackageDescriptionDocument",
+    "JarvisPackageSummaryDocument",
+]

--- a/clio-kit-mcp-servers/jarvis/src/jarvis_mcp/models/progress.py
+++ b/clio-kit-mcp-servers/jarvis/src/jarvis_mcp/models/progress.py
@@ -1,0 +1,135 @@
+"""Package progress event and execution-scoped progress snapshot documents."""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+
+class JarvisProgressEventDocument(BaseModel):
+    """One closed, JARVIS-owned package progress observation."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+    schema_version: Literal["jarvis.progress.v1"]
+    package_name: str = Field(min_length=1, max_length=256)
+    package_id: str = Field(min_length=1, max_length=256)
+    execution_id: str = Field(min_length=1, max_length=256)
+    label: str = Field(min_length=1, max_length=256)
+    state: Literal[
+        "pending",
+        "starting",
+        "running",
+        "ready",
+        "completed",
+        "failed",
+        "canceled",
+    ]
+    current: float | None = Field(default=None, ge=0, allow_inf_nan=False)
+    total: float | None = Field(default=None, gt=0, allow_inf_nan=False)
+    unit: str | None = Field(default=None, min_length=1, max_length=256)
+    message: str | None = Field(default=None, min_length=1, max_length=4096)
+    sequence: int = Field(ge=0)
+    observed_at_epoch: float = Field(ge=0, allow_inf_nan=False)
+    determinate: bool
+    metadata: dict[str, Any]
+
+    @field_validator(
+        "package_name",
+        "package_id",
+        "execution_id",
+        "label",
+        "unit",
+        "message",
+        mode="after",
+    )
+    @classmethod
+    def validate_nonblank_text(cls, value: str | None) -> str | None:
+        """Reject whitespace-only text while preserving producer spelling."""
+        if value is not None and not value.strip():
+            raise ValueError("progress text fields must not be blank")
+        return value
+
+    @model_validator(mode="after")
+    def validate_quantitative_progress(self) -> "JarvisProgressEventDocument":
+        """Keep the public determination flag consistent with numeric fields."""
+        if self.total is not None and self.current is None:
+            raise ValueError("progress total requires current")
+        if (
+            self.current is not None
+            and self.total is not None
+            and self.current > self.total
+        ):
+            raise ValueError("progress current cannot exceed total")
+        expected = self.current is not None and self.total is not None
+        if self.determinate is not expected:
+            raise ValueError(
+                "progress determinate must match the presence of current and total"
+            )
+        return self
+
+
+class JarvisPackageProgressDocument(BaseModel):
+    """Latest stable progress observation for one package alias."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+    package_id: str = Field(min_length=1, max_length=256)
+    package_name: str = Field(min_length=1, max_length=256)
+    event_count: int = Field(ge=0)
+    latest: JarvisProgressEventDocument | None
+
+    @model_validator(mode="after")
+    def validate_latest_event(self) -> "JarvisPackageProgressDocument":
+        """Cross-check the package identity and event-count sentinel."""
+        if self.latest is None:
+            if self.event_count != 0:
+                raise ValueError("progress event count requires a latest event")
+            return self
+        if self.event_count == 0:
+            raise ValueError("latest progress event requires a positive event count")
+        if (
+            self.latest.package_id != self.package_id
+            or self.latest.package_name != self.package_name
+        ):
+            raise ValueError("latest progress event package identity did not match")
+        return self
+
+
+class JarvisProgressSnapshotDocument(BaseModel):
+    """Stable aggregate returned by JARVIS-CD's execution progress API."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+    schema_version: Literal["jarvis.execution.progress.v1"]
+    execution_id: str = Field(min_length=1, max_length=256)
+    pipeline_id: str = Field(min_length=1, max_length=256)
+    execution_state: Literal[
+        "preparing",
+        "scripted",
+        "submitting",
+        "submitted",
+        "running",
+        "completed",
+        "failed",
+        "canceled",
+        "unknown",
+    ]
+    terminal: bool
+    packages: list[JarvisPackageProgressDocument] = Field(max_length=4096)
+
+    @model_validator(mode="after")
+    def validate_package_identities(self) -> "JarvisProgressSnapshotDocument":
+        """Bind every package event to this execution and reject aliases twice."""
+        package_ids: set[str] = set()
+        for package in self.packages:
+            if package.package_id in package_ids:
+                raise ValueError("progress package aliases must be unique")
+            package_ids.add(package.package_id)
+            if (
+                package.latest is not None
+                and package.latest.execution_id != self.execution_id
+            ):
+                raise ValueError("progress event execution identity did not match")
+        return self

--- a/clio-kit-mcp-servers/jarvis/src/jarvis_mcp/models/service_runtime.py
+++ b/clio-kit-mcp-servers/jarvis/src/jarvis_mcp/models/service_runtime.py
@@ -1,0 +1,146 @@
+"""Execution-owned service-runtime documents."""
+
+from __future__ import annotations
+
+from pathlib import PurePosixPath
+from typing import Annotated, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from .datasets import JarvisDatasetDescriptorDocument
+
+
+class JarvisServiceAuthorizationDocument(BaseModel):
+    """Non-secret fingerprint for an execution-owned runtime capability."""
+
+    model_config = ConfigDict(
+        extra="forbid",
+        frozen=True,
+        strict=True,
+        hide_input_in_errors=True,
+    )
+
+    scheme: Literal["bearer"]
+    token_sha256: str = Field(
+        min_length=64,
+        max_length=64,
+        pattern=r"^[0-9a-f]{64}$",
+        repr=False,
+    )
+
+
+class _JarvisServiceRuntimeDocumentBase(BaseModel):
+    """Fields shared by every released JARVIS service-runtime revision."""
+
+    model_config = ConfigDict(
+        extra="forbid",
+        frozen=True,
+        strict=True,
+        hide_input_in_errors=True,
+    )
+
+    execution_id: str = Field(min_length=1, max_length=256)
+    package_name: str = Field(min_length=1, max_length=256)
+    package_id: str = Field(min_length=1, max_length=256)
+    service_instance_id: str = Field(min_length=1, max_length=256)
+    revision: int = Field(ge=1)
+    lifecycle: Literal["starting", "ready", "degraded", "stopping", "stopped", "failed"]
+    host: str = Field(min_length=1, max_length=255)
+    port: int = Field(ge=1, le=65535)
+    protocol: Literal["http", "https"]
+    health_path: str = Field(min_length=1, max_length=256)
+    live_data_path: str = Field(min_length=1, max_length=256)
+    events_path: str = Field(min_length=1, max_length=256)
+    state_path: str = Field(min_length=1, max_length=256)
+    command_path: str = Field(min_length=1, max_length=256)
+    delivery_mode: Literal["push"]
+    dataset_descriptor: JarvisDatasetDescriptorDocument
+    message: str | None = Field(default=None, min_length=1, max_length=4096)
+    observed_at_epoch: float = Field(ge=0, allow_inf_nan=False)
+
+    @model_validator(mode="after")
+    def validate_private_endpoint_metadata(
+        self,
+    ) -> "_JarvisServiceRuntimeDocumentBase":
+        """Reject wildcard hosts and ambiguous or duplicated HTTP paths."""
+        if self.host in {"0.0.0.0", "::", "*", "localhost"}:
+            raise ValueError("service runtime host cannot be a wildcard or alias")
+        paths = (
+            self.health_path,
+            self.live_data_path,
+            self.events_path,
+            self.state_path,
+            self.command_path,
+        )
+        if len(set(paths)) != len(paths):
+            raise ValueError("service runtime endpoint paths must be distinct")
+        for value in paths:
+            path = PurePosixPath(value)
+            if (
+                not value.startswith("/")
+                or value.startswith("//")
+                or path.as_posix() != value
+                or ".." in path.parts
+                or any(character in value for character in "?#\\")
+            ):
+                raise ValueError("service runtime endpoint path is invalid")
+        return self
+
+
+class JarvisServiceRuntimeV1Document(_JarvisServiceRuntimeDocumentBase):
+    """Released unauthenticated service-runtime v1 document."""
+
+    schema_version: Literal["jarvis.service-runtime.v1"]
+
+
+class JarvisServiceRuntimeV2Document(_JarvisServiceRuntimeDocumentBase):
+    """Service-runtime v2 document with a non-secret capability fingerprint."""
+
+    schema_version: Literal["jarvis.service-runtime.v2"]
+    authorization: JarvisServiceAuthorizationDocument
+
+
+JarvisServiceRuntimeDocument = Annotated[
+    JarvisServiceRuntimeV1Document | JarvisServiceRuntimeV2Document,
+    Field(discriminator="schema_version"),
+]
+
+
+class JarvisServiceRuntimeSnapshotDocument(BaseModel):
+    """Execution-bound current service runtimes returned by JARVIS."""
+
+    model_config = ConfigDict(
+        extra="forbid",
+        frozen=True,
+        strict=True,
+        hide_input_in_errors=True,
+    )
+
+    schema_version: Literal["jarvis.execution.service-runtimes.v1"]
+    execution_id: str = Field(min_length=1, max_length=256)
+    pipeline_id: str = Field(min_length=1, max_length=256)
+    execution_state: Literal[
+        "preparing",
+        "scripted",
+        "submitting",
+        "submitted",
+        "running",
+        "completed",
+        "failed",
+        "canceled",
+        "unknown",
+    ]
+    terminal: bool
+    service_runtimes: list[JarvisServiceRuntimeDocument] = Field(max_length=4096)
+
+    @model_validator(mode="after")
+    def validate_runtime_identities(self) -> "JarvisServiceRuntimeSnapshotDocument":
+        """Bind every service to this execution and reject duplicate instances."""
+        identities: set[str] = set()
+        for runtime in self.service_runtimes:
+            if runtime.execution_id != self.execution_id:
+                raise ValueError("service runtime execution identity did not match")
+            if runtime.service_instance_id in identities:
+                raise ValueError("service runtime instance identities must be unique")
+            identities.add(runtime.service_instance_id)
+        return self

--- a/clio-kit-mcp-servers/jarvis/src/jarvis_mcp/package_discovery.py
+++ b/clio-kit-mcp-servers/jarvis/src/jarvis_mcp/package_discovery.py
@@ -1,0 +1,669 @@
+"""Package inventory discovery, bounded search, and agent-visible settings.
+
+Split out of ``jarvis_mcp.server`` (clio-kit campaign #362, Slice 1). This
+module owns everything about turning a registered JARVIS-CD repository into
+the agent-visible package contract: inventory discovery, the bounded
+``package_search`` page (with its opaque, revision-bound cursor), and one
+package's full description (settings + versioned deployment contract).
+
+``_discover_package_inventory`` needs the process-local JARVIS manager
+singleton, which lives in ``server.py``. It imports ``get_manager`` lazily
+(inside the function body, not at module load time) for two reasons: it
+breaks what would otherwise be an import cycle (``server`` imports this
+module's discovery/search functions; this module would need ``server``'s
+manager back), and it re-resolves ``jarvis_mcp.server.get_manager`` fresh on
+every call, so ``unittest.mock.patch("jarvis_mcp.server.get_manager", ...)``
+in tests keeps working exactly as it did when this function lived in
+``server.py``.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import hashlib
+import json
+import re
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from fastmcp.exceptions import ToolError
+from pydantic import BaseModel, ValidationError
+
+from .models.describe import PACKAGE_SEARCH_CURSOR_SCHEMA, PACKAGE_SEARCH_SCHEMA
+from .models.packages import (
+    PACKAGE_DEPLOYMENT_SCHEMA,
+    PACKAGE_DESCRIPTION_SCHEMA,
+    JarvisConfigurationInputBindingDocument,
+    JarvisPackageDeploymentDocument,
+    _PackageAgentMetadata,
+    _PackageInventoryEntry,
+)
+
+PACKAGE_SEARCH_DEFAULT_PAGE_SIZE = 10
+PACKAGE_SEARCH_MAX_PAGE_SIZE = 25
+PACKAGE_SEARCH_MAX_RESULT_BYTES = 64 * 1024
+PACKAGE_SEARCH_MAX_CURSOR_LENGTH = 1024
+_PACKAGE_SEARCH_CURSOR_TEXT = re.compile(r"^[A-Za-z0-9_-]+$")
+_PACKAGE_SEARCH_SHA256 = re.compile(r"^[0-9a-f]{64}$")
+
+
+def _discover_packages() -> list[dict[str, Any]]:
+    """Return the legacy exhaustive package descriptions with full settings."""
+
+    return [
+        _package_description_from_inventory(entry)
+        for entry in _discover_package_inventory()
+    ]
+
+
+def _discover_package_inventory() -> list[_PackageInventoryEntry]:
+    """Discover lightweight package identities without importing package classes."""
+
+    from .server import get_manager
+
+    packages: list[_PackageInventoryEntry] = []
+    seen: set[str] = set()
+    try:
+        manager = get_manager()
+        repos = [Path(str(repo)) for repo in manager.list_repos()]
+    except Exception:
+        repos = []
+    for repo in repos:
+        if not repo.exists():
+            continue
+        package_files = sorted(
+            (*repo.rglob("pkg.py"), *repo.rglob("package.py")),
+            key=lambda path: (path.parent.as_posix(), path.name != "pkg.py"),
+        )
+        for pkg_file in package_files:
+            package = _package_inventory_entry(repo, pkg_file)
+            name = package.name
+            if not name or name in seen:
+                continue
+            seen.add(name)
+            packages.append(package)
+    return sorted(packages, key=lambda package: (package.name.casefold(), package.name))
+
+
+def _find_package_description(package_name: str) -> dict[str, Any] | None:
+    """Resolve one exact canonical or short name and load only its settings."""
+
+    normalized = package_name.strip().casefold()
+    inventory = _discover_package_inventory()
+    canonical = next(
+        (package for package in inventory if package.name.casefold() == normalized),
+        None,
+    )
+    if canonical is not None:
+        return _package_description_from_inventory(canonical)
+
+    short_matches = [
+        package for package in inventory if package.short_name.casefold() == normalized
+    ]
+    if len(short_matches) == 1:
+        return _package_description_from_inventory(short_matches[0])
+    if len(short_matches) > 1:
+        candidates = ", ".join(package.name for package in short_matches)
+        raise ToolError(
+            f"package short name is ambiguous: {package_name}; use one of: {candidates}"
+        )
+    return None
+
+
+def _package_from_pkg_file(repo: Path, pkg_file: Path) -> dict[str, Any]:
+    """Build one full package description from a repository source file."""
+
+    return _package_description_from_inventory(_package_inventory_entry(repo, pkg_file))
+
+
+def _package_inventory_entry(repo: Path, pkg_file: Path) -> _PackageInventoryEntry:
+    """Build one lightweight package inventory entry from its source location."""
+
+    relative = pkg_file.relative_to(repo)
+    parts = list(relative.parts[:-1])
+    short_name = parts[-1] if parts else repo.name
+    dotted = ".".join(parts) if parts else short_name
+    description = _first_docstring_or_comment(pkg_file)
+    repository = parts[0] if parts else repo.name
+    return _PackageInventoryEntry(
+        name=dotted,
+        short_name=short_name,
+        repository=repository,
+        description=description,
+        repo=repo,
+        package_file=pkg_file,
+    )
+
+
+def _package_description_from_inventory(
+    entry: _PackageInventoryEntry,
+) -> dict[str, Any]:
+    """Load one selected package's path-free agent contract."""
+
+    metadata = _package_agent_metadata(entry.name)
+    package: dict[str, Any] = {
+        "schema_version": PACKAGE_DESCRIPTION_SCHEMA,
+        "name": entry.name,
+        "short_name": entry.short_name,
+        "description": entry.description,
+        "deployment": metadata.deployment,
+    }
+    if metadata.settings is not None:
+        package["settings"] = metadata.settings
+    return package
+
+
+def _search_packages(
+    *,
+    query: str,
+    page_size: int = PACKAGE_SEARCH_DEFAULT_PAGE_SIZE,
+    cursor: str | None = None,
+) -> dict[str, Any]:
+    """Return a bounded, summary-only page from the registered package inventory."""
+
+    normalized_query = " ".join(query.split())
+    if not normalized_query:
+        raise ToolError("package_search query must not be blank")
+    if (
+        isinstance(page_size, bool)
+        or not isinstance(page_size, int)
+        or not 1 <= page_size <= PACKAGE_SEARCH_MAX_PAGE_SIZE
+    ):
+        raise ToolError(
+            "package_search page_size must be between 1 and "
+            f"{PACKAGE_SEARCH_MAX_PAGE_SIZE}"
+        )
+
+    inventory = _discover_package_inventory()
+    # The declared configuration contract is part of what ranks and pages this
+    # search, so it is also part of the revision the cursor is bound to: a menu
+    # that changes between pages must invalidate the cursor exactly as a
+    # changed docstring already does.
+    configuration_texts = {
+        package.name: _package_configuration_search_text(package.name)
+        for package in inventory
+    }
+    inventory_revision = _package_inventory_revision(inventory, configuration_texts)
+    query_sha256 = hashlib.sha256(
+        normalized_query.casefold().encode("utf-8")
+    ).hexdigest()
+    ranked = sorted(
+        (
+            (rank, package)
+            for package in inventory
+            if (
+                rank := _package_search_rank(
+                    package,
+                    normalized_query,
+                    configuration_texts.get(package.name, ""),
+                )
+            )
+            is not None
+        ),
+        key=lambda item: (item[0], item[1].name.casefold(), item[1].name),
+    )
+    matches = [package for _, package in ranked]
+
+    start = 0
+    if cursor is not None:
+        decoded = _decode_package_search_cursor(cursor)
+        if decoded["query_sha256"] != query_sha256:
+            raise ToolError("package_search cursor does not match the requested query")
+        if decoded["inventory_revision"] != inventory_revision:
+            raise ToolError(
+                "package_search cursor is stale because the package inventory changed"
+            )
+        anchor = decoded["after_package_name"]
+        try:
+            start = next(
+                index + 1
+                for index, package in enumerate(matches)
+                if package.name == anchor
+            )
+        except StopIteration as exc:
+            raise ToolError(
+                "package_search cursor is stale because its package anchor disappeared"
+            ) from exc
+
+    page = [package.summary() for package in matches[start : start + page_size]]
+    while True:
+        has_more = start + len(page) < len(matches)
+        next_cursor = None
+        if has_more and page:
+            next_cursor = _encode_package_search_cursor(
+                after_package_name=str(page[-1]["name"]),
+                query_sha256=query_sha256,
+                inventory_revision=inventory_revision,
+            )
+        result: dict[str, Any] = {
+            "schema_version": PACKAGE_SEARCH_SCHEMA,
+            "target": "package_search",
+            "query": normalized_query,
+            "inventory_revision": inventory_revision,
+            "packages": page,
+            "total_matches": len(matches),
+            "returned_count": len(page),
+            "next_cursor": next_cursor,
+        }
+        if len(_package_search_json_bytes(result)) <= PACKAGE_SEARCH_MAX_RESULT_BYTES:
+            return result
+        if len(page) <= 1:
+            raise ToolError(
+                "one package_search result exceeded the response byte limit"
+            )
+        page.pop()
+
+
+def _package_configuration_search_text(package_name: str) -> str:
+    """Return one package's declared agent-visible configuration as search text.
+
+    Discovery ranks over what a package DECLARES, not only over the module
+    docstring that ``_first_docstring_or_comment`` scrapes. A caller looking
+    for a package that accepts a *staged local input* has no other way to find
+    one: the bounded search summary carries identity only, and a setting's
+    ``input_binding`` -- the single authoritative staging signal -- lives in
+    the package's configure menu, which search never consulted. Every term
+    here is package-declared (setting names, setting prose, and the binding's
+    own ``kind``/``structure`` vocabulary); nothing about specific packages is
+    encoded in this function.
+
+    Loading is best-effort by design and mirrors
+    :func:`_package_agent_metadata`'s existing treatment of an unloadable
+    menu: a package that cannot be imported contributes no configuration text
+    and stays rankable by identity exactly as before, so one broken package in
+    a registered repository can never fail a whole search.
+    """
+
+    try:
+        from jarvis_cd.core.pkg import Pkg  # type: ignore[import-untyped]
+
+        pkg = Pkg.load_standalone(package_name)
+        settings = [
+            _setting_from_menu_item(item)
+            for item in pkg.configure_menu()
+            if _setting_is_agent_visible(item)
+        ]
+    except Exception:
+        return ""
+
+    terms: list[str] = []
+    for setting in settings:
+        for field in ("name", "description"):
+            value = setting.get(field)
+            if isinstance(value, str) and value:
+                terms.append(value)
+        binding = setting.get("input_binding")
+        if isinstance(binding, dict):
+            terms.append("input_binding")
+            for field in ("kind", "structure"):
+                value = binding.get(field)
+                if isinstance(value, str) and value:
+                    terms.append(value)
+    return " ".join(terms)
+
+
+def _package_search_rank(
+    package: _PackageInventoryEntry,
+    query: str,
+    configuration_text: str = "",
+) -> int | None:
+    """Return a deterministic relevance rank, or ``None`` when no field matches.
+
+    Ranks 0-4 are identity and docstring matches and are unchanged. Ranks 5
+    and 6 are the package's own declared configuration contract, which ranks
+    below every identity match so an exact name never loses to a setting that
+    merely mentions the query.
+    """
+
+    folded_query = query.casefold()
+    folded_name = package.name.casefold()
+    folded_short_name = package.short_name.casefold()
+    if folded_query in {folded_name, folded_short_name}:
+        return 0
+    if folded_name.startswith(folded_query) or folded_short_name.startswith(
+        folded_query
+    ):
+        return 1
+    if folded_query in folded_name or folded_query in folded_short_name:
+        return 2
+    folded_description = (package.description or "").casefold()
+    if folded_query in folded_description:
+        return 3
+
+    normalized_query = _package_search_terms(folded_query)
+    if not normalized_query:
+        return None
+    identity_terms = _package_search_terms(
+        " ".join(
+            (
+                package.name,
+                package.short_name,
+                package.description or "",
+            )
+        ).casefold()
+    )
+    if all(term in identity_terms for term in normalized_query):
+        return 4
+
+    folded_configuration = configuration_text.casefold()
+    if folded_configuration and folded_query in folded_configuration:
+        return 5
+    searchable = identity_terms + _package_search_terms(folded_configuration)
+    if all(term in searchable for term in normalized_query):
+        return 6
+    return None
+
+
+def _package_search_terms(value: str) -> list[str]:
+    """Tokenize package names and prose without locale-dependent behavior."""
+
+    return [term for term in re.split(r"[^a-z0-9]+", value) if term]
+
+
+def _package_inventory_revision(
+    inventory: list[_PackageInventoryEntry],
+    configuration_texts: Mapping[str, str] | None = None,
+) -> str:
+    """Hash the full inventory used to rank and page package search."""
+
+    texts = configuration_texts or {}
+    hasher = hashlib.sha256()
+    hasher.update(b"clio-kit.jarvis-package-inventory.v1\0")
+    for package in inventory:
+        encoded = _package_search_json_bytes(
+            {
+                "name": package.name,
+                "short_name": package.short_name,
+                "repository": package.repository,
+                "description": package.description,
+                "configuration": texts.get(package.name, ""),
+            }
+        )
+        hasher.update(len(encoded).to_bytes(8, "big"))
+        hasher.update(encoded)
+    return hasher.hexdigest()
+
+
+def _encode_package_search_cursor(
+    *,
+    after_package_name: str,
+    query_sha256: str,
+    inventory_revision: str,
+) -> str:
+    """Encode an opaque cursor bound to one query and inventory revision."""
+
+    payload = _package_search_json_bytes(
+        {
+            "schema_version": PACKAGE_SEARCH_CURSOR_SCHEMA,
+            "after_package_name": after_package_name,
+            "query_sha256": query_sha256,
+            "inventory_revision": inventory_revision,
+        }
+    )
+    cursor = base64.urlsafe_b64encode(payload).decode("ascii").rstrip("=")
+    if len(cursor) > PACKAGE_SEARCH_MAX_CURSOR_LENGTH:
+        raise ToolError("package_search cursor exceeded its byte limit")
+    return cursor
+
+
+def _decode_package_search_cursor(cursor: str) -> dict[str, str]:
+    """Decode and strictly validate one package-search cursor."""
+
+    if (
+        not cursor
+        or len(cursor) > PACKAGE_SEARCH_MAX_CURSOR_LENGTH
+        or _PACKAGE_SEARCH_CURSOR_TEXT.fullmatch(cursor) is None
+    ):
+        raise ToolError("package_search cursor is invalid")
+    padding = "=" * (-len(cursor) % 4)
+    try:
+        payload = base64.b64decode(
+            cursor + padding,
+            altchars=b"-_",
+            validate=True,
+        )
+        if len(payload) > PACKAGE_SEARCH_MAX_CURSOR_LENGTH:
+            raise ToolError("package_search cursor exceeded its byte limit")
+        value = json.loads(
+            payload.decode("utf-8"),
+            object_pairs_hook=_reject_package_search_duplicate_keys,
+        )
+    except ToolError:
+        raise
+    except (
+        binascii.Error,
+        UnicodeDecodeError,
+        json.JSONDecodeError,
+        ValueError,
+    ) as exc:
+        raise ToolError("package_search cursor is invalid") from exc
+    expected_fields = {
+        "schema_version",
+        "after_package_name",
+        "query_sha256",
+        "inventory_revision",
+    }
+    if not isinstance(value, dict) or set(value) != expected_fields:
+        raise ToolError("package_search cursor schema is invalid")
+    if value.get("schema_version") != PACKAGE_SEARCH_CURSOR_SCHEMA:
+        raise ToolError("package_search cursor schema is unsupported")
+    after_package_name = value.get("after_package_name")
+    query_sha256 = value.get("query_sha256")
+    inventory_revision = value.get("inventory_revision")
+    if (
+        not isinstance(after_package_name, str)
+        or not after_package_name
+        or not isinstance(query_sha256, str)
+        or _PACKAGE_SEARCH_SHA256.fullmatch(query_sha256) is None
+        or not isinstance(inventory_revision, str)
+        or _PACKAGE_SEARCH_SHA256.fullmatch(inventory_revision) is None
+    ):
+        raise ToolError("package_search cursor fields are invalid")
+    return {
+        "after_package_name": after_package_name,
+        "query_sha256": query_sha256,
+        "inventory_revision": inventory_revision,
+    }
+
+
+def _package_search_json_bytes(value: object) -> bytes:
+    """Serialize bounded search state using a deterministic UTF-8 encoding."""
+
+    return json.dumps(
+        value,
+        allow_nan=False,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+def _reject_package_search_duplicate_keys(
+    pairs: list[tuple[str, Any]],
+) -> dict[str, Any]:
+    """Reject ambiguous JSON objects inside opaque package-search cursors."""
+
+    value: dict[str, Any] = {}
+    for key, item in pairs:
+        if key in value:
+            raise ValueError(f"duplicate package_search cursor key: {key}")
+        value[key] = item
+    return value
+
+
+def _first_docstring_or_comment(path: Path) -> str | None:
+    try:
+        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError:
+        return None
+    in_docstring = False
+    docstring_quote: str | None = None
+    collected: list[str] = []
+    for raw_line in lines[:80]:
+        line = raw_line.strip()
+        if not line:
+            continue
+        if line.startswith("#"):
+            comment = line.lstrip("#").strip()
+            if comment:
+                return comment
+            continue
+        if in_docstring and docstring_quote is not None:
+            if line.endswith(docstring_quote):
+                line = line[: -len(docstring_quote)]
+                if line:
+                    collected.append(line.strip())
+                return " ".join(collected).strip() or None
+            collected.append(line)
+            continue
+        if line.startswith(('"""', "'''")):
+            docstring_quote = line[:3]
+            remainder = line[3:]
+            if remainder.endswith(docstring_quote):
+                remainder = remainder[:-3]
+                return remainder.strip() or None
+            in_docstring = True
+            if remainder:
+                collected.append(remainder.strip())
+            continue
+        return None
+    return " ".join(collected).strip() or None
+
+
+def _step_snapshot(
+    pipeline_snapshot: dict[str, Any], step_id: str
+) -> dict[str, Any] | None:
+    for package in pipeline_snapshot.get("packages", []):
+        if not isinstance(package, dict):
+            continue
+        identifiers = {
+            str(package.get("pkg_id", "")),
+            str(package.get("global_id", "")),
+        }
+        if step_id in identifiers:
+            return package
+    return None
+
+
+def _package_agent_metadata(package_name: str) -> _PackageAgentMetadata:
+    """Load package-owned configuration and deployment metadata once.
+
+    Older JARVIS packages do not implement ``describe_deployment`` and are
+    represented with ``deployment=None``. If a package advertises the method,
+    however, its document must match the versioned, path-free contract instead
+    of being silently downgraded to legacy behavior.
+    """
+
+    try:
+        from jarvis_cd.core.pkg import Pkg  # type: ignore[import-untyped]
+
+        pkg = Pkg.load_standalone(package_name)
+    except Exception:
+        return _PackageAgentMetadata(settings=None, deployment=None)
+
+    try:
+        menu = pkg.configure_menu()
+        settings = [
+            _setting_from_menu_item(item)
+            for item in menu
+            if _setting_is_agent_visible(item)
+        ]
+    except Exception:
+        settings = None
+
+    describe_deployment = getattr(pkg, "describe_deployment", None)
+    if not callable(describe_deployment):
+        return _PackageAgentMetadata(settings=settings, deployment=None)
+    try:
+        raw_deployment = describe_deployment()
+    except Exception:
+        raise ToolError(
+            f"package '{package_name}' failed to describe its deployment contract"
+        ) from None
+    if raw_deployment is None:
+        return _PackageAgentMetadata(settings=settings, deployment=None)
+    if isinstance(raw_deployment, BaseModel):
+        raw_deployment = raw_deployment.model_dump(mode="json")
+    if not isinstance(raw_deployment, dict):
+        raise ToolError(
+            f"package '{package_name}' returned an invalid deployment contract"
+        )
+    try:
+        deployment = json.loads(
+            json.dumps(
+                raw_deployment,
+                allow_nan=False,
+                ensure_ascii=False,
+                separators=(",", ":"),
+                sort_keys=True,
+            )
+        )
+    except (TypeError, ValueError):
+        raise ToolError(
+            f"package '{package_name}' returned a non-JSON deployment contract"
+        ) from None
+    try:
+        validated = JarvisPackageDeploymentDocument.model_validate(deployment)
+    except ValidationError:
+        raise ToolError(
+            f"package '{package_name}' returned an invalid deployment contract"
+        ) from None
+    if (
+        validated.schema_version != PACKAGE_DEPLOYMENT_SCHEMA
+        or validated.package != package_name
+    ):
+        raise ToolError(
+            f"package '{package_name}' returned an invalid deployment contract"
+        )
+    return _PackageAgentMetadata(settings=settings, deployment=deployment)
+
+
+def _setting_from_menu_item(item: dict[str, Any]) -> dict[str, Any]:
+    setting: dict[str, Any] = {
+        "name": item.get("name"),
+        "description": item.get("msg"),
+        "required": bool(item.get("required", False)),
+        "nullable": _setting_accepts_null(item),
+    }
+    kind = item.get("type")
+    if isinstance(kind, type):
+        setting["type"] = kind.__name__
+    elif kind is not None:
+        setting["type"] = str(kind)
+    if "default" in item:
+        setting["default"] = item["default"]
+    choices = item.get("choices")
+    if isinstance(choices, (list, tuple)):
+        setting["choices"] = list(choices)
+    aliases = item.get("aliases")
+    if isinstance(aliases, (list, tuple)) and all(
+        isinstance(alias, str) and alias for alias in aliases
+    ):
+        setting["aliases"] = list(aliases)
+    if "input_binding" in item:
+        try:
+            input_binding = JarvisConfigurationInputBindingDocument.model_validate(
+                item["input_binding"]
+            )
+        except ValidationError as error:
+            raise ValueError("invalid package configuration input binding") from error
+        setting["input_binding"] = input_binding.model_dump(mode="json")
+    return {
+        key: value
+        for key, value in setting.items()
+        if value is not None or key == "default"
+    }
+
+
+def _setting_is_agent_visible(item: dict[str, Any]) -> bool:
+    """Return whether package metadata exposes a setting to user agents."""
+
+    return item.get("agent_visible", True) is not False
+
+
+def _setting_accepts_null(item: dict[str, Any]) -> bool:
+    """Return whether the structured add-step path accepts explicit null."""
+
+    return "default" in item and item["default"] is None

--- a/clio-kit-mcp-servers/jarvis/src/jarvis_mcp/server.py
+++ b/clio-kit-mcp-servers/jarvis/src/jarvis_mcp/server.py
@@ -11,8 +11,6 @@ from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 from typing import Annotated, Any, Literal, Optional, cast
 
-from typing_extensions import NotRequired, TypedDict
-
 from dotenv import load_dotenv
 from fastmcp import Context, FastMCP
 from fastmcp.exceptions import ToolError
@@ -25,6 +23,7 @@ from pydantic import (
     field_validator,
     model_validator,
 )
+from typing_extensions import NotRequired, TypedDict
 
 from .capabilities.jarvis_handler import (
     create_pipeline,
@@ -41,142 +40,314 @@ from .capabilities.jarvis_handler import (
     update_pipeline,
     build_pipeline_env,
 )
+from .models._base import _ClosedDocument
+from .models.artifact_documents import (
+    ExecutionArtifactQuery,
+    JarvisArtifactDocument,
+    JarvisArtifactLocationDocument,
+    JarvisExecutionArtifactPageDocument,
+)
+from .models.compat import _CurrentJarvisManager, _load_jarvis_manager_class
+from .models.datasets import (
+    JarvisDatasetArrayDocument,
+    JarvisDatasetDescriptorDocument,
+    JarvisDatasetFingerprintDocument,
+    JarvisDatasetMemberDocument,
+    JarvisDatasetSourceArtifactDocument,
+)
+from .models.describe import (
+    JarvisDescribePackageResult,
+    JarvisDescribePackageSearchResult,
+    JarvisDescribePackagesResult,
+    JarvisDescribePipelineResult,
+    JarvisDescribeResult,
+    JarvisDescribeStepResult,
+    PACKAGE_SEARCH_CURSOR_SCHEMA,
+    PACKAGE_SEARCH_SCHEMA,
+)
+from .models.execution import (
+    ExecutionIntent,
+    JarvisExecutionHandleDocument,
+    JarvisExecutionRecordDocument,
+    JarvisExecutionResult,
+    JarvisRunResult,
+    _EXECUTION_MODES,
+    _HOST_ENTRY,
+    _SCHEDULER_EXECUTION_FIELDS,
+    _SCHEDULER_TOKEN,
+    _bounded_single_line,
+    _detect_scheduler_name,
+    _execution_intent_to_pipeline_config,
+    _validated_execution_intent,
+)
+from .models.packages import (
+    CONFIGURATION_INPUT_BINDING_SCHEMA,
+    JarvisConfigurationInputBindingDocument,
+    JarvisPackageConditionDocument,
+    JarvisPackageConfigurationRuleDocument,
+    JarvisPackageDeploymentDocument,
+    JarvisPackageDescriptionDocument,
+    JarvisPackageExecutionProfileDocument,
+    JarvisPackageReadinessDocument,
+    JarvisPackageSettingDocument,
+    JarvisPackageSummaryDocument,
+    JarvisProviderQueryDocument,
+    JarvisProviderResolutionDocument,
+    JarvisRuntimeRequirementDocument,
+    JarvisRuntimeRequirementStatusDocument,
+    PACKAGE_DEPLOYMENT_SCHEMA,
+    PACKAGE_DESCRIPTION_SCHEMA,
+    PACKAGE_SEARCH_MAX_DESCRIPTION_BYTES,
+    _PackageInventoryEntry,
+    _bounded_package_search_description,
+)
+from .models.progress import (
+    JarvisPackageProgressDocument,
+    JarvisProgressEventDocument,
+    JarvisProgressSnapshotDocument,
+)
+from .models.service_runtime import (
+    JarvisServiceAuthorizationDocument,
+    JarvisServiceRuntimeDocument,
+    JarvisServiceRuntimeSnapshotDocument,
+    JarvisServiceRuntimeV1Document,
+    JarvisServiceRuntimeV2Document,
+    _JarvisServiceRuntimeDocumentBase,
+)
+from .package_discovery import (
+    PACKAGE_SEARCH_DEFAULT_PAGE_SIZE,
+    PACKAGE_SEARCH_MAX_CURSOR_LENGTH,
+    PACKAGE_SEARCH_MAX_PAGE_SIZE,
+    PACKAGE_SEARCH_MAX_RESULT_BYTES,
+    _PACKAGE_SEARCH_CURSOR_TEXT,
+    _PACKAGE_SEARCH_SHA256,
+    _PackageAgentMetadata,
+    _decode_package_search_cursor,
+    _discover_package_inventory,
+    _discover_packages,
+    _encode_package_search_cursor,
+    _find_package_description,
+    _first_docstring_or_comment,
+    _package_agent_metadata,
+    _package_configuration_search_text,
+    _package_description_from_inventory,
+    _package_from_pkg_file,
+    _package_inventory_entry,
+    _package_inventory_revision,
+    _package_search_json_bytes,
+    _package_search_rank,
+    _package_search_terms,
+    _reject_package_search_duplicate_keys,
+    _search_packages,
+    _setting_accepts_null,
+    _setting_from_menu_item,
+    _setting_is_agent_visible,
+    _step_snapshot,
+)
 
-
-class _CurrentJarvisManager:
-    """Compatibility adapter over the current JARVIS-CD Jarvis singleton."""
-
-    @classmethod
-    def get_instance(cls) -> "_CurrentJarvisManager":
-        jarvis_module = importlib.import_module("jarvis_cd.core.config")
-        return cls(jarvis_module.Jarvis.get_instance())
-
-    def __init__(self, jarvis: Any) -> None:
-        self.jarvis = jarvis
-
-    def create(
-        self, config_dir: str, private_dir: str, shared_dir: Optional[str] = None
-    ) -> "_CurrentJarvisManager":
-        self.jarvis.initialize(
-            config_dir=config_dir,
-            private_dir=private_dir,
-            shared_dir=shared_dir or private_dir,
-        )
-        return self
-
-    def load(self) -> "_CurrentJarvisManager":
-        _ = self.jarvis.config
-        return self
-
-    def save(self) -> "_CurrentJarvisManager":
-        if getattr(self.jarvis, "_config", None) is not None:
-            self.jarvis.save_config(self.jarvis.config)
-        if getattr(self.jarvis, "_repos", None) is not None:
-            self.jarvis.save_repos(self.jarvis.repos)
-        return self
-
-    def set_hostfile(self, path: str) -> "_CurrentJarvisManager":
-        self.jarvis.set_hostfile(path)
-        return self
-
-    def bootstrap_from(self, machine: str) -> "_CurrentJarvisManager":
-        raise NotImplementedError(
-            f"bootstrap templates are not exposed by current JARVIS-CD: {machine}"
-        )
-
-    def bootstrap_list(self) -> list[str]:
-        return []
-
-    def reset(self) -> "_CurrentJarvisManager":
-        raise NotImplementedError(
-            "reset is not exposed through the compatibility adapter"
-        )
-
-    def list_pipelines(self) -> list[str]:
-        pipelines_dir = self.jarvis.get_pipelines_dir()
-        if not pipelines_dir.exists():
-            return []
-        return sorted(path.name for path in pipelines_dir.iterdir() if path.is_dir())
-
-    def cd(self, pipeline_id: str) -> "_CurrentJarvisManager":
-        self.jarvis.set_current_pipeline(pipeline_id)
-        return self
-
-    def list_repos(self) -> list[str]:
-        return list(self.jarvis.repos.get("repos", []))
-
-    def add_repo(self, path: str, force: bool = False) -> "_CurrentJarvisManager":
-        self.jarvis.add_repo(path, force=force)
-        return self
-
-    def remove_repo(self, repo_name: str) -> "_CurrentJarvisManager":
-        repo_paths = list(self.jarvis.repos.get("repos", []))
-        matches = [
-            repo_path
-            for repo_path in repo_paths
-            if repo_path == repo_name or Path(repo_path).name == repo_name
-        ]
-        if not matches:
-            self.jarvis.remove_repo(repo_name)
-        for repo_path in matches:
-            self.jarvis.remove_repo(repo_path)
-        return self
-
-    def promote_repo(self, repo_name: str) -> "_CurrentJarvisManager":
-        repos = self.jarvis.repos.copy()
-        repo_paths = list(repos.get("repos", []))
-        matches = [
-            repo_path
-            for repo_path in repo_paths
-            if repo_path == repo_name or Path(repo_path).name == repo_name
-        ]
-        if not matches:
-            raise ValueError(f"repository not found: {repo_name}")
-        for repo_path in reversed(matches):
-            repo_paths.remove(repo_path)
-            repo_paths.insert(0, repo_path)
-        repos["repos"] = repo_paths
-        self.jarvis.save_repos(repos)
-        return self
-
-    def get_repo(self, repo_name: str) -> dict[str, Any] | None:
-        for index, repo_path in enumerate(self.jarvis.repos.get("repos", []), start=1):
-            if repo_path == repo_name or Path(repo_path).name == repo_name:
-                return {
-                    "index": index,
-                    "name": Path(repo_path).name,
-                    "path": repo_path,
-                    "exists": Path(repo_path).exists(),
-                }
-        return None
-
-    def construct_pkg(self, pkg_type: str) -> Any:
-        raise NotImplementedError(
-            f"package construction is not exposed by current JARVIS-CD: {pkg_type}"
-        )
-
-    def resource_graph_show(self) -> dict[str, Any]:
-        return self.jarvis.resource_graph
-
-    def resource_graph_build(self, net_sleep: float) -> dict[str, Any]:
-        _ = net_sleep
-        raise NotImplementedError(
-            "resource graph build is not exposed through the compatibility adapter"
-        )
-
-    def resource_graph_modify(self, net_sleep: float) -> dict[str, Any]:
-        _ = net_sleep
-        raise NotImplementedError(
-            "resource graph modify is not exposed through the compatibility adapter"
-        )
-
-
-def _load_jarvis_manager_class() -> Any:
-    try:
-        module = importlib.import_module("jarvis_cd.basic.jarvis_manager")
-        return module.JarvisManager
-    except ModuleNotFoundError:
-        return _CurrentJarvisManager
+# Re-exported so ``jarvis_mcp.server.X`` keeps working for every name that was
+# importable from this module before the models/package_discovery owner-module
+# split (clio-kit campaign #362, Slice 1; PR #364 review finding 3). This is
+# the FULL top-level surface of the pre-split server.py -- not a hand-picked
+# subset -- covering both the wire-facing document classes/constants that
+# moved to jarvis_mcp.models.* and jarvis_mcp.package_discovery, and the
+# stdlib/third-party names (json, re, BaseModel, ...) that were incidentally
+# module attributes here too. Many entries below are not otherwise referenced
+# in this file; that is the point of a compatibility re-export, not a mistake
+# for a linter to "clean up". tests/test_backward_compat_reexports.py asserts
+# every one of these is importable from jarvis_mcp.server.
+__all__ = [
+    "ADMIN_TOOLS",
+    "Annotated",
+    "Any",
+    "BaseModel",
+    "CONFIGURATION_INPUT_BINDING_SCHEMA",
+    "ConfigDict",
+    "Context",
+    "ExecutionArtifactQuery",
+    "ExecutionIntent",
+    "FastMCP",
+    "Field",
+    "JarvisArtifactDocument",
+    "JarvisArtifactLocationDocument",
+    "JarvisConfigurationInputBindingDocument",
+    "JarvisDatasetArrayDocument",
+    "JarvisDatasetDescriptorDocument",
+    "JarvisDatasetFingerprintDocument",
+    "JarvisDatasetMemberDocument",
+    "JarvisDatasetSourceArtifactDocument",
+    "JarvisDescribePackageResult",
+    "JarvisDescribePackageSearchResult",
+    "JarvisDescribePackagesResult",
+    "JarvisDescribePipelineResult",
+    "JarvisDescribeResult",
+    "JarvisDescribeStepResult",
+    "JarvisExecutionArtifactPageDocument",
+    "JarvisExecutionHandleDocument",
+    "JarvisExecutionRecordDocument",
+    "JarvisExecutionResult",
+    "JarvisManager",
+    "JarvisPackageConditionDocument",
+    "JarvisPackageConfigurationRuleDocument",
+    "JarvisPackageDeploymentDocument",
+    "JarvisPackageDescriptionDocument",
+    "JarvisPackageExecutionProfileDocument",
+    "JarvisPackageProgressDocument",
+    "JarvisPackageReadinessDocument",
+    "JarvisPackageSettingDocument",
+    "JarvisPackageSummaryDocument",
+    "JarvisProgressEventDocument",
+    "JarvisProgressSnapshotDocument",
+    "JarvisProviderQueryDocument",
+    "JarvisProviderResolutionDocument",
+    "JarvisRunResult",
+    "JarvisRuntimeRequirementDocument",
+    "JarvisRuntimeRequirementStatusDocument",
+    "JarvisServiceAuthorizationDocument",
+    "JarvisServiceRuntimeDocument",
+    "JarvisServiceRuntimeSnapshotDocument",
+    "JarvisServiceRuntimeV1Document",
+    "JarvisServiceRuntimeV2Document",
+    "Literal",
+    "MCP_METADATA_PROFILE",
+    "Mapping",
+    "Message",
+    "NotRequired",
+    "Optional",
+    "PACKAGE_DEPLOYMENT_SCHEMA",
+    "PACKAGE_DESCRIPTION_SCHEMA",
+    "PACKAGE_SEARCH_CURSOR_SCHEMA",
+    "PACKAGE_SEARCH_DEFAULT_PAGE_SIZE",
+    "PACKAGE_SEARCH_MAX_CURSOR_LENGTH",
+    "PACKAGE_SEARCH_MAX_DESCRIPTION_BYTES",
+    "PACKAGE_SEARCH_MAX_PAGE_SIZE",
+    "PACKAGE_SEARCH_MAX_RESULT_BYTES",
+    "PACKAGE_SEARCH_SCHEMA",
+    "Path",
+    "PurePosixPath",
+    "ToolError",
+    "TypedDict",
+    "USER_TOOLS",
+    "ValidationError",
+    "_ClosedDocument",
+    "_CurrentJarvisManager",
+    "_EXECUTION_MODES",
+    "_HOST_ENTRY",
+    "_JarvisServiceRuntimeDocumentBase",
+    "_PACKAGE_SEARCH_CURSOR_TEXT",
+    "_PACKAGE_SEARCH_SHA256",
+    "_PackageAgentMetadata",
+    "_PackageInventoryEntry",
+    "_SCHEDULER_EXECUTION_FIELDS",
+    "_SCHEDULER_TOKEN",
+    "_bounded_package_search_description",
+    "_bounded_single_line",
+    "_context_has_progress_token",
+    "_decode_package_search_cursor",
+    "_detect_scheduler_name",
+    "_discover_package_inventory",
+    "_discover_packages",
+    "_encode_package_search_cursor",
+    "_execution_intent_to_pipeline_config",
+    "_existing_directory_path",
+    "_find_package_description",
+    "_first_docstring_or_comment",
+    "_load_jarvis_manager_class",
+    "_manager",
+    "_package_agent_metadata",
+    "_package_configuration_search_text",
+    "_package_description_from_inventory",
+    "_package_from_pkg_file",
+    "_package_inventory_entry",
+    "_package_inventory_revision",
+    "_package_search_json_bytes",
+    "_package_search_rank",
+    "_package_search_terms",
+    "_protocol_stdout_to_stderr",
+    "_registered_tools",
+    "_reject_package_search_duplicate_keys",
+    "_search_packages",
+    "_setting_accepts_null",
+    "_setting_from_menu_item",
+    "_setting_is_agent_visible",
+    "_spack_command_path",
+    "_step_snapshot",
+    "_validated_execution_intent",
+    "add_jarvis_root_argument",
+    "add_spack_command_argument",
+    "admin_main",
+    "append_pkg",
+    "append_pkg_tool",
+    "apply_tool_profile",
+    "argparse",
+    "base64",
+    "binascii",
+    "build_pipeline_env",
+    "build_pipeline_env_tool",
+    "cast",
+    "configure_jarvis_root",
+    "configure_pkg",
+    "configure_pkg_tool",
+    "configure_spack_command",
+    "create_pipeline",
+    "create_pipeline_tool",
+    "create_pipeline_workflow",
+    "dataclass",
+    "destroy_pipeline",
+    "destroy_pipeline_tool",
+    "export_pipeline",
+    "export_pipeline_tool",
+    "field_validator",
+    "get_execution",
+    "get_manager",
+    "get_pkg_config",
+    "get_pkg_config_tool",
+    "hashlib",
+    "importlib",
+    "jarvis_add_step_tool",
+    "jarvis_capabilities",
+    "jarvis_create_pipeline_tool",
+    "jarvis_describe_tool",
+    "jarvis_edit_step_tool",
+    "jarvis_get_execution_tool",
+    "jarvis_run_tool",
+    "jm_add_repo",
+    "jm_bootstrap_from",
+    "jm_bootstrap_list",
+    "jm_cd",
+    "jm_construct_pkg",
+    "jm_create_config",
+    "jm_get_repo",
+    "jm_graph_build",
+    "jm_graph_modify",
+    "jm_graph_show",
+    "jm_list_pipelines",
+    "jm_list_repos",
+    "jm_load_config",
+    "jm_promote_repo",
+    "jm_remove_repo",
+    "jm_reset",
+    "jm_save_config",
+    "jm_set_hostfile",
+    "json",
+    "load_dotenv",
+    "load_pipeline",
+    "load_pipeline_tool",
+    "main",
+    "manager",
+    "mcp",
+    "model_validator",
+    "os",
+    "re",
+    "remove_pkg",
+    "remove_pkg_tool",
+    "run_pipeline",
+    "run_pipeline_tool",
+    "unlink_pkg",
+    "unlink_pkg_tool",
+    "update_pipeline",
+    "update_pipeline_tool",
+]
 
 
 # Load environment variables from .env file
@@ -192,780 +363,6 @@ mcp: FastMCP = FastMCP(
     list_page_size=10,
 )
 MCP_METADATA_PROFILE = "user"
-
-PACKAGE_SEARCH_SCHEMA = "jarvis.package-search.v1"
-PACKAGE_SEARCH_CURSOR_SCHEMA = "clio-kit.jarvis-package-search-cursor.v1"
-PACKAGE_DESCRIPTION_SCHEMA = "jarvis.package-description.v1"
-PACKAGE_DEPLOYMENT_SCHEMA = "jarvis.package-deployment.v1"
-CONFIGURATION_INPUT_BINDING_SCHEMA = "jarvis.configuration-input-binding.v1"
-PACKAGE_SEARCH_DEFAULT_PAGE_SIZE = 10
-PACKAGE_SEARCH_MAX_PAGE_SIZE = 25
-PACKAGE_SEARCH_MAX_RESULT_BYTES = 64 * 1024
-PACKAGE_SEARCH_MAX_CURSOR_LENGTH = 1024
-PACKAGE_SEARCH_MAX_DESCRIPTION_BYTES = 4096
-_PACKAGE_SEARCH_CURSOR_TEXT = re.compile(r"^[A-Za-z0-9_-]+$")
-_PACKAGE_SEARCH_SHA256 = re.compile(r"^[0-9a-f]{64}$")
-
-
-@dataclass(frozen=True)
-class _PackageInventoryEntry:
-    """Lightweight package identity discovered from one registered repository."""
-
-    name: str
-    short_name: str
-    repository: str
-    description: str | None
-    repo: Path
-    package_file: Path
-
-    def summary(self) -> dict[str, Any]:
-        """Return the bounded search representation without package settings."""
-
-        summary: dict[str, Any] = {
-            "name": self.name,
-            "short_name": self.short_name,
-            "repository": self.repository,
-            "description": _bounded_package_search_description(self.description),
-        }
-        return {key: value for key, value in summary.items() if value is not None}
-
-
-@dataclass(frozen=True)
-class _PackageAgentMetadata:
-    """Package-owned metadata safe to return through the user MCP surface."""
-
-    settings: list[dict[str, Any]] | None
-    deployment: dict[str, Any] | None
-
-
-class _ClosedDocument(BaseModel):
-    """Base for agent-visible documents with no undeclared fields."""
-
-    model_config = ConfigDict(extra="forbid")
-
-
-class JarvisPackageConditionDocument(_ClosedDocument):
-    """One package-owned predicate over a canonical configuration setting."""
-
-    parameter: str
-    operator: Literal["equals", "greater_than", "is_empty", "is_not_empty"]
-    value: str | int | float | bool | None = None
-
-
-class JarvisPackageReadinessDocument(_ClosedDocument):
-    """Observable condition that makes one execution profile ready."""
-
-    mechanism: Literal["process_exit", "progress_event", "service_runtime"]
-    condition: str
-    capability: str | None = None
-
-
-class JarvisPackageExecutionProfileDocument(_ClosedDocument):
-    """Package-owned execution kind, applicability, requirements, and readiness."""
-
-    name: str
-    execution_kind: Literal["batch", "service"]
-    when: list[JarvisPackageConditionDocument]
-    runtime_requirements: list[str]
-    readiness: JarvisPackageReadinessDocument
-    description: str | None = None
-
-
-class JarvisConfigurationInputBindingDocument(_ClosedDocument):
-    """Declared client-local input that must be staged before package use."""
-
-    schema_version: Literal["jarvis.configuration-input-binding.v1"]
-    kind: Literal["local_file"]
-    structure: Literal["regular_file"]
-
-
-class JarvisRuntimeRequirementStatusDocument(_ClosedDocument):
-    """Package observation of whether a runtime requirement can be used."""
-
-    state: Literal["ready", "unavailable", "unknown"]
-    usable: bool | None
-    reason_code: str
-
-
-class JarvisProviderQueryDocument(_ClosedDocument):
-    """Provider-neutral query that can resolve one runtime requirement."""
-
-    kind: str
-    value: str
-
-
-class JarvisProviderResolutionDocument(_ClosedDocument):
-    """One provider and query capable of resolving a runtime requirement."""
-
-    provider: str
-    query: JarvisProviderQueryDocument
-
-
-class JarvisRuntimeRequirementDocument(_ClosedDocument):
-    """Runtime capabilities and provider resolutions owned by a package."""
-
-    id: str
-    description: str
-    required_capabilities: list[str]
-    available_capabilities: list[str]
-    status: JarvisRuntimeRequirementStatusDocument
-    provider_resolutions: list[JarvisProviderResolutionDocument]
-
-
-class JarvisPackageConfigurationRuleDocument(_ClosedDocument):
-    """Conditional requirement over canonical package configuration settings."""
-
-    when: list[JarvisPackageConditionDocument]
-    requires: list[JarvisPackageConditionDocument]
-    description: str
-
-
-class JarvisPackageDeploymentDocument(_ClosedDocument):
-    """Versioned deployment and readiness contract supplied by JARVIS."""
-
-    schema_version: Literal["jarvis.package-deployment.v1"]
-    package: str
-    execution_profiles: list[JarvisPackageExecutionProfileDocument]
-    runtime_requirements: list[JarvisRuntimeRequirementDocument]
-    configuration_rules: list[JarvisPackageConfigurationRuleDocument]
-
-
-class JarvisPackageSettingDocument(TypedDict):
-    """One package parser setting with truthful default and null semantics."""
-
-    name: str
-    description: NotRequired[str]
-    type: NotRequired[str]
-    default: NotRequired[Any]
-    choices: NotRequired[list[Any]]
-    required: bool
-    nullable: bool
-    aliases: NotRequired[list[str]]
-    input_binding: NotRequired[JarvisConfigurationInputBindingDocument]
-
-
-class JarvisPackageDescriptionDocument(_ClosedDocument):
-    """Path-free package detail returned after selecting one canonical package."""
-
-    schema_version: Literal["jarvis.package-description.v1"]
-    name: str
-    short_name: str
-    description: str | None
-    deployment: JarvisPackageDeploymentDocument | None
-    settings: list[JarvisPackageSettingDocument] | None = None
-
-
-class JarvisPackageSummaryDocument(_ClosedDocument):
-    """Bounded package identity returned during search."""
-
-    name: str
-    short_name: str
-    repository: str
-    description: str | None = None
-
-
-class JarvisDescribePackagesResult(_ClosedDocument):
-    """Exhaustive legacy package inventory result."""
-
-    target: Literal["packages"]
-    packages: list[JarvisPackageDescriptionDocument]
-
-
-class JarvisDescribePackageSearchResult(_ClosedDocument):
-    """Bounded package search page."""
-
-    schema_version: Literal["jarvis.package-search.v1"]
-    target: Literal["package_search"]
-    query: str
-    inventory_revision: str
-    packages: list[JarvisPackageSummaryDocument]
-    total_matches: int
-    returned_count: int
-    next_cursor: str | None
-
-
-class JarvisDescribePackageResult(_ClosedDocument):
-    """Exact package description result."""
-
-    target: Literal["package"]
-    package: JarvisPackageDescriptionDocument
-
-
-class JarvisDescribePipelineResult(_ClosedDocument):
-    """Stored pipeline snapshot result."""
-
-    target: Literal["pipeline"]
-    pipeline: dict[str, Any]
-
-
-class JarvisDescribeStepResult(_ClosedDocument):
-    """Stored pipeline step and package configuration result."""
-
-    target: Literal["step"]
-    step: dict[str, Any]
-    config: dict[str, Any]
-
-
-JarvisDescribeResult = Annotated[
-    JarvisDescribePackagesResult
-    | JarvisDescribePackageSearchResult
-    | JarvisDescribePackageResult
-    | JarvisDescribePipelineResult
-    | JarvisDescribeStepResult,
-    Field(discriminator="target"),
-]
-
-
-class JarvisExecutionHandleDocument(TypedDict):
-    """Stable JARVIS-CD execution-handle document."""
-
-    schema_version: Literal["jarvis.execution.handle.v1"]
-    execution_id: str
-    pipeline_id: str
-    mode: Literal["direct", "scheduler"]
-    scheduler_provider: str | None
-    scheduler_native_id: str | None
-    cluster: str | None
-
-
-class JarvisExecutionRecordDocument(TypedDict):
-    """Stable JARVIS-CD durable execution-record document."""
-
-    schema_version: Literal["jarvis.execution.record.v1"]
-    execution_id: str
-    pipeline_id: str
-    pipeline_name: str
-    mode: Literal["direct", "scheduler"]
-    scheduler_provider: str | None
-    scheduler_native_id: str | None
-    cluster: str | None
-    state: Literal[
-        "preparing",
-        "scripted",
-        "submitting",
-        "submitted",
-        "running",
-        "completed",
-        "failed",
-        "canceled",
-        "unknown",
-    ]
-    submitted: bool
-    terminal: bool
-    created_at: str
-    updated_at: str
-    return_code: int | None
-    error: str | None
-    metadata: dict[str, Any]
-
-
-class JarvisProgressEventDocument(BaseModel):
-    """One closed, JARVIS-owned package progress observation."""
-
-    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
-
-    schema_version: Literal["jarvis.progress.v1"]
-    package_name: str = Field(min_length=1, max_length=256)
-    package_id: str = Field(min_length=1, max_length=256)
-    execution_id: str = Field(min_length=1, max_length=256)
-    label: str = Field(min_length=1, max_length=256)
-    state: Literal[
-        "pending",
-        "starting",
-        "running",
-        "ready",
-        "completed",
-        "failed",
-        "canceled",
-    ]
-    current: float | None = Field(default=None, ge=0, allow_inf_nan=False)
-    total: float | None = Field(default=None, gt=0, allow_inf_nan=False)
-    unit: str | None = Field(default=None, min_length=1, max_length=256)
-    message: str | None = Field(default=None, min_length=1, max_length=4096)
-    sequence: int = Field(ge=0)
-    observed_at_epoch: float = Field(ge=0, allow_inf_nan=False)
-    determinate: bool
-    metadata: dict[str, Any]
-
-    @field_validator(
-        "package_name",
-        "package_id",
-        "execution_id",
-        "label",
-        "unit",
-        "message",
-        mode="after",
-    )
-    @classmethod
-    def validate_nonblank_text(cls, value: str | None) -> str | None:
-        """Reject whitespace-only text while preserving producer spelling."""
-        if value is not None and not value.strip():
-            raise ValueError("progress text fields must not be blank")
-        return value
-
-    @model_validator(mode="after")
-    def validate_quantitative_progress(self) -> "JarvisProgressEventDocument":
-        """Keep the public determination flag consistent with numeric fields."""
-        if self.total is not None and self.current is None:
-            raise ValueError("progress total requires current")
-        if (
-            self.current is not None
-            and self.total is not None
-            and self.current > self.total
-        ):
-            raise ValueError("progress current cannot exceed total")
-        expected = self.current is not None and self.total is not None
-        if self.determinate is not expected:
-            raise ValueError(
-                "progress determinate must match the presence of current and total"
-            )
-        return self
-
-
-class JarvisPackageProgressDocument(BaseModel):
-    """Latest stable progress observation for one package alias."""
-
-    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
-
-    package_id: str = Field(min_length=1, max_length=256)
-    package_name: str = Field(min_length=1, max_length=256)
-    event_count: int = Field(ge=0)
-    latest: JarvisProgressEventDocument | None
-
-    @model_validator(mode="after")
-    def validate_latest_event(self) -> "JarvisPackageProgressDocument":
-        """Cross-check the package identity and event-count sentinel."""
-        if self.latest is None:
-            if self.event_count != 0:
-                raise ValueError("progress event count requires a latest event")
-            return self
-        if self.event_count == 0:
-            raise ValueError("latest progress event requires a positive event count")
-        if (
-            self.latest.package_id != self.package_id
-            or self.latest.package_name != self.package_name
-        ):
-            raise ValueError("latest progress event package identity did not match")
-        return self
-
-
-class JarvisProgressSnapshotDocument(BaseModel):
-    """Stable aggregate returned by JARVIS-CD's execution progress API."""
-
-    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
-
-    schema_version: Literal["jarvis.execution.progress.v1"]
-    execution_id: str = Field(min_length=1, max_length=256)
-    pipeline_id: str = Field(min_length=1, max_length=256)
-    execution_state: Literal[
-        "preparing",
-        "scripted",
-        "submitting",
-        "submitted",
-        "running",
-        "completed",
-        "failed",
-        "canceled",
-        "unknown",
-    ]
-    terminal: bool
-    packages: list[JarvisPackageProgressDocument] = Field(max_length=4096)
-
-    @model_validator(mode="after")
-    def validate_package_identities(self) -> "JarvisProgressSnapshotDocument":
-        """Bind every package event to this execution and reject aliases twice."""
-        package_ids: set[str] = set()
-        for package in self.packages:
-            if package.package_id in package_ids:
-                raise ValueError("progress package aliases must be unique")
-            package_ids.add(package.package_id)
-            if (
-                package.latest is not None
-                and package.latest.execution_id != self.execution_id
-            ):
-                raise ValueError("progress event execution identity did not match")
-        return self
-
-
-class JarvisArtifactLocationDocument(TypedDict):
-    """Transport-neutral location in a JARVIS artifact manifest."""
-
-    kind: Literal["execution_path", "cluster_path", "external_uri"]
-    value: str
-
-
-class JarvisArtifactDocument(TypedDict):
-    """Current JARVIS-owned lifecycle observation for one generated artifact."""
-
-    schema_version: Literal["jarvis.artifact.v1"]
-    package_name: str
-    package_id: str
-    execution_id: str
-    artifact_id: str
-    logical_name: str
-    kind: str
-    role: Literal[
-        "intermediate",
-        "output",
-        "log",
-        "checkpoint",
-        "provenance",
-        "validation",
-    ]
-    structure: Literal["file", "directory", "collection", "stream"]
-    ownership: Literal["execution", "external", "shared"]
-    state: Literal["producing", "available", "finalized", "incomplete", "failed"]
-    revision: int
-    sequence: int
-    observed_at_epoch: float
-    metadata: dict[str, Any]
-    location: NotRequired[JarvisArtifactLocationDocument]
-    media_type: NotRequired[str]
-    format: NotRequired[str]
-    size_bytes: NotRequired[int]
-    checksum: NotRequired[str]
-    message: NotRequired[str]
-
-
-class JarvisRunResult(TypedDict):
-    """Frozen top-level result envelope for ``jarvis_run``."""
-
-    schema_version: Literal["clio-kit.jarvis-run.v1"]
-    pipeline_id: str
-    execution_id: str
-    status: Literal[
-        "preparing",
-        "scripted",
-        "submitting",
-        "submitted",
-        "running",
-        "completed",
-        "failed",
-        "canceled",
-        "unknown",
-    ]
-    mode: Literal["direct", "scheduler"]
-    scheduler: dict[str, Any] | None
-    script_path: str | None
-    wait: bool
-    execution_handle: JarvisExecutionHandleDocument
-    execution_record: JarvisExecutionRecordDocument
-    progress: JarvisProgressSnapshotDocument
-    runtime_metadata: dict[str, Any]
-
-
-class JarvisExecutionArtifactPageDocument(BaseModel):
-    """Bounded artifact page nested in a unified execution query."""
-
-    model_config = ConfigDict(extra="forbid", frozen=True)
-
-    producer_schema_version: Literal["jarvis.execution.artifacts.v1"]
-    pipeline_id: str
-    execution_id: str
-    execution_state: Literal[
-        "preparing",
-        "scripted",
-        "submitting",
-        "submitted",
-        "running",
-        "completed",
-        "failed",
-        "canceled",
-        "unknown",
-    ]
-    terminal: bool
-    artifacts: list[JarvisArtifactDocument]
-    matching_artifact_count: int
-    returned_artifact_count: int
-    next_cursor: str | None
-
-
-class JarvisDatasetMemberDocument(BaseModel):
-    """One ordered member in a JARVIS service dataset descriptor."""
-
-    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
-
-    index: int = Field(ge=0)
-    location: str = Field(min_length=1, max_length=4096)
-    timestep: float | None = Field(default=None, allow_inf_nan=False)
-
-    @field_validator("location")
-    @classmethod
-    def validate_cluster_location(cls, value: str) -> str:
-        """Require the normalized absolute POSIX path emitted by JARVIS."""
-        path = PurePosixPath(value)
-        if (
-            "\\" in value
-            or not path.is_absolute()
-            or path.as_posix() != value
-            or ".." in path.parts
-        ):
-            raise ValueError(
-                "dataset member location must be a normalized absolute path"
-            )
-        return value
-
-
-class JarvisDatasetArrayDocument(BaseModel):
-    """One intrinsic array exposed by a JARVIS-owned service."""
-
-    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
-
-    name: str = Field(min_length=1, max_length=512)
-    association: Literal["point", "cell", "field"]
-    components: int = Field(ge=1, le=64)
-    units: str | None = Field(default=None, min_length=1, max_length=256)
-
-
-class JarvisDatasetFingerprintDocument(BaseModel):
-    """Canonical identity digest for one bounded dataset descriptor."""
-
-    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
-
-    algorithm: Literal["sha256"]
-    digest: str = Field(pattern=r"^[0-9a-f]{64}$")
-
-
-class JarvisDatasetSourceArtifactDocument(BaseModel):
-    """Optional content identity of a JARVIS-generated source artifact."""
-
-    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
-
-    artifact_id: str = Field(pattern=r"^art_[A-Za-z0-9_-]{22,86}$")
-    sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
-
-
-class JarvisDatasetDescriptorDocument(BaseModel):
-    """Intrinsic, recipe-free dataset identity owned by JARVIS."""
-
-    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
-
-    schema_version: Literal["jarvis.dataset-descriptor.v1"]
-    dataset_id: str = Field(min_length=1, max_length=256)
-    kind: str = Field(min_length=1, max_length=256)
-    format: str = Field(min_length=1, max_length=256)
-    members: list[JarvisDatasetMemberDocument] = Field(min_length=1, max_length=512)
-    arrays: list[JarvisDatasetArrayDocument] = Field(max_length=256)
-    bounds: list[float] | None = Field(default=None, min_length=6, max_length=6)
-    fingerprint: JarvisDatasetFingerprintDocument
-    source_artifact: JarvisDatasetSourceArtifactDocument | None
-
-    @model_validator(mode="after")
-    def validate_intrinsic_identity(self) -> "JarvisDatasetDescriptorDocument":
-        """Reject ambiguous ordering and verify the canonical fingerprint."""
-        if [member.index for member in self.members] != list(range(len(self.members))):
-            raise ValueError("dataset member indexes must be contiguous and ordered")
-        locations = [member.location for member in self.members]
-        if len(locations) != len(set(locations)):
-            raise ValueError("dataset member locations must be unique")
-        array_keys = [(array.association, array.name) for array in self.arrays]
-        if len(array_keys) != len(set(array_keys)):
-            raise ValueError("dataset array identities must be unique")
-        if self.bounds is not None:
-            for lower, upper in zip(self.bounds[::2], self.bounds[1::2]):
-                if lower > upper:
-                    raise ValueError("dataset bounds must be ordered")
-        members: list[dict[str, Any]] = []
-        for member in self.members:
-            value: dict[str, Any] = {
-                "index": member.index,
-                "location": member.location,
-            }
-            if member.timestep is not None:
-                value["timestep"] = member.timestep
-            members.append(value)
-        arrays: list[dict[str, Any]] = []
-        for array in self.arrays:
-            value = {
-                "name": array.name,
-                "association": array.association,
-                "components": array.components,
-            }
-            if array.units is not None:
-                value["units"] = array.units
-            arrays.append(value)
-        canonical = {
-            "schema_version": self.schema_version,
-            "dataset_id": self.dataset_id,
-            "kind": self.kind,
-            "format": self.format,
-            "members": members,
-            "arrays": arrays,
-            "bounds": list(self.bounds) if self.bounds is not None else None,
-            "source_artifact": (
-                self.source_artifact.model_dump(mode="json")
-                if self.source_artifact is not None
-                else None
-            ),
-        }
-        digest = hashlib.sha256(
-            json.dumps(
-                canonical,
-                allow_nan=False,
-                ensure_ascii=False,
-                separators=(",", ":"),
-                sort_keys=True,
-            ).encode("utf-8")
-        ).hexdigest()
-        if digest != self.fingerprint.digest:
-            raise ValueError("dataset fingerprint did not match its descriptor")
-        return self
-
-
-class JarvisServiceAuthorizationDocument(BaseModel):
-    """Non-secret fingerprint for an execution-owned runtime capability."""
-
-    model_config = ConfigDict(
-        extra="forbid",
-        frozen=True,
-        strict=True,
-        hide_input_in_errors=True,
-    )
-
-    scheme: Literal["bearer"]
-    token_sha256: str = Field(
-        min_length=64,
-        max_length=64,
-        pattern=r"^[0-9a-f]{64}$",
-        repr=False,
-    )
-
-
-class _JarvisServiceRuntimeDocumentBase(BaseModel):
-    """Fields shared by every released JARVIS service-runtime revision."""
-
-    model_config = ConfigDict(
-        extra="forbid",
-        frozen=True,
-        strict=True,
-        hide_input_in_errors=True,
-    )
-
-    execution_id: str = Field(min_length=1, max_length=256)
-    package_name: str = Field(min_length=1, max_length=256)
-    package_id: str = Field(min_length=1, max_length=256)
-    service_instance_id: str = Field(min_length=1, max_length=256)
-    revision: int = Field(ge=1)
-    lifecycle: Literal["starting", "ready", "degraded", "stopping", "stopped", "failed"]
-    host: str = Field(min_length=1, max_length=255)
-    port: int = Field(ge=1, le=65535)
-    protocol: Literal["http", "https"]
-    health_path: str = Field(min_length=1, max_length=256)
-    live_data_path: str = Field(min_length=1, max_length=256)
-    events_path: str = Field(min_length=1, max_length=256)
-    state_path: str = Field(min_length=1, max_length=256)
-    command_path: str = Field(min_length=1, max_length=256)
-    delivery_mode: Literal["push"]
-    dataset_descriptor: JarvisDatasetDescriptorDocument
-    message: str | None = Field(default=None, min_length=1, max_length=4096)
-    observed_at_epoch: float = Field(ge=0, allow_inf_nan=False)
-
-    @model_validator(mode="after")
-    def validate_private_endpoint_metadata(
-        self,
-    ) -> "_JarvisServiceRuntimeDocumentBase":
-        """Reject wildcard hosts and ambiguous or duplicated HTTP paths."""
-        if self.host in {"0.0.0.0", "::", "*", "localhost"}:
-            raise ValueError("service runtime host cannot be a wildcard or alias")
-        paths = (
-            self.health_path,
-            self.live_data_path,
-            self.events_path,
-            self.state_path,
-            self.command_path,
-        )
-        if len(set(paths)) != len(paths):
-            raise ValueError("service runtime endpoint paths must be distinct")
-        for value in paths:
-            path = PurePosixPath(value)
-            if (
-                not value.startswith("/")
-                or value.startswith("//")
-                or path.as_posix() != value
-                or ".." in path.parts
-                or any(character in value for character in "?#\\")
-            ):
-                raise ValueError("service runtime endpoint path is invalid")
-        return self
-
-
-class JarvisServiceRuntimeV1Document(_JarvisServiceRuntimeDocumentBase):
-    """Released unauthenticated service-runtime v1 document."""
-
-    schema_version: Literal["jarvis.service-runtime.v1"]
-
-
-class JarvisServiceRuntimeV2Document(_JarvisServiceRuntimeDocumentBase):
-    """Service-runtime v2 document with a non-secret capability fingerprint."""
-
-    schema_version: Literal["jarvis.service-runtime.v2"]
-    authorization: JarvisServiceAuthorizationDocument
-
-
-JarvisServiceRuntimeDocument = Annotated[
-    JarvisServiceRuntimeV1Document | JarvisServiceRuntimeV2Document,
-    Field(discriminator="schema_version"),
-]
-
-
-class JarvisServiceRuntimeSnapshotDocument(BaseModel):
-    """Execution-bound current service runtimes returned by JARVIS."""
-
-    model_config = ConfigDict(
-        extra="forbid",
-        frozen=True,
-        strict=True,
-        hide_input_in_errors=True,
-    )
-
-    schema_version: Literal["jarvis.execution.service-runtimes.v1"]
-    execution_id: str = Field(min_length=1, max_length=256)
-    pipeline_id: str = Field(min_length=1, max_length=256)
-    execution_state: Literal[
-        "preparing",
-        "scripted",
-        "submitting",
-        "submitted",
-        "running",
-        "completed",
-        "failed",
-        "canceled",
-        "unknown",
-    ]
-    terminal: bool
-    service_runtimes: list[JarvisServiceRuntimeDocument] = Field(max_length=4096)
-
-    @model_validator(mode="after")
-    def validate_runtime_identities(self) -> "JarvisServiceRuntimeSnapshotDocument":
-        """Bind every service to this execution and reject duplicate instances."""
-        identities: set[str] = set()
-        for runtime in self.service_runtimes:
-            if runtime.execution_id != self.execution_id:
-                raise ValueError("service runtime execution identity did not match")
-            if runtime.service_instance_id in identities:
-                raise ValueError("service runtime instance identities must be unique")
-            identities.add(runtime.service_instance_id)
-        return self
-
-
-class JarvisExecutionResult(BaseModel):
-    """Frozen top-level result envelope for a selectable execution query."""
-
-    model_config = ConfigDict(
-        extra="forbid",
-        frozen=True,
-        hide_input_in_errors=True,
-    )
-
-    schema_version: Literal["clio-kit.jarvis-execution.v2"]
-    pipeline_id: str
-    execution_id: str
-    execution_handle: JarvisExecutionHandleDocument
-    execution_record: JarvisExecutionRecordDocument
-    runtime_metadata: dict[str, Any]
-    progress: JarvisProgressSnapshotDocument | None
-    artifact_page: JarvisExecutionArtifactPageDocument | None
-    service_runtimes: JarvisServiceRuntimeSnapshotDocument | None
 
 
 # Resolve the JARVIS manager lazily so MCP metadata discovery does not require a
@@ -1027,209 +424,6 @@ ADMIN_TOOLS = {
     "jm_graph_modify",
     "destroy_pipeline",
 }
-
-
-_EXECUTION_MODES = {
-    "auto",
-    "local",
-    "direct",
-    "cluster",
-    "scheduler",
-    "hostfile",
-}
-_SCHEDULER_EXECUTION_FIELDS = {
-    "job_name",
-    "nodes",
-    "tasks",
-    "tasks_per_node",
-    "cpus_per_task",
-    "walltime",
-    "partition",
-    "account",
-    "qos",
-    "output",
-    "error",
-    "exclusive",
-    "gpus",
-    "gpus_per_node",
-}
-_SCHEDULER_TOKEN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:@%+,-]{0,255}$")
-_HOST_ENTRY = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,252}$")
-
-
-def _bounded_single_line(value: str, *, field: str, limit: int = 4096) -> str:
-    """Reject control characters and unbounded scheduler/path text."""
-    if not value or len(value.encode("utf-8")) > limit:
-        raise ValueError(f"execution.{field} must be a non-empty bounded string")
-    if any(ord(character) < 32 or ord(character) == 127 for character in value):
-        raise ValueError(f"execution.{field} cannot contain control characters")
-    return value
-
-
-class ExecutionIntent(BaseModel):
-    """Validated, backend-neutral execution request for a JARVIS pipeline."""
-
-    model_config = ConfigDict(extra="forbid", strict=True)
-
-    mode: Literal["auto", "local", "direct", "cluster", "scheduler", "hostfile"] = (
-        "auto"
-    )
-    hostfile: str | None = None
-    hosts: list[str] | None = Field(default=None, min_length=1)
-    job_name: str | None = None
-    nodes: int | None = Field(default=None, gt=0)
-    tasks: int | None = Field(default=None, gt=0)
-    tasks_per_node: int | None = Field(default=None, gt=0)
-    cpus_per_task: int | None = Field(default=None, gt=0)
-    walltime: str | None = None
-    partition: str | None = None
-    account: str | None = None
-    qos: str | None = None
-    output: str | None = None
-    error: str | None = None
-    exclusive: bool | None = None
-    gpus: int | None = Field(default=None, gt=0)
-    gpus_per_node: int | None = Field(default=None, gt=0)
-
-    @field_validator("mode", mode="before")
-    @classmethod
-    def normalize_mode(cls, value: object) -> object:
-        """Normalize a textual mode while preserving strict rejection of other types."""
-        if isinstance(value, str):
-            return value.strip().lower()
-        return value
-
-    @field_validator("hostfile", mode="after")
-    @classmethod
-    def validate_hostfile(cls, value: str | None) -> str | None:
-        """Validate a hostfile path without forbidding platform separators."""
-        if value is None:
-            return None
-        return _bounded_single_line(value, field="hostfile")
-
-    @field_validator("output", "error", mode="after")
-    @classmethod
-    def validate_scheduler_path(cls, value: str | None, info: Any) -> str | None:
-        """Require a single printable directive path token."""
-        if value is None:
-            return None
-        rendered = _bounded_single_line(value, field=info.field_name)
-        if any(character.isspace() for character in rendered) or "#" in rendered:
-            raise ValueError(
-                f"execution.{info.field_name} must be one printable path token"
-            )
-        return rendered
-
-    @field_validator(
-        "job_name",
-        "walltime",
-        "partition",
-        "account",
-        "qos",
-        mode="after",
-    )
-    @classmethod
-    def validate_scheduler_token(cls, value: str | None, info: Any) -> str | None:
-        """Reject whitespace/control injection in scheduler directive values."""
-        if value is None:
-            return None
-        rendered = _bounded_single_line(value, field=info.field_name, limit=256)
-        if _SCHEDULER_TOKEN.fullmatch(rendered) is None:
-            raise ValueError(
-                f"execution.{info.field_name} is not a valid scheduler token"
-            )
-        return rendered
-
-    @field_validator("hosts", mode="after")
-    @classmethod
-    def validate_hosts(cls, value: list[str] | None) -> list[str] | None:
-        """Validate semantic host names before writing a scheduler hostfile."""
-        if value is None:
-            return None
-        if len(value) > 4096:
-            raise ValueError("execution.hosts cannot contain more than 4096 entries")
-        if any(_HOST_ENTRY.fullmatch(host) is None for host in value):
-            raise ValueError("execution.hosts contains an invalid host name")
-        return value
-
-    @model_validator(mode="after")
-    def validate_mode_fields(self) -> "ExecutionIntent":
-        """Reject fields that cannot be represented by the selected execution mode."""
-        populated = self.model_fields_set
-        scheduler_fields = sorted(populated & _SCHEDULER_EXECUTION_FIELDS)
-        host_fields = sorted(populated & {"hostfile", "hosts"})
-
-        if self.mode in {"local", "direct"} and (scheduler_fields or host_fields):
-            incompatible = ", ".join(scheduler_fields + host_fields)
-            raise ValueError(
-                f"execution.mode='{self.mode}' does not accept fields: {incompatible}"
-            )
-        if self.mode == "hostfile":
-            if scheduler_fields:
-                raise ValueError(
-                    "execution.mode='hostfile' does not accept scheduler fields: "
-                    + ", ".join(scheduler_fields)
-                )
-            if (self.hostfile is None) == (self.hosts is None):
-                raise ValueError(
-                    "execution.hostfile requires exactly one of hostfile or hosts "
-                    "when execution.mode='hostfile'"
-                )
-        elif host_fields:
-            raise ValueError(
-                f"execution.mode='{self.mode}' does not accept fields: "
-                + ", ".join(host_fields)
-            )
-        return self
-
-
-class ExecutionArtifactQuery(BaseModel):
-    """Optional filters for one bounded page of execution artifacts."""
-
-    model_config = ConfigDict(extra="forbid", strict=True)
-
-    package_id: str | None = Field(
-        default=None,
-        description="Exact JARVIS package alias filter.",
-        max_length=256,
-    )
-    role: (
-        Literal[
-            "intermediate",
-            "output",
-            "log",
-            "checkpoint",
-            "provenance",
-            "validation",
-        ]
-        | None
-    ) = None
-    state: (
-        Literal[
-            "producing",
-            "available",
-            "finalized",
-            "incomplete",
-            "failed",
-        ]
-        | None
-    ) = None
-    artifact_id: str | None = Field(
-        default=None,
-        description="Exact opaque JARVIS artifact ID filter.",
-        max_length=90,
-    )
-    page_size: int = Field(
-        default=50,
-        description="Maximum artifacts to return in this page.",
-        ge=1,
-        le=100,
-    )
-    cursor: str | None = Field(
-        default=None,
-        description="Opaque next-page cursor.",
-        max_length=1024,
-    )
 
 
 # ─── RESOURCE ────────────────────────────────────────────────────────────────
@@ -2252,727 +1446,6 @@ def jm_graph_modify(net_sleep: float) -> list:
         return [{"type": "text", "text": "Resource graph modified."}]
     except Exception as e:
         raise ToolError(f"Error: {e}")
-
-
-def _discover_packages() -> list[dict[str, Any]]:
-    """Return the legacy exhaustive package descriptions with full settings."""
-
-    return [
-        _package_description_from_inventory(entry)
-        for entry in _discover_package_inventory()
-    ]
-
-
-def _discover_package_inventory() -> list[_PackageInventoryEntry]:
-    """Discover lightweight package identities without importing package classes."""
-
-    packages: list[_PackageInventoryEntry] = []
-    seen: set[str] = set()
-    try:
-        manager = get_manager()
-        repos = [Path(str(repo)) for repo in manager.list_repos()]
-    except Exception:
-        repos = []
-    for repo in repos:
-        if not repo.exists():
-            continue
-        package_files = sorted(
-            (*repo.rglob("pkg.py"), *repo.rglob("package.py")),
-            key=lambda path: (path.parent.as_posix(), path.name != "pkg.py"),
-        )
-        for pkg_file in package_files:
-            package = _package_inventory_entry(repo, pkg_file)
-            name = package.name
-            if not name or name in seen:
-                continue
-            seen.add(name)
-            packages.append(package)
-    return sorted(packages, key=lambda package: (package.name.casefold(), package.name))
-
-
-def _find_package_description(package_name: str) -> dict[str, Any] | None:
-    """Resolve one exact canonical or short name and load only its settings."""
-
-    normalized = package_name.strip().casefold()
-    inventory = _discover_package_inventory()
-    canonical = next(
-        (package for package in inventory if package.name.casefold() == normalized),
-        None,
-    )
-    if canonical is not None:
-        return _package_description_from_inventory(canonical)
-
-    short_matches = [
-        package for package in inventory if package.short_name.casefold() == normalized
-    ]
-    if len(short_matches) == 1:
-        return _package_description_from_inventory(short_matches[0])
-    if len(short_matches) > 1:
-        candidates = ", ".join(package.name for package in short_matches)
-        raise ToolError(
-            f"package short name is ambiguous: {package_name}; use one of: {candidates}"
-        )
-    return None
-
-
-def _package_from_pkg_file(repo: Path, pkg_file: Path) -> dict[str, Any]:
-    """Build one full package description from a repository source file."""
-
-    return _package_description_from_inventory(_package_inventory_entry(repo, pkg_file))
-
-
-def _package_inventory_entry(repo: Path, pkg_file: Path) -> _PackageInventoryEntry:
-    """Build one lightweight package inventory entry from its source location."""
-
-    relative = pkg_file.relative_to(repo)
-    parts = list(relative.parts[:-1])
-    short_name = parts[-1] if parts else repo.name
-    dotted = ".".join(parts) if parts else short_name
-    description = _first_docstring_or_comment(pkg_file)
-    repository = parts[0] if parts else repo.name
-    return _PackageInventoryEntry(
-        name=dotted,
-        short_name=short_name,
-        repository=repository,
-        description=description,
-        repo=repo,
-        package_file=pkg_file,
-    )
-
-
-def _package_description_from_inventory(
-    entry: _PackageInventoryEntry,
-) -> dict[str, Any]:
-    """Load one selected package's path-free agent contract."""
-
-    metadata = _package_agent_metadata(entry.name)
-    package: dict[str, Any] = {
-        "schema_version": PACKAGE_DESCRIPTION_SCHEMA,
-        "name": entry.name,
-        "short_name": entry.short_name,
-        "description": entry.description,
-        "deployment": metadata.deployment,
-    }
-    if metadata.settings is not None:
-        package["settings"] = metadata.settings
-    return package
-
-
-def _search_packages(
-    *,
-    query: str,
-    page_size: int = PACKAGE_SEARCH_DEFAULT_PAGE_SIZE,
-    cursor: str | None = None,
-) -> dict[str, Any]:
-    """Return a bounded, summary-only page from the registered package inventory."""
-
-    normalized_query = " ".join(query.split())
-    if not normalized_query:
-        raise ToolError("package_search query must not be blank")
-    if (
-        isinstance(page_size, bool)
-        or not isinstance(page_size, int)
-        or not 1 <= page_size <= PACKAGE_SEARCH_MAX_PAGE_SIZE
-    ):
-        raise ToolError(
-            "package_search page_size must be between 1 and "
-            f"{PACKAGE_SEARCH_MAX_PAGE_SIZE}"
-        )
-
-    inventory = _discover_package_inventory()
-    # The declared configuration contract is part of what ranks and pages this
-    # search, so it is also part of the revision the cursor is bound to: a menu
-    # that changes between pages must invalidate the cursor exactly as a
-    # changed docstring already does.
-    configuration_texts = {
-        package.name: _package_configuration_search_text(package.name)
-        for package in inventory
-    }
-    inventory_revision = _package_inventory_revision(inventory, configuration_texts)
-    query_sha256 = hashlib.sha256(
-        normalized_query.casefold().encode("utf-8")
-    ).hexdigest()
-    ranked = sorted(
-        (
-            (rank, package)
-            for package in inventory
-            if (
-                rank := _package_search_rank(
-                    package,
-                    normalized_query,
-                    configuration_texts.get(package.name, ""),
-                )
-            )
-            is not None
-        ),
-        key=lambda item: (item[0], item[1].name.casefold(), item[1].name),
-    )
-    matches = [package for _, package in ranked]
-
-    start = 0
-    if cursor is not None:
-        decoded = _decode_package_search_cursor(cursor)
-        if decoded["query_sha256"] != query_sha256:
-            raise ToolError("package_search cursor does not match the requested query")
-        if decoded["inventory_revision"] != inventory_revision:
-            raise ToolError(
-                "package_search cursor is stale because the package inventory changed"
-            )
-        anchor = decoded["after_package_name"]
-        try:
-            start = next(
-                index + 1
-                for index, package in enumerate(matches)
-                if package.name == anchor
-            )
-        except StopIteration as exc:
-            raise ToolError(
-                "package_search cursor is stale because its package anchor disappeared"
-            ) from exc
-
-    page = [package.summary() for package in matches[start : start + page_size]]
-    while True:
-        has_more = start + len(page) < len(matches)
-        next_cursor = None
-        if has_more and page:
-            next_cursor = _encode_package_search_cursor(
-                after_package_name=str(page[-1]["name"]),
-                query_sha256=query_sha256,
-                inventory_revision=inventory_revision,
-            )
-        result: dict[str, Any] = {
-            "schema_version": PACKAGE_SEARCH_SCHEMA,
-            "target": "package_search",
-            "query": normalized_query,
-            "inventory_revision": inventory_revision,
-            "packages": page,
-            "total_matches": len(matches),
-            "returned_count": len(page),
-            "next_cursor": next_cursor,
-        }
-        if len(_package_search_json_bytes(result)) <= PACKAGE_SEARCH_MAX_RESULT_BYTES:
-            return result
-        if len(page) <= 1:
-            raise ToolError(
-                "one package_search result exceeded the response byte limit"
-            )
-        page.pop()
-
-
-def _package_configuration_search_text(package_name: str) -> str:
-    """Return one package's declared agent-visible configuration as search text.
-
-    Discovery ranks over what a package DECLARES, not only over the module
-    docstring that ``_first_docstring_or_comment`` scrapes. A caller looking
-    for a package that accepts a *staged local input* has no other way to find
-    one: the bounded search summary carries identity only, and a setting's
-    ``input_binding`` -- the single authoritative staging signal -- lives in
-    the package's configure menu, which search never consulted. Every term
-    here is package-declared (setting names, setting prose, and the binding's
-    own ``kind``/``structure`` vocabulary); nothing about specific packages is
-    encoded in this function.
-
-    Loading is best-effort by design and mirrors
-    :func:`_package_agent_metadata`'s existing treatment of an unloadable
-    menu: a package that cannot be imported contributes no configuration text
-    and stays rankable by identity exactly as before, so one broken package in
-    a registered repository can never fail a whole search.
-    """
-
-    try:
-        from jarvis_cd.core.pkg import Pkg  # type: ignore[import-untyped]
-
-        pkg = Pkg.load_standalone(package_name)
-        settings = [
-            _setting_from_menu_item(item)
-            for item in pkg.configure_menu()
-            if _setting_is_agent_visible(item)
-        ]
-    except Exception:
-        return ""
-
-    terms: list[str] = []
-    for setting in settings:
-        for field in ("name", "description"):
-            value = setting.get(field)
-            if isinstance(value, str) and value:
-                terms.append(value)
-        binding = setting.get("input_binding")
-        if isinstance(binding, dict):
-            terms.append("input_binding")
-            for field in ("kind", "structure"):
-                value = binding.get(field)
-                if isinstance(value, str) and value:
-                    terms.append(value)
-    return " ".join(terms)
-
-
-def _package_search_rank(
-    package: _PackageInventoryEntry,
-    query: str,
-    configuration_text: str = "",
-) -> int | None:
-    """Return a deterministic relevance rank, or ``None`` when no field matches.
-
-    Ranks 0-4 are identity and docstring matches and are unchanged. Ranks 5
-    and 6 are the package's own declared configuration contract, which ranks
-    below every identity match so an exact name never loses to a setting that
-    merely mentions the query.
-    """
-
-    folded_query = query.casefold()
-    folded_name = package.name.casefold()
-    folded_short_name = package.short_name.casefold()
-    if folded_query in {folded_name, folded_short_name}:
-        return 0
-    if folded_name.startswith(folded_query) or folded_short_name.startswith(
-        folded_query
-    ):
-        return 1
-    if folded_query in folded_name or folded_query in folded_short_name:
-        return 2
-    folded_description = (package.description or "").casefold()
-    if folded_query in folded_description:
-        return 3
-
-    normalized_query = _package_search_terms(folded_query)
-    if not normalized_query:
-        return None
-    identity_terms = _package_search_terms(
-        " ".join(
-            (
-                package.name,
-                package.short_name,
-                package.description or "",
-            )
-        ).casefold()
-    )
-    if all(term in identity_terms for term in normalized_query):
-        return 4
-
-    folded_configuration = configuration_text.casefold()
-    if folded_configuration and folded_query in folded_configuration:
-        return 5
-    searchable = identity_terms + _package_search_terms(folded_configuration)
-    if all(term in searchable for term in normalized_query):
-        return 6
-    return None
-
-
-def _package_search_terms(value: str) -> list[str]:
-    """Tokenize package names and prose without locale-dependent behavior."""
-
-    return [term for term in re.split(r"[^a-z0-9]+", value) if term]
-
-
-def _package_inventory_revision(
-    inventory: list[_PackageInventoryEntry],
-    configuration_texts: Mapping[str, str] | None = None,
-) -> str:
-    """Hash the full inventory used to rank and page package search."""
-
-    texts = configuration_texts or {}
-    hasher = hashlib.sha256()
-    hasher.update(b"clio-kit.jarvis-package-inventory.v1\0")
-    for package in inventory:
-        encoded = _package_search_json_bytes(
-            {
-                "name": package.name,
-                "short_name": package.short_name,
-                "repository": package.repository,
-                "description": package.description,
-                "configuration": texts.get(package.name, ""),
-            }
-        )
-        hasher.update(len(encoded).to_bytes(8, "big"))
-        hasher.update(encoded)
-    return hasher.hexdigest()
-
-
-def _encode_package_search_cursor(
-    *,
-    after_package_name: str,
-    query_sha256: str,
-    inventory_revision: str,
-) -> str:
-    """Encode an opaque cursor bound to one query and inventory revision."""
-
-    payload = _package_search_json_bytes(
-        {
-            "schema_version": PACKAGE_SEARCH_CURSOR_SCHEMA,
-            "after_package_name": after_package_name,
-            "query_sha256": query_sha256,
-            "inventory_revision": inventory_revision,
-        }
-    )
-    cursor = base64.urlsafe_b64encode(payload).decode("ascii").rstrip("=")
-    if len(cursor) > PACKAGE_SEARCH_MAX_CURSOR_LENGTH:
-        raise ToolError("package_search cursor exceeded its byte limit")
-    return cursor
-
-
-def _decode_package_search_cursor(cursor: str) -> dict[str, str]:
-    """Decode and strictly validate one package-search cursor."""
-
-    if (
-        not cursor
-        or len(cursor) > PACKAGE_SEARCH_MAX_CURSOR_LENGTH
-        or _PACKAGE_SEARCH_CURSOR_TEXT.fullmatch(cursor) is None
-    ):
-        raise ToolError("package_search cursor is invalid")
-    padding = "=" * (-len(cursor) % 4)
-    try:
-        payload = base64.b64decode(
-            cursor + padding,
-            altchars=b"-_",
-            validate=True,
-        )
-        if len(payload) > PACKAGE_SEARCH_MAX_CURSOR_LENGTH:
-            raise ToolError("package_search cursor exceeded its byte limit")
-        value = json.loads(
-            payload.decode("utf-8"),
-            object_pairs_hook=_reject_package_search_duplicate_keys,
-        )
-    except ToolError:
-        raise
-    except (
-        binascii.Error,
-        UnicodeDecodeError,
-        json.JSONDecodeError,
-        ValueError,
-    ) as exc:
-        raise ToolError("package_search cursor is invalid") from exc
-    expected_fields = {
-        "schema_version",
-        "after_package_name",
-        "query_sha256",
-        "inventory_revision",
-    }
-    if not isinstance(value, dict) or set(value) != expected_fields:
-        raise ToolError("package_search cursor schema is invalid")
-    if value.get("schema_version") != PACKAGE_SEARCH_CURSOR_SCHEMA:
-        raise ToolError("package_search cursor schema is unsupported")
-    after_package_name = value.get("after_package_name")
-    query_sha256 = value.get("query_sha256")
-    inventory_revision = value.get("inventory_revision")
-    if (
-        not isinstance(after_package_name, str)
-        or not after_package_name
-        or not isinstance(query_sha256, str)
-        or _PACKAGE_SEARCH_SHA256.fullmatch(query_sha256) is None
-        or not isinstance(inventory_revision, str)
-        or _PACKAGE_SEARCH_SHA256.fullmatch(inventory_revision) is None
-    ):
-        raise ToolError("package_search cursor fields are invalid")
-    return {
-        "after_package_name": after_package_name,
-        "query_sha256": query_sha256,
-        "inventory_revision": inventory_revision,
-    }
-
-
-def _bounded_package_search_description(value: str | None) -> str | None:
-    """Truncate only search summaries to their documented UTF-8 byte ceiling."""
-
-    if value is None:
-        return None
-    encoded = value.encode("utf-8")
-    if len(encoded) <= PACKAGE_SEARCH_MAX_DESCRIPTION_BYTES:
-        return value
-    suffix = "..."
-    budget = PACKAGE_SEARCH_MAX_DESCRIPTION_BYTES - len(suffix)
-    prefix = encoded[:budget]
-    while prefix:
-        try:
-            return prefix.decode("utf-8") + suffix
-        except UnicodeDecodeError:
-            prefix = prefix[:-1]
-    return suffix
-
-
-def _package_search_json_bytes(value: object) -> bytes:
-    """Serialize bounded search state using a deterministic UTF-8 encoding."""
-
-    return json.dumps(
-        value,
-        allow_nan=False,
-        ensure_ascii=False,
-        separators=(",", ":"),
-        sort_keys=True,
-    ).encode("utf-8")
-
-
-def _reject_package_search_duplicate_keys(
-    pairs: list[tuple[str, Any]],
-) -> dict[str, Any]:
-    """Reject ambiguous JSON objects inside opaque package-search cursors."""
-
-    value: dict[str, Any] = {}
-    for key, item in pairs:
-        if key in value:
-            raise ValueError(f"duplicate package_search cursor key: {key}")
-        value[key] = item
-    return value
-
-
-def _first_docstring_or_comment(path: Path) -> str | None:
-    try:
-        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
-    except OSError:
-        return None
-    in_docstring = False
-    docstring_quote: str | None = None
-    collected: list[str] = []
-    for raw_line in lines[:80]:
-        line = raw_line.strip()
-        if not line:
-            continue
-        if line.startswith("#"):
-            comment = line.lstrip("#").strip()
-            if comment:
-                return comment
-            continue
-        if in_docstring and docstring_quote is not None:
-            if line.endswith(docstring_quote):
-                line = line[: -len(docstring_quote)]
-                if line:
-                    collected.append(line.strip())
-                return " ".join(collected).strip() or None
-            collected.append(line)
-            continue
-        if line.startswith(('"""', "'''")):
-            docstring_quote = line[:3]
-            remainder = line[3:]
-            if remainder.endswith(docstring_quote):
-                remainder = remainder[:-3]
-                return remainder.strip() or None
-            in_docstring = True
-            if remainder:
-                collected.append(remainder.strip())
-            continue
-        return None
-    return " ".join(collected).strip() or None
-
-
-def _step_snapshot(
-    pipeline_snapshot: dict[str, Any], step_id: str
-) -> dict[str, Any] | None:
-    for package in pipeline_snapshot.get("packages", []):
-        if not isinstance(package, dict):
-            continue
-        identifiers = {
-            str(package.get("pkg_id", "")),
-            str(package.get("global_id", "")),
-        }
-        if step_id in identifiers:
-            return package
-    return None
-
-
-def _package_agent_metadata(package_name: str) -> _PackageAgentMetadata:
-    """Load package-owned configuration and deployment metadata once.
-
-    Older JARVIS packages do not implement ``describe_deployment`` and are
-    represented with ``deployment=None``. If a package advertises the method,
-    however, its document must match the versioned, path-free contract instead
-    of being silently downgraded to legacy behavior.
-    """
-
-    try:
-        from jarvis_cd.core.pkg import Pkg  # type: ignore[import-untyped]
-
-        pkg = Pkg.load_standalone(package_name)
-    except Exception:
-        return _PackageAgentMetadata(settings=None, deployment=None)
-
-    try:
-        menu = pkg.configure_menu()
-        settings = [
-            _setting_from_menu_item(item)
-            for item in menu
-            if _setting_is_agent_visible(item)
-        ]
-    except Exception:
-        settings = None
-
-    describe_deployment = getattr(pkg, "describe_deployment", None)
-    if not callable(describe_deployment):
-        return _PackageAgentMetadata(settings=settings, deployment=None)
-    try:
-        raw_deployment = describe_deployment()
-    except Exception:
-        raise ToolError(
-            f"package '{package_name}' failed to describe its deployment contract"
-        ) from None
-    if raw_deployment is None:
-        return _PackageAgentMetadata(settings=settings, deployment=None)
-    if isinstance(raw_deployment, BaseModel):
-        raw_deployment = raw_deployment.model_dump(mode="json")
-    if not isinstance(raw_deployment, dict):
-        raise ToolError(
-            f"package '{package_name}' returned an invalid deployment contract"
-        )
-    try:
-        deployment = json.loads(
-            json.dumps(
-                raw_deployment,
-                allow_nan=False,
-                ensure_ascii=False,
-                separators=(",", ":"),
-                sort_keys=True,
-            )
-        )
-    except (TypeError, ValueError):
-        raise ToolError(
-            f"package '{package_name}' returned a non-JSON deployment contract"
-        ) from None
-    try:
-        validated = JarvisPackageDeploymentDocument.model_validate(deployment)
-    except ValidationError:
-        raise ToolError(
-            f"package '{package_name}' returned an invalid deployment contract"
-        ) from None
-    if (
-        validated.schema_version != PACKAGE_DEPLOYMENT_SCHEMA
-        or validated.package != package_name
-    ):
-        raise ToolError(
-            f"package '{package_name}' returned an invalid deployment contract"
-        )
-    return _PackageAgentMetadata(settings=settings, deployment=deployment)
-
-
-def _setting_from_menu_item(item: dict[str, Any]) -> dict[str, Any]:
-    setting: dict[str, Any] = {
-        "name": item.get("name"),
-        "description": item.get("msg"),
-        "required": bool(item.get("required", False)),
-        "nullable": _setting_accepts_null(item),
-    }
-    kind = item.get("type")
-    if isinstance(kind, type):
-        setting["type"] = kind.__name__
-    elif kind is not None:
-        setting["type"] = str(kind)
-    if "default" in item:
-        setting["default"] = item["default"]
-    choices = item.get("choices")
-    if isinstance(choices, (list, tuple)):
-        setting["choices"] = list(choices)
-    aliases = item.get("aliases")
-    if isinstance(aliases, (list, tuple)) and all(
-        isinstance(alias, str) and alias for alias in aliases
-    ):
-        setting["aliases"] = list(aliases)
-    if "input_binding" in item:
-        try:
-            input_binding = JarvisConfigurationInputBindingDocument.model_validate(
-                item["input_binding"]
-            )
-        except ValidationError as error:
-            raise ValueError("invalid package configuration input binding") from error
-        setting["input_binding"] = input_binding.model_dump(mode="json")
-    return {
-        key: value
-        for key, value in setting.items()
-        if value is not None or key == "default"
-    }
-
-
-def _setting_is_agent_visible(item: dict[str, Any]) -> bool:
-    """Return whether package metadata exposes a setting to user agents."""
-
-    return item.get("agent_visible", True) is not False
-
-
-def _setting_accepts_null(item: dict[str, Any]) -> bool:
-    """Return whether the structured add-step path accepts explicit null."""
-
-    return "default" in item and item["default"] is None
-
-
-def _validated_execution_intent(
-    execution: ExecutionIntent | dict[str, Any],
-) -> ExecutionIntent:
-    if isinstance(execution, ExecutionIntent):
-        return execution
-    raw_mode = execution.get("mode", "auto")
-    if (
-        not isinstance(raw_mode, str)
-        or raw_mode.strip().lower() not in _EXECUTION_MODES
-    ):
-        raise ToolError(
-            "execution.mode must be one of: auto, local, direct, cluster, scheduler, hostfile"
-        )
-    try:
-        return ExecutionIntent.model_validate(execution)
-    except ValidationError as error:
-        details = []
-        for item in error.errors(include_url=False, include_context=False):
-            location = ".".join(str(part) for part in item["loc"])
-            prefix = f"{location}: " if location else ""
-            details.append(f"{prefix}{item['msg']}")
-        raise ToolError("invalid execution intent: " + "; ".join(details)) from error
-
-
-def _execution_intent_to_pipeline_config(
-    execution: ExecutionIntent | dict[str, Any],
-) -> dict[str, Any]:
-    intent = _validated_execution_intent(execution)
-    values = intent.model_dump(exclude_none=True)
-    mode = intent.mode
-    if mode in {"local", "direct"}:
-        return {"scheduler": None, "hostfile": None}
-    if mode == "hostfile":
-        if intent.hostfile is not None:
-            return {"scheduler": None, "hostfile": intent.hostfile}
-        if intent.hosts is not None:
-            return {
-                "scheduler": None,
-                "hostfile_entries": intent.hosts,
-            }
-        raise AssertionError("validated hostfile intent has no target")
-    if mode in {"cluster", "scheduler", "auto"}:
-        scheduler_name = _detect_scheduler_name()
-        if scheduler_name is None:
-            if mode == "auto" and set(values) <= {"mode"}:
-                return {}
-            raise ToolError("no supported cluster scheduler detected on this machine")
-        if mode == "auto" and set(values) <= {"mode"}:
-            return {}
-        scheduler: dict[str, Any] = {"name": scheduler_name}
-        mapping = {
-            "job_name": "job_name",
-            "nodes": "nodes",
-            "tasks": "ntasks",
-            "tasks_per_node": "ntasks_per_node",
-            "cpus_per_task": "cpus_per_task",
-            "walltime": "time",
-            "partition": "partition",
-            "account": "account",
-            "qos": "qos",
-            "output": "output",
-            "error": "error",
-            "exclusive": "exclusive",
-            "gpus": "gpus",
-            "gpus_per_node": "gpus_per_node",
-        }
-        for public_key, scheduler_key in mapping.items():
-            if public_key in values:
-                scheduler[scheduler_key] = values[public_key]
-        return {"scheduler": scheduler}
-    raise AssertionError(f"validated execution intent has unsupported mode: {mode}")
-
-
-def _detect_scheduler_name() -> str | None:
-    configured = os.getenv("JARVIS_MCP_SCHEDULER") or os.getenv("JARVIS_SCHEDULER")
-    if configured:
-        return configured.strip().lower()
-    from shutil import which
-
-    if which("sbatch") is not None:
-        return "slurm"
-    return None
 
 
 def _protocol_stdout_to_stderr() -> Any:

--- a/clio-kit-mcp-servers/jarvis/tests/fixtures/jarvis_tool_call_pins.json
+++ b/clio-kit-mcp-servers/jarvis/tests/fixtures/jarvis_tool_call_pins.json
@@ -1,0 +1,207 @@
+{
+  "jarvis_create_pipeline": {
+    "args": {
+      "pipeline_id": "pin_pipeline"
+    },
+    "result": {
+      "content": [
+        {
+          "annotations": null,
+          "meta": null,
+          "text": "{\"pipeline_id\":\"pin_pipeline\",\"status\":\"created\"}",
+          "type": "text"
+        }
+      ],
+      "is_error": false,
+      "meta": {
+        "io.modelcontextprotocol/serverInfo": {
+          "name": "jarvis",
+          "version": "4.0.0b1"
+        }
+      },
+      "structured_content": {
+        "pipeline_id": "pin_pipeline",
+        "status": "created"
+      }
+    }
+  },
+  "jarvis_describe_package_search": {
+    "args": {
+      "query": "proc",
+      "target": "package_search"
+    },
+    "result": {
+      "content": [
+        {
+          "annotations": null,
+          "meta": null,
+          "text": "{\"schema_version\":\"jarvis.package-search.v1\",\"target\":\"package_search\",\"query\":\"proc\",\"inventory_revision\":\"c3997476927a492d85a8c9ff0c3ae5772d7bb5c1ef4556871c3a202e3545c451\",\"packages\":[],\"total_matches\":0,\"returned_count\":0,\"next_cursor\":null}",
+          "type": "text"
+        }
+      ],
+      "is_error": false,
+      "meta": {
+        "fastmcp": {
+          "wrap_result": true
+        },
+        "io.modelcontextprotocol/serverInfo": {
+          "name": "jarvis",
+          "version": "4.0.0b1"
+        }
+      },
+      "structured_content": {
+        "result": {
+          "inventory_revision": "c3997476927a492d85a8c9ff0c3ae5772d7bb5c1ef4556871c3a202e3545c451",
+          "next_cursor": null,
+          "packages": [],
+          "query": "proc",
+          "returned_count": 0,
+          "schema_version": "jarvis.package-search.v1",
+          "target": "package_search",
+          "total_matches": 0
+        }
+      }
+    }
+  },
+  "jarvis_get_execution": {
+    "args": {
+      "execution_id": "pin-exec-0001",
+      "pipeline_id": "pin_pipeline"
+    },
+    "result": {
+      "content": [
+        {
+          "annotations": null,
+          "meta": null,
+          "text": "{\"schema_version\":\"clio-kit.jarvis-execution.v2\",\"pipeline_id\":\"pin_pipeline\",\"execution_id\":\"pin-exec-0001\",\"execution_handle\":{\"schema_version\":\"jarvis.execution.handle.v1\",\"execution_id\":\"pin-exec-0001\",\"pipeline_id\":\"pin_pipeline\",\"mode\":\"direct\",\"scheduler_provider\":null,\"scheduler_native_id\":null,\"cluster\":null},\"execution_record\":{\"schema_version\":\"jarvis.execution.record.v1\",\"execution_id\":\"pin-exec-0001\",\"pipeline_id\":\"pin_pipeline\",\"pipeline_name\":\"pin_pipeline\",\"mode\":\"direct\",\"scheduler_provider\":null,\"scheduler_native_id\":null,\"cluster\":null,\"state\":\"running\",\"submitted\":false,\"terminal\":false,\"created_at\":\"2026-08-01T00:00:00Z\",\"updated_at\":\"2026-08-01T00:00:01Z\",\"return_code\":null,\"error\":null,\"metadata\":{}},\"runtime_metadata\":{\"source\":\"jarvis_mcp\",\"schema_version\":\"jarvis.runtime.v1\"},\"progress\":{\"schema_version\":\"jarvis.execution.progress.v1\",\"execution_id\":\"pin-exec-0001\",\"pipeline_id\":\"pin_pipeline\",\"execution_state\":\"running\",\"terminal\":false,\"packages\":[]},\"artifact_page\":null,\"service_runtimes\":null}",
+          "type": "text"
+        }
+      ],
+      "is_error": false,
+      "meta": {
+        "io.modelcontextprotocol/serverInfo": {
+          "name": "jarvis",
+          "version": "4.0.0b1"
+        }
+      },
+      "structured_content": {
+        "artifact_page": null,
+        "execution_handle": {
+          "cluster": null,
+          "execution_id": "pin-exec-0001",
+          "mode": "direct",
+          "pipeline_id": "pin_pipeline",
+          "scheduler_native_id": null,
+          "scheduler_provider": null,
+          "schema_version": "jarvis.execution.handle.v1"
+        },
+        "execution_id": "pin-exec-0001",
+        "execution_record": {
+          "cluster": null,
+          "created_at": "2026-08-01T00:00:00Z",
+          "error": null,
+          "execution_id": "pin-exec-0001",
+          "metadata": {},
+          "mode": "direct",
+          "pipeline_id": "pin_pipeline",
+          "pipeline_name": "pin_pipeline",
+          "return_code": null,
+          "scheduler_native_id": null,
+          "scheduler_provider": null,
+          "schema_version": "jarvis.execution.record.v1",
+          "state": "running",
+          "submitted": false,
+          "terminal": false,
+          "updated_at": "2026-08-01T00:00:01Z"
+        },
+        "pipeline_id": "pin_pipeline",
+        "progress": {
+          "execution_id": "pin-exec-0001",
+          "execution_state": "running",
+          "packages": [],
+          "pipeline_id": "pin_pipeline",
+          "schema_version": "jarvis.execution.progress.v1",
+          "terminal": false
+        },
+        "runtime_metadata": {
+          "schema_version": "jarvis.runtime.v1",
+          "source": "jarvis_mcp"
+        },
+        "schema_version": "clio-kit.jarvis-execution.v2",
+        "service_runtimes": null
+      }
+    }
+  },
+  "jarvis_run": {
+    "args": {
+      "execution_id": "pin-exec-0001",
+      "pipeline_id": "pin_pipeline"
+    },
+    "result": {
+      "content": [
+        {
+          "annotations": null,
+          "meta": null,
+          "text": "{\"schema_version\":\"clio-kit.jarvis-run.v1\",\"pipeline_id\":\"pin_pipeline\",\"execution_id\":\"pin-exec-0001\",\"status\":\"running\",\"mode\":\"direct\",\"scheduler\":null,\"script_path\":null,\"wait\":false,\"execution_handle\":{\"schema_version\":\"jarvis.execution.handle.v1\",\"execution_id\":\"pin-exec-0001\",\"pipeline_id\":\"pin_pipeline\",\"mode\":\"direct\",\"scheduler_provider\":null,\"scheduler_native_id\":null,\"cluster\":null},\"execution_record\":{\"schema_version\":\"jarvis.execution.record.v1\",\"execution_id\":\"pin-exec-0001\",\"pipeline_id\":\"pin_pipeline\",\"pipeline_name\":\"pin_pipeline\",\"mode\":\"direct\",\"scheduler_provider\":null,\"scheduler_native_id\":null,\"cluster\":null,\"state\":\"running\",\"submitted\":false,\"terminal\":false,\"created_at\":\"2026-08-01T00:00:00Z\",\"updated_at\":\"2026-08-01T00:00:01Z\",\"return_code\":null,\"error\":null,\"metadata\":{}},\"progress\":{\"schema_version\":\"jarvis.execution.progress.v1\",\"execution_id\":\"pin-exec-0001\",\"pipeline_id\":\"pin_pipeline\",\"execution_state\":\"running\",\"terminal\":false,\"packages\":[]},\"runtime_metadata\":{\"source\":\"jarvis_mcp\",\"schema_version\":\"jarvis.runtime.v1\"}}",
+          "type": "text"
+        }
+      ],
+      "is_error": false,
+      "meta": {
+        "io.modelcontextprotocol/serverInfo": {
+          "name": "jarvis",
+          "version": "4.0.0b1"
+        }
+      },
+      "structured_content": {
+        "execution_handle": {
+          "cluster": null,
+          "execution_id": "pin-exec-0001",
+          "mode": "direct",
+          "pipeline_id": "pin_pipeline",
+          "scheduler_native_id": null,
+          "scheduler_provider": null,
+          "schema_version": "jarvis.execution.handle.v1"
+        },
+        "execution_id": "pin-exec-0001",
+        "execution_record": {
+          "cluster": null,
+          "created_at": "2026-08-01T00:00:00Z",
+          "error": null,
+          "execution_id": "pin-exec-0001",
+          "metadata": {},
+          "mode": "direct",
+          "pipeline_id": "pin_pipeline",
+          "pipeline_name": "pin_pipeline",
+          "return_code": null,
+          "scheduler_native_id": null,
+          "scheduler_provider": null,
+          "schema_version": "jarvis.execution.record.v1",
+          "state": "running",
+          "submitted": false,
+          "terminal": false,
+          "updated_at": "2026-08-01T00:00:01Z"
+        },
+        "mode": "direct",
+        "pipeline_id": "pin_pipeline",
+        "progress": {
+          "execution_id": "pin-exec-0001",
+          "execution_state": "running",
+          "packages": [],
+          "pipeline_id": "pin_pipeline",
+          "schema_version": "jarvis.execution.progress.v1",
+          "terminal": false
+        },
+        "runtime_metadata": {
+          "schema_version": "jarvis.runtime.v1",
+          "source": "jarvis_mcp"
+        },
+        "scheduler": null,
+        "schema_version": "clio-kit.jarvis-run.v1",
+        "script_path": null,
+        "status": "running",
+        "wait": false
+      }
+    }
+  }
+}

--- a/clio-kit-mcp-servers/jarvis/tests/fixtures/jarvis_tools_list_pin.json
+++ b/clio-kit-mcp-servers/jarvis/tests/fixtures/jarvis_tools_list_pin.json
@@ -1,0 +1,5205 @@
+{
+  "order": [
+    "update_pipeline",
+    "build_pipeline_env",
+    "create_pipeline",
+    "load_pipeline",
+    "export_pipeline",
+    "get_pkg_config",
+    "append_pkg",
+    "configure_pkg",
+    "unlink_pkg",
+    "remove_pkg",
+    "run_pipeline",
+    "jarvis_create_pipeline",
+    "jarvis_describe",
+    "jarvis_add_step",
+    "jarvis_edit_step",
+    "jarvis_run",
+    "jarvis_get_execution",
+    "destroy_pipeline",
+    "jm_create_config",
+    "jm_load_config",
+    "jm_save_config",
+    "jm_set_hostfile",
+    "jm_bootstrap_from",
+    "jm_bootstrap_list",
+    "jm_reset",
+    "jm_list_pipelines",
+    "jm_cd",
+    "jm_list_repos",
+    "jm_add_repo",
+    "jm_remove_repo",
+    "jm_promote_repo",
+    "jm_get_repo",
+    "jm_construct_pkg",
+    "jm_graph_show",
+    "jm_graph_build",
+    "jm_graph_modify"
+  ],
+  "tools": {
+    "append_pkg": {
+      "_meta": {
+        "fastmcp": {
+          "tags": [
+            "jarvis",
+            "pipeline"
+          ]
+        }
+      },
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": null,
+        "readOnlyHint": false,
+        "title": null
+      },
+      "description": "Append a package to a Jarvis-CD pipeline.",
+      "execution": null,
+      "icons": null,
+      "inputSchema": {
+        "additionalProperties": false,
+        "properties": {
+          "do_configure": {
+            "default": true,
+            "type": "boolean"
+          },
+          "extra_args": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "pipeline_id": {
+            "type": "string"
+          },
+          "pkg_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "pkg_type": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "pipeline_id",
+          "pkg_type"
+        ],
+        "type": "object"
+      },
+      "name": "append_pkg",
+      "outputSchema": {
+        "additionalProperties": true,
+        "type": "object"
+      },
+      "title": "Append Package"
+    },
+    "build_pipeline_env": {
+      "_meta": {
+        "fastmcp": {
+          "tags": [
+            "jarvis",
+            "pipeline"
+          ]
+        }
+      },
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": null,
+        "readOnlyHint": false,
+        "title": null
+      },
+      "description": "Rebuild a pipeline's env.yaml, capturing CMAKE_PREFIX_PATH and PATH.",
+      "execution": null,
+      "icons": null,
+      "inputSchema": {
+        "additionalProperties": false,
+        "properties": {
+          "pipeline_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "pipeline_id"
+        ],
+        "type": "object"
+      },
+      "name": "build_pipeline_env",
+      "outputSchema": {
+        "additionalProperties": true,
+        "type": "object"
+      },
+      "title": "Build Environment"
+    },
+    "configure_pkg": {
+      "_meta": {
+        "fastmcp": {
+          "tags": [
+            "jarvis",
+            "pipeline"
+          ]
+        }
+      },
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": null,
+        "readOnlyHint": false,
+        "title": null
+      },
+      "description": "Configure a package in a Jarvis-CD pipeline.",
+      "execution": null,
+      "icons": null,
+      "inputSchema": {
+        "additionalProperties": false,
+        "properties": {
+          "extra_args": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "pipeline_id": {
+            "type": "string"
+          },
+          "pkg_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "pipeline_id",
+          "pkg_id"
+        ],
+        "type": "object"
+      },
+      "name": "configure_pkg",
+      "outputSchema": {
+        "additionalProperties": true,
+        "type": "object"
+      },
+      "title": "Configure Package"
+    },
+    "create_pipeline": {
+      "_meta": {
+        "fastmcp": {
+          "tags": [
+            "jarvis",
+            "pipeline"
+          ]
+        }
+      },
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": null,
+        "readOnlyHint": false,
+        "title": null
+      },
+      "description": "Create a new Jarvis-CD pipeline environment.",
+      "execution": null,
+      "icons": null,
+      "inputSchema": {
+        "additionalProperties": false,
+        "properties": {
+          "pipeline_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "pipeline_id"
+        ],
+        "type": "object"
+      },
+      "name": "create_pipeline",
+      "outputSchema": {
+        "additionalProperties": true,
+        "type": "object"
+      },
+      "title": "Create Pipeline"
+    },
+    "destroy_pipeline": {
+      "_meta": {
+        "fastmcp": {
+          "tags": [
+            "jarvis",
+            "pipeline"
+          ]
+        }
+      },
+      "annotations": {
+        "destructiveHint": true,
+        "idempotentHint": true,
+        "openWorldHint": null,
+        "readOnlyHint": false,
+        "title": null
+      },
+      "description": "Destroy a pipeline environment and clean up files.",
+      "execution": null,
+      "icons": null,
+      "inputSchema": {
+        "additionalProperties": false,
+        "properties": {
+          "pipeline_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "pipeline_id"
+        ],
+        "type": "object"
+      },
+      "name": "destroy_pipeline",
+      "outputSchema": {
+        "additionalProperties": true,
+        "type": "object"
+      },
+      "title": "Destroy Pipeline"
+    },
+    "export_pipeline": {
+      "_meta": {
+        "fastmcp": {
+          "tags": [
+            "jarvis",
+            "pipeline"
+          ]
+        }
+      },
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": null,
+        "readOnlyHint": true,
+        "title": null
+      },
+      "description": "Export a structured snapshot of a Jarvis-CD pipeline.",
+      "execution": null,
+      "icons": null,
+      "inputSchema": {
+        "additionalProperties": false,
+        "properties": {
+          "include_yaml": {
+            "default": true,
+            "type": "boolean"
+          },
+          "pipeline_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "pipeline_id"
+        ],
+        "type": "object"
+      },
+      "name": "export_pipeline",
+      "outputSchema": {
+        "additionalProperties": true,
+        "type": "object"
+      },
+      "title": "Export Pipeline"
+    },
+    "get_pkg_config": {
+      "_meta": {
+        "fastmcp": {
+          "tags": [
+            "jarvis",
+            "pipeline"
+          ]
+        }
+      },
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": null,
+        "readOnlyHint": true,
+        "title": null
+      },
+      "description": "Retrieve the configuration of a specific package in a pipeline.",
+      "execution": null,
+      "icons": null,
+      "inputSchema": {
+        "additionalProperties": false,
+        "properties": {
+          "pipeline_id": {
+            "type": "string"
+          },
+          "pkg_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "pipeline_id",
+          "pkg_id"
+        ],
+        "type": "object"
+      },
+      "name": "get_pkg_config",
+      "outputSchema": {
+        "additionalProperties": true,
+        "type": "object"
+      },
+      "title": "Get Package Config"
+    },
+    "jarvis_add_step": {
+      "_meta": {
+        "fastmcp": {
+          "tags": [
+            "jarvis",
+            "pipeline",
+            "user"
+          ]
+        }
+      },
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": null,
+        "readOnlyHint": false,
+        "title": null
+      },
+      "description": "Add and configure a package-backed step in a JARVIS pipeline. First use jarvis_describe(target='package') for the selected package; config keys must use its canonical setting names exactly, except for aliases explicitly listed there. Explicit null is accepted only when that setting reports nullable=true; omit a setting to use its declared default. Only settings marked agent-visible by the package are accepted here. User-level step configuration is always validated and cannot be bypassed.",
+      "execution": null,
+      "icons": null,
+      "inputSchema": {
+        "additionalProperties": false,
+        "properties": {
+          "config": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Package-owned configuration. Use canonical setting names exactly as returned by jarvis_describe(target='package'); only aliases listed there are also accepted, and settings must not be renamed or placed under invented nesting. JSON documents may be passed directly as objects or lists under their exact setting name; clio-kit serializes them canonically before JARVIS package validation. Explicit null is accepted only for a setting that reports nullable=true. Omit config or an individual setting to use the package-owned default."
+          },
+          "package_name": {
+            "type": "string"
+          },
+          "pipeline_id": {
+            "type": "string"
+          },
+          "step_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          }
+        },
+        "required": [
+          "pipeline_id",
+          "package_name"
+        ],
+        "type": "object"
+      },
+      "name": "jarvis_add_step",
+      "outputSchema": {
+        "additionalProperties": true,
+        "type": "object"
+      },
+      "title": "Add Step"
+    },
+    "jarvis_create_pipeline": {
+      "_meta": {
+        "fastmcp": {
+          "tags": [
+            "jarvis",
+            "pipeline",
+            "user"
+          ]
+        }
+      },
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": null,
+        "readOnlyHint": false,
+        "title": null
+      },
+      "description": "Create a JARVIS pipeline. Optionally pass execution intent such as local, cluster, or hostfile mode; backend details are resolved where the MCP server runs.",
+      "execution": null,
+      "icons": null,
+      "inputSchema": {
+        "additionalProperties": false,
+        "properties": {
+          "execution": {
+            "anyOf": [
+              {
+                "additionalProperties": false,
+                "description": "Validated, backend-neutral execution request for a JARVIS pipeline.",
+                "properties": {
+                  "account": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "cpus_per_task": {
+                    "anyOf": [
+                      {
+                        "exclusiveMinimum": 0,
+                        "type": "integer"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "error": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "exclusive": {
+                    "anyOf": [
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "gpus": {
+                    "anyOf": [
+                      {
+                        "exclusiveMinimum": 0,
+                        "type": "integer"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "gpus_per_node": {
+                    "anyOf": [
+                      {
+                        "exclusiveMinimum": 0,
+                        "type": "integer"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "hostfile": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "hosts": {
+                    "anyOf": [
+                      {
+                        "items": {
+                          "type": "string"
+                        },
+                        "minItems": 1,
+                        "type": "array"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "job_name": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "mode": {
+                    "default": "auto",
+                    "enum": [
+                      "auto",
+                      "local",
+                      "direct",
+                      "cluster",
+                      "scheduler",
+                      "hostfile"
+                    ],
+                    "type": "string"
+                  },
+                  "nodes": {
+                    "anyOf": [
+                      {
+                        "exclusiveMinimum": 0,
+                        "type": "integer"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "output": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "partition": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "qos": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "tasks": {
+                    "anyOf": [
+                      {
+                        "exclusiveMinimum": 0,
+                        "type": "integer"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "tasks_per_node": {
+                    "anyOf": [
+                      {
+                        "exclusiveMinimum": 0,
+                        "type": "integer"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "walltime": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  }
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "pipeline_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "pipeline_id"
+        ],
+        "type": "object"
+      },
+      "name": "jarvis_create_pipeline",
+      "outputSchema": {
+        "additionalProperties": true,
+        "type": "object"
+      },
+      "title": "Create Jarvis Run"
+    },
+    "jarvis_describe": {
+      "_meta": {
+        "fastmcp": {
+          "tags": [
+            "jarvis",
+            "pipeline",
+            "user"
+          ]
+        }
+      },
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": null,
+        "readOnlyHint": true,
+        "title": null
+      },
+      "description": "Describe JARVIS packages, one package, a pipeline, or one pipeline step. For a named application, first use target='package' with its unique short name or fully qualified package name. Use target='package_search' for bounded discovery, then describe the selected canonical name. A package description returns package-owned configuration metadata and, when supported, a versioned deployment contract covering execution profiles, runtime requirements, readiness, and configuration rules. Package settings include only semantic parameters explicitly marked agent-visible. A setting may include a versioned input_binding descriptor for a declared local input that must be staged; callers must not infer file semantics from setting names or prose. Installer, scheduler, and other implementation controls remain owned by their dedicated contracts. target='packages' is an exhaustive legacy inventory with every agent-visible package setting and can be large; use it only when the complete installed catalog is explicitly required.",
+      "execution": null,
+      "icons": null,
+      "inputSchema": {
+        "additionalProperties": false,
+        "properties": {
+          "cursor": {
+            "anyOf": [
+              {
+                "maxLength": 1024,
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Opaque next-page cursor returned by an earlier package_search with the identical query."
+          },
+          "include_yaml": {
+            "default": true,
+            "description": "Include stored pipeline YAML only for target='pipeline'; ignored for package and package discovery targets.",
+            "type": "boolean"
+          },
+          "package_name": {
+            "anyOf": [
+              {
+                "maxLength": 512,
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Case-insensitive unique short name or fully qualified package name for target='package'. Ambiguous short names fail with canonical candidates."
+          },
+          "page_size": {
+            "default": 10,
+            "description": "Maximum summary matches returned by target='package_search'; bounded to 25.",
+            "maximum": 25,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "pipeline_id": {
+            "anyOf": [
+              {
+                "maxLength": 256,
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Pipeline identifier for target='pipeline' or target='step'."
+          },
+          "query": {
+            "anyOf": [
+              {
+                "maxLength": 256,
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Natural-language or package-name query required for target='package_search'."
+          },
+          "step_id": {
+            "anyOf": [
+              {
+                "maxLength": 256,
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Pipeline step identifier for target='step'."
+          },
+          "target": {
+            "description": "Object to describe. Prefer package for a named application and package_search for discovery; packages is exhaustive and unbounded.",
+            "enum": [
+              "packages",
+              "package_search",
+              "package",
+              "pipeline",
+              "step"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "target"
+        ],
+        "type": "object"
+      },
+      "name": "jarvis_describe",
+      "outputSchema": {
+        "properties": {
+          "result": {
+            "oneOf": [
+              {
+                "additionalProperties": false,
+                "description": "Exhaustive legacy package inventory result.",
+                "properties": {
+                  "packages": {
+                    "items": {
+                      "additionalProperties": false,
+                      "description": "Path-free package detail returned after selecting one canonical package.",
+                      "properties": {
+                        "deployment": {
+                          "anyOf": [
+                            {
+                              "additionalProperties": false,
+                              "description": "Versioned deployment and readiness contract supplied by JARVIS.",
+                              "properties": {
+                                "configuration_rules": {
+                                  "items": {
+                                    "additionalProperties": false,
+                                    "description": "Conditional requirement over canonical package configuration settings.",
+                                    "properties": {
+                                      "description": {
+                                        "type": "string"
+                                      },
+                                      "requires": {
+                                        "items": {
+                                          "additionalProperties": false,
+                                          "description": "One package-owned predicate over a canonical configuration setting.",
+                                          "properties": {
+                                            "operator": {
+                                              "enum": [
+                                                "equals",
+                                                "greater_than",
+                                                "is_empty",
+                                                "is_not_empty"
+                                              ],
+                                              "type": "string"
+                                            },
+                                            "parameter": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "string"
+                                                },
+                                                {
+                                                  "type": "integer"
+                                                },
+                                                {
+                                                  "type": "number"
+                                                },
+                                                {
+                                                  "type": "boolean"
+                                                },
+                                                {
+                                                  "type": "null"
+                                                }
+                                              ],
+                                              "default": null
+                                            }
+                                          },
+                                          "required": [
+                                            "parameter",
+                                            "operator"
+                                          ],
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "when": {
+                                        "items": {
+                                          "additionalProperties": false,
+                                          "description": "One package-owned predicate over a canonical configuration setting.",
+                                          "properties": {
+                                            "operator": {
+                                              "enum": [
+                                                "equals",
+                                                "greater_than",
+                                                "is_empty",
+                                                "is_not_empty"
+                                              ],
+                                              "type": "string"
+                                            },
+                                            "parameter": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "string"
+                                                },
+                                                {
+                                                  "type": "integer"
+                                                },
+                                                {
+                                                  "type": "number"
+                                                },
+                                                {
+                                                  "type": "boolean"
+                                                },
+                                                {
+                                                  "type": "null"
+                                                }
+                                              ],
+                                              "default": null
+                                            }
+                                          },
+                                          "required": [
+                                            "parameter",
+                                            "operator"
+                                          ],
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "required": [
+                                      "when",
+                                      "requires",
+                                      "description"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                "execution_profiles": {
+                                  "items": {
+                                    "additionalProperties": false,
+                                    "description": "Package-owned execution kind, applicability, requirements, and readiness.",
+                                    "properties": {
+                                      "description": {
+                                        "anyOf": [
+                                          {
+                                            "type": "string"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ],
+                                        "default": null
+                                      },
+                                      "execution_kind": {
+                                        "enum": [
+                                          "batch",
+                                          "service"
+                                        ],
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "readiness": {
+                                        "additionalProperties": false,
+                                        "description": "Observable condition that makes one execution profile ready.",
+                                        "properties": {
+                                          "capability": {
+                                            "anyOf": [
+                                              {
+                                                "type": "string"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ],
+                                            "default": null
+                                          },
+                                          "condition": {
+                                            "type": "string"
+                                          },
+                                          "mechanism": {
+                                            "enum": [
+                                              "process_exit",
+                                              "progress_event",
+                                              "service_runtime"
+                                            ],
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "mechanism",
+                                          "condition"
+                                        ],
+                                        "type": "object"
+                                      },
+                                      "runtime_requirements": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "when": {
+                                        "items": {
+                                          "additionalProperties": false,
+                                          "description": "One package-owned predicate over a canonical configuration setting.",
+                                          "properties": {
+                                            "operator": {
+                                              "enum": [
+                                                "equals",
+                                                "greater_than",
+                                                "is_empty",
+                                                "is_not_empty"
+                                              ],
+                                              "type": "string"
+                                            },
+                                            "parameter": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "string"
+                                                },
+                                                {
+                                                  "type": "integer"
+                                                },
+                                                {
+                                                  "type": "number"
+                                                },
+                                                {
+                                                  "type": "boolean"
+                                                },
+                                                {
+                                                  "type": "null"
+                                                }
+                                              ],
+                                              "default": null
+                                            }
+                                          },
+                                          "required": [
+                                            "parameter",
+                                            "operator"
+                                          ],
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "required": [
+                                      "name",
+                                      "execution_kind",
+                                      "when",
+                                      "runtime_requirements",
+                                      "readiness"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                "package": {
+                                  "type": "string"
+                                },
+                                "runtime_requirements": {
+                                  "items": {
+                                    "additionalProperties": false,
+                                    "description": "Runtime capabilities and provider resolutions owned by a package.",
+                                    "properties": {
+                                      "available_capabilities": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "description": {
+                                        "type": "string"
+                                      },
+                                      "id": {
+                                        "type": "string"
+                                      },
+                                      "provider_resolutions": {
+                                        "items": {
+                                          "additionalProperties": false,
+                                          "description": "One provider and query capable of resolving a runtime requirement.",
+                                          "properties": {
+                                            "provider": {
+                                              "type": "string"
+                                            },
+                                            "query": {
+                                              "additionalProperties": false,
+                                              "description": "Provider-neutral query that can resolve one runtime requirement.",
+                                              "properties": {
+                                                "kind": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "kind",
+                                                "value"
+                                              ],
+                                              "type": "object"
+                                            }
+                                          },
+                                          "required": [
+                                            "provider",
+                                            "query"
+                                          ],
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "required_capabilities": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "status": {
+                                        "additionalProperties": false,
+                                        "description": "Package observation of whether a runtime requirement can be used.",
+                                        "properties": {
+                                          "reason_code": {
+                                            "type": "string"
+                                          },
+                                          "state": {
+                                            "enum": [
+                                              "ready",
+                                              "unavailable",
+                                              "unknown"
+                                            ],
+                                            "type": "string"
+                                          },
+                                          "usable": {
+                                            "anyOf": [
+                                              {
+                                                "type": "boolean"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "required": [
+                                          "state",
+                                          "usable",
+                                          "reason_code"
+                                        ],
+                                        "type": "object"
+                                      }
+                                    },
+                                    "required": [
+                                      "id",
+                                      "description",
+                                      "required_capabilities",
+                                      "available_capabilities",
+                                      "status",
+                                      "provider_resolutions"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                "schema_version": {
+                                  "const": "jarvis.package-deployment.v1",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "schema_version",
+                                "package",
+                                "execution_profiles",
+                                "runtime_requirements",
+                                "configuration_rules"
+                              ],
+                              "type": "object"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "description": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "schema_version": {
+                          "const": "jarvis.package-description.v1",
+                          "type": "string"
+                        },
+                        "settings": {
+                          "anyOf": [
+                            {
+                              "items": {
+                                "additionalProperties": false,
+                                "description": "One package parser setting with truthful default and null semantics.",
+                                "properties": {
+                                  "aliases": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "choices": {
+                                    "items": {},
+                                    "type": "array"
+                                  },
+                                  "default": {},
+                                  "description": {
+                                    "type": "string"
+                                  },
+                                  "input_binding": {
+                                    "additionalProperties": false,
+                                    "description": "Declared client-local input that must be staged before package use.",
+                                    "properties": {
+                                      "kind": {
+                                        "const": "local_file",
+                                        "type": "string"
+                                      },
+                                      "schema_version": {
+                                        "const": "jarvis.configuration-input-binding.v1",
+                                        "type": "string"
+                                      },
+                                      "structure": {
+                                        "const": "regular_file",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "schema_version",
+                                      "kind",
+                                      "structure"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "nullable": {
+                                    "type": "boolean"
+                                  },
+                                  "required": {
+                                    "type": "boolean"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name",
+                                  "required",
+                                  "nullable"
+                                ],
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "short_name": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "schema_version",
+                        "name",
+                        "short_name",
+                        "description",
+                        "deployment"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "target": {
+                    "const": "packages",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "target",
+                  "packages"
+                ],
+                "type": "object"
+              },
+              {
+                "additionalProperties": false,
+                "description": "Bounded package search page.",
+                "properties": {
+                  "inventory_revision": {
+                    "type": "string"
+                  },
+                  "next_cursor": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "packages": {
+                    "items": {
+                      "additionalProperties": false,
+                      "description": "Bounded package identity returned during search.",
+                      "properties": {
+                        "description": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "repository": {
+                          "type": "string"
+                        },
+                        "short_name": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name",
+                        "short_name",
+                        "repository"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "query": {
+                    "type": "string"
+                  },
+                  "returned_count": {
+                    "type": "integer"
+                  },
+                  "schema_version": {
+                    "const": "jarvis.package-search.v1",
+                    "type": "string"
+                  },
+                  "target": {
+                    "const": "package_search",
+                    "type": "string"
+                  },
+                  "total_matches": {
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "schema_version",
+                  "target",
+                  "query",
+                  "inventory_revision",
+                  "packages",
+                  "total_matches",
+                  "returned_count",
+                  "next_cursor"
+                ],
+                "type": "object"
+              },
+              {
+                "additionalProperties": false,
+                "description": "Exact package description result.",
+                "properties": {
+                  "package": {
+                    "additionalProperties": false,
+                    "description": "Path-free package detail returned after selecting one canonical package.",
+                    "properties": {
+                      "deployment": {
+                        "anyOf": [
+                          {
+                            "additionalProperties": false,
+                            "description": "Versioned deployment and readiness contract supplied by JARVIS.",
+                            "properties": {
+                              "configuration_rules": {
+                                "items": {
+                                  "additionalProperties": false,
+                                  "description": "Conditional requirement over canonical package configuration settings.",
+                                  "properties": {
+                                    "description": {
+                                      "type": "string"
+                                    },
+                                    "requires": {
+                                      "items": {
+                                        "additionalProperties": false,
+                                        "description": "One package-owned predicate over a canonical configuration setting.",
+                                        "properties": {
+                                          "operator": {
+                                            "enum": [
+                                              "equals",
+                                              "greater_than",
+                                              "is_empty",
+                                              "is_not_empty"
+                                            ],
+                                            "type": "string"
+                                          },
+                                          "parameter": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "anyOf": [
+                                              {
+                                                "type": "string"
+                                              },
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "number"
+                                              },
+                                              {
+                                                "type": "boolean"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ],
+                                            "default": null
+                                          }
+                                        },
+                                        "required": [
+                                          "parameter",
+                                          "operator"
+                                        ],
+                                        "type": "object"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "when": {
+                                      "items": {
+                                        "additionalProperties": false,
+                                        "description": "One package-owned predicate over a canonical configuration setting.",
+                                        "properties": {
+                                          "operator": {
+                                            "enum": [
+                                              "equals",
+                                              "greater_than",
+                                              "is_empty",
+                                              "is_not_empty"
+                                            ],
+                                            "type": "string"
+                                          },
+                                          "parameter": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "anyOf": [
+                                              {
+                                                "type": "string"
+                                              },
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "number"
+                                              },
+                                              {
+                                                "type": "boolean"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ],
+                                            "default": null
+                                          }
+                                        },
+                                        "required": [
+                                          "parameter",
+                                          "operator"
+                                        ],
+                                        "type": "object"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "required": [
+                                    "when",
+                                    "requires",
+                                    "description"
+                                  ],
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "execution_profiles": {
+                                "items": {
+                                  "additionalProperties": false,
+                                  "description": "Package-owned execution kind, applicability, requirements, and readiness.",
+                                  "properties": {
+                                    "description": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ],
+                                      "default": null
+                                    },
+                                    "execution_kind": {
+                                      "enum": [
+                                        "batch",
+                                        "service"
+                                      ],
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "readiness": {
+                                      "additionalProperties": false,
+                                      "description": "Observable condition that makes one execution profile ready.",
+                                      "properties": {
+                                        "capability": {
+                                          "anyOf": [
+                                            {
+                                              "type": "string"
+                                            },
+                                            {
+                                              "type": "null"
+                                            }
+                                          ],
+                                          "default": null
+                                        },
+                                        "condition": {
+                                          "type": "string"
+                                        },
+                                        "mechanism": {
+                                          "enum": [
+                                            "process_exit",
+                                            "progress_event",
+                                            "service_runtime"
+                                          ],
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "mechanism",
+                                        "condition"
+                                      ],
+                                      "type": "object"
+                                    },
+                                    "runtime_requirements": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "when": {
+                                      "items": {
+                                        "additionalProperties": false,
+                                        "description": "One package-owned predicate over a canonical configuration setting.",
+                                        "properties": {
+                                          "operator": {
+                                            "enum": [
+                                              "equals",
+                                              "greater_than",
+                                              "is_empty",
+                                              "is_not_empty"
+                                            ],
+                                            "type": "string"
+                                          },
+                                          "parameter": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "anyOf": [
+                                              {
+                                                "type": "string"
+                                              },
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "number"
+                                              },
+                                              {
+                                                "type": "boolean"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ],
+                                            "default": null
+                                          }
+                                        },
+                                        "required": [
+                                          "parameter",
+                                          "operator"
+                                        ],
+                                        "type": "object"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "required": [
+                                    "name",
+                                    "execution_kind",
+                                    "when",
+                                    "runtime_requirements",
+                                    "readiness"
+                                  ],
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "package": {
+                                "type": "string"
+                              },
+                              "runtime_requirements": {
+                                "items": {
+                                  "additionalProperties": false,
+                                  "description": "Runtime capabilities and provider resolutions owned by a package.",
+                                  "properties": {
+                                    "available_capabilities": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "description": {
+                                      "type": "string"
+                                    },
+                                    "id": {
+                                      "type": "string"
+                                    },
+                                    "provider_resolutions": {
+                                      "items": {
+                                        "additionalProperties": false,
+                                        "description": "One provider and query capable of resolving a runtime requirement.",
+                                        "properties": {
+                                          "provider": {
+                                            "type": "string"
+                                          },
+                                          "query": {
+                                            "additionalProperties": false,
+                                            "description": "Provider-neutral query that can resolve one runtime requirement.",
+                                            "properties": {
+                                              "kind": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "kind",
+                                              "value"
+                                            ],
+                                            "type": "object"
+                                          }
+                                        },
+                                        "required": [
+                                          "provider",
+                                          "query"
+                                        ],
+                                        "type": "object"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "required_capabilities": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "status": {
+                                      "additionalProperties": false,
+                                      "description": "Package observation of whether a runtime requirement can be used.",
+                                      "properties": {
+                                        "reason_code": {
+                                          "type": "string"
+                                        },
+                                        "state": {
+                                          "enum": [
+                                            "ready",
+                                            "unavailable",
+                                            "unknown"
+                                          ],
+                                          "type": "string"
+                                        },
+                                        "usable": {
+                                          "anyOf": [
+                                            {
+                                              "type": "boolean"
+                                            },
+                                            {
+                                              "type": "null"
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "required": [
+                                        "state",
+                                        "usable",
+                                        "reason_code"
+                                      ],
+                                      "type": "object"
+                                    }
+                                  },
+                                  "required": [
+                                    "id",
+                                    "description",
+                                    "required_capabilities",
+                                    "available_capabilities",
+                                    "status",
+                                    "provider_resolutions"
+                                  ],
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "schema_version": {
+                                "const": "jarvis.package-deployment.v1",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "schema_version",
+                              "package",
+                              "execution_profiles",
+                              "runtime_requirements",
+                              "configuration_rules"
+                            ],
+                            "type": "object"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "description": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "schema_version": {
+                        "const": "jarvis.package-description.v1",
+                        "type": "string"
+                      },
+                      "settings": {
+                        "anyOf": [
+                          {
+                            "items": {
+                              "additionalProperties": false,
+                              "description": "One package parser setting with truthful default and null semantics.",
+                              "properties": {
+                                "aliases": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "choices": {
+                                  "items": {},
+                                  "type": "array"
+                                },
+                                "default": {},
+                                "description": {
+                                  "type": "string"
+                                },
+                                "input_binding": {
+                                  "additionalProperties": false,
+                                  "description": "Declared client-local input that must be staged before package use.",
+                                  "properties": {
+                                    "kind": {
+                                      "const": "local_file",
+                                      "type": "string"
+                                    },
+                                    "schema_version": {
+                                      "const": "jarvis.configuration-input-binding.v1",
+                                      "type": "string"
+                                    },
+                                    "structure": {
+                                      "const": "regular_file",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "schema_version",
+                                    "kind",
+                                    "structure"
+                                  ],
+                                  "type": "object"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "nullable": {
+                                  "type": "boolean"
+                                },
+                                "required": {
+                                  "type": "boolean"
+                                },
+                                "type": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name",
+                                "required",
+                                "nullable"
+                              ],
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ],
+                        "default": null
+                      },
+                      "short_name": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "schema_version",
+                      "name",
+                      "short_name",
+                      "description",
+                      "deployment"
+                    ],
+                    "type": "object"
+                  },
+                  "target": {
+                    "const": "package",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "target",
+                  "package"
+                ],
+                "type": "object"
+              },
+              {
+                "additionalProperties": false,
+                "description": "Stored pipeline snapshot result.",
+                "properties": {
+                  "pipeline": {
+                    "additionalProperties": true,
+                    "type": "object"
+                  },
+                  "target": {
+                    "const": "pipeline",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "target",
+                  "pipeline"
+                ],
+                "type": "object"
+              },
+              {
+                "additionalProperties": false,
+                "description": "Stored pipeline step and package configuration result.",
+                "properties": {
+                  "config": {
+                    "additionalProperties": true,
+                    "type": "object"
+                  },
+                  "step": {
+                    "additionalProperties": true,
+                    "type": "object"
+                  },
+                  "target": {
+                    "const": "step",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "target",
+                  "step",
+                  "config"
+                ],
+                "type": "object"
+              }
+            ]
+          }
+        },
+        "required": [
+          "result"
+        ],
+        "type": "object",
+        "x-fastmcp-wrap-result": true
+      },
+      "title": "Describe"
+    },
+    "jarvis_edit_step": {
+      "_meta": {
+        "fastmcp": {
+          "tags": [
+            "jarvis",
+            "pipeline",
+            "user"
+          ]
+        }
+      },
+      "annotations": {
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": null,
+        "readOnlyHint": false,
+        "title": null
+      },
+      "description": "Edit or remove a step in a JARVIS pipeline. Use operation='edit' with config, or operation='remove' without config.",
+      "execution": null,
+      "icons": null,
+      "inputSchema": {
+        "additionalProperties": false,
+        "properties": {
+          "config": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "operation": {
+            "default": "edit",
+            "enum": [
+              "edit",
+              "remove"
+            ],
+            "type": "string"
+          },
+          "pipeline_id": {
+            "type": "string"
+          },
+          "step_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "pipeline_id",
+          "step_id"
+        ],
+        "type": "object"
+      },
+      "name": "jarvis_edit_step",
+      "outputSchema": {
+        "additionalProperties": true,
+        "type": "object"
+      },
+      "title": "Edit Step"
+    },
+    "jarvis_get_execution": {
+      "_meta": {
+        "fastmcp": {
+          "tags": [
+            "execution",
+            "jarvis",
+            "pipeline",
+            "user"
+          ]
+        }
+      },
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": null,
+        "readOnlyHint": true,
+        "title": null
+      },
+      "description": "Query one JARVIS execution handle, durable lifecycle record, and runtime metadata. Progress is included by default and can be omitted. Set include_service_runtimes=true to include execution-owned network services; authenticated services expose only a non-secret bearer token SHA-256 fingerprint. Set artifacts to {} or filters to include one bounded artifact page; omit artifacts to avoid querying the artifact manifest.",
+      "execution": null,
+      "icons": null,
+      "inputSchema": {
+        "additionalProperties": false,
+        "properties": {
+          "artifacts": {
+            "anyOf": [
+              {
+                "additionalProperties": false,
+                "description": "Optional filters for one bounded page of execution artifacts.",
+                "properties": {
+                  "artifact_id": {
+                    "anyOf": [
+                      {
+                        "maxLength": 90,
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "Exact opaque JARVIS artifact ID filter."
+                  },
+                  "cursor": {
+                    "anyOf": [
+                      {
+                        "maxLength": 1024,
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "Opaque next-page cursor."
+                  },
+                  "package_id": {
+                    "anyOf": [
+                      {
+                        "maxLength": 256,
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "Exact JARVIS package alias filter."
+                  },
+                  "page_size": {
+                    "default": 50,
+                    "description": "Maximum artifacts to return in this page.",
+                    "maximum": 100,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "role": {
+                    "anyOf": [
+                      {
+                        "enum": [
+                          "intermediate",
+                          "output",
+                          "log",
+                          "checkpoint",
+                          "provenance",
+                          "validation"
+                        ],
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "state": {
+                    "anyOf": [
+                      {
+                        "enum": [
+                          "producing",
+                          "available",
+                          "finalized",
+                          "incomplete",
+                          "failed"
+                        ],
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  }
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "execution_id": {
+            "type": "string"
+          },
+          "include_progress": {
+            "default": true,
+            "type": "boolean"
+          },
+          "include_service_runtimes": {
+            "default": false,
+            "type": "boolean"
+          },
+          "pipeline_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "pipeline_id",
+          "execution_id"
+        ],
+        "type": "object"
+      },
+      "name": "jarvis_get_execution",
+      "outputSchema": {
+        "additionalProperties": false,
+        "description": "Frozen top-level result envelope for a selectable execution query.",
+        "properties": {
+          "artifact_page": {
+            "anyOf": [
+              {
+                "additionalProperties": false,
+                "description": "Bounded artifact page nested in a unified execution query.",
+                "properties": {
+                  "artifacts": {
+                    "items": {
+                      "additionalProperties": false,
+                      "description": "Current JARVIS-owned lifecycle observation for one generated artifact.",
+                      "properties": {
+                        "artifact_id": {
+                          "type": "string"
+                        },
+                        "checksum": {
+                          "type": "string"
+                        },
+                        "execution_id": {
+                          "type": "string"
+                        },
+                        "format": {
+                          "type": "string"
+                        },
+                        "kind": {
+                          "type": "string"
+                        },
+                        "location": {
+                          "additionalProperties": false,
+                          "description": "Transport-neutral location in a JARVIS artifact manifest.",
+                          "properties": {
+                            "kind": {
+                              "enum": [
+                                "execution_path",
+                                "cluster_path",
+                                "external_uri"
+                              ],
+                              "type": "string"
+                            },
+                            "value": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "value"
+                          ],
+                          "type": "object"
+                        },
+                        "logical_name": {
+                          "type": "string"
+                        },
+                        "media_type": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "metadata": {
+                          "additionalProperties": true,
+                          "type": "object"
+                        },
+                        "observed_at_epoch": {
+                          "type": "number"
+                        },
+                        "ownership": {
+                          "enum": [
+                            "execution",
+                            "external",
+                            "shared"
+                          ],
+                          "type": "string"
+                        },
+                        "package_id": {
+                          "type": "string"
+                        },
+                        "package_name": {
+                          "type": "string"
+                        },
+                        "revision": {
+                          "type": "integer"
+                        },
+                        "role": {
+                          "enum": [
+                            "intermediate",
+                            "output",
+                            "log",
+                            "checkpoint",
+                            "provenance",
+                            "validation"
+                          ],
+                          "type": "string"
+                        },
+                        "schema_version": {
+                          "const": "jarvis.artifact.v1",
+                          "type": "string"
+                        },
+                        "sequence": {
+                          "type": "integer"
+                        },
+                        "size_bytes": {
+                          "type": "integer"
+                        },
+                        "state": {
+                          "enum": [
+                            "producing",
+                            "available",
+                            "finalized",
+                            "incomplete",
+                            "failed"
+                          ],
+                          "type": "string"
+                        },
+                        "structure": {
+                          "enum": [
+                            "file",
+                            "directory",
+                            "collection",
+                            "stream"
+                          ],
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "schema_version",
+                        "package_name",
+                        "package_id",
+                        "execution_id",
+                        "artifact_id",
+                        "logical_name",
+                        "kind",
+                        "role",
+                        "structure",
+                        "ownership",
+                        "state",
+                        "revision",
+                        "sequence",
+                        "observed_at_epoch",
+                        "metadata"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "execution_id": {
+                    "type": "string"
+                  },
+                  "execution_state": {
+                    "enum": [
+                      "preparing",
+                      "scripted",
+                      "submitting",
+                      "submitted",
+                      "running",
+                      "completed",
+                      "failed",
+                      "canceled",
+                      "unknown"
+                    ],
+                    "type": "string"
+                  },
+                  "matching_artifact_count": {
+                    "type": "integer"
+                  },
+                  "next_cursor": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "pipeline_id": {
+                    "type": "string"
+                  },
+                  "producer_schema_version": {
+                    "const": "jarvis.execution.artifacts.v1",
+                    "type": "string"
+                  },
+                  "returned_artifact_count": {
+                    "type": "integer"
+                  },
+                  "terminal": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "producer_schema_version",
+                  "pipeline_id",
+                  "execution_id",
+                  "execution_state",
+                  "terminal",
+                  "artifacts",
+                  "matching_artifact_count",
+                  "returned_artifact_count",
+                  "next_cursor"
+                ],
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "execution_handle": {
+            "additionalProperties": false,
+            "description": "Stable JARVIS-CD execution-handle document.",
+            "properties": {
+              "cluster": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "execution_id": {
+                "type": "string"
+              },
+              "mode": {
+                "enum": [
+                  "direct",
+                  "scheduler"
+                ],
+                "type": "string"
+              },
+              "pipeline_id": {
+                "type": "string"
+              },
+              "scheduler_native_id": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "scheduler_provider": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "schema_version": {
+                "const": "jarvis.execution.handle.v1",
+                "type": "string"
+              }
+            },
+            "required": [
+              "schema_version",
+              "execution_id",
+              "pipeline_id",
+              "mode",
+              "scheduler_provider",
+              "scheduler_native_id",
+              "cluster"
+            ],
+            "type": "object"
+          },
+          "execution_id": {
+            "type": "string"
+          },
+          "execution_record": {
+            "additionalProperties": false,
+            "description": "Stable JARVIS-CD durable execution-record document.",
+            "properties": {
+              "cluster": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "created_at": {
+                "type": "string"
+              },
+              "error": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "execution_id": {
+                "type": "string"
+              },
+              "metadata": {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              "mode": {
+                "enum": [
+                  "direct",
+                  "scheduler"
+                ],
+                "type": "string"
+              },
+              "pipeline_id": {
+                "type": "string"
+              },
+              "pipeline_name": {
+                "type": "string"
+              },
+              "return_code": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "scheduler_native_id": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "scheduler_provider": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "schema_version": {
+                "const": "jarvis.execution.record.v1",
+                "type": "string"
+              },
+              "state": {
+                "enum": [
+                  "preparing",
+                  "scripted",
+                  "submitting",
+                  "submitted",
+                  "running",
+                  "completed",
+                  "failed",
+                  "canceled",
+                  "unknown"
+                ],
+                "type": "string"
+              },
+              "submitted": {
+                "type": "boolean"
+              },
+              "terminal": {
+                "type": "boolean"
+              },
+              "updated_at": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "schema_version",
+              "execution_id",
+              "pipeline_id",
+              "pipeline_name",
+              "mode",
+              "scheduler_provider",
+              "scheduler_native_id",
+              "cluster",
+              "state",
+              "submitted",
+              "terminal",
+              "created_at",
+              "updated_at",
+              "return_code",
+              "error",
+              "metadata"
+            ],
+            "type": "object"
+          },
+          "pipeline_id": {
+            "type": "string"
+          },
+          "progress": {
+            "anyOf": [
+              {
+                "additionalProperties": false,
+                "description": "Stable aggregate returned by JARVIS-CD's execution progress API.",
+                "properties": {
+                  "execution_id": {
+                    "maxLength": 256,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "execution_state": {
+                    "enum": [
+                      "preparing",
+                      "scripted",
+                      "submitting",
+                      "submitted",
+                      "running",
+                      "completed",
+                      "failed",
+                      "canceled",
+                      "unknown"
+                    ],
+                    "type": "string"
+                  },
+                  "packages": {
+                    "items": {
+                      "additionalProperties": false,
+                      "description": "Latest stable progress observation for one package alias.",
+                      "properties": {
+                        "event_count": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "latest": {
+                          "anyOf": [
+                            {
+                              "additionalProperties": false,
+                              "description": "One closed, JARVIS-owned package progress observation.",
+                              "properties": {
+                                "current": {
+                                  "anyOf": [
+                                    {
+                                      "minimum": 0,
+                                      "type": "number"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ],
+                                  "default": null
+                                },
+                                "determinate": {
+                                  "type": "boolean"
+                                },
+                                "execution_id": {
+                                  "maxLength": 256,
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "label": {
+                                  "maxLength": 256,
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "message": {
+                                  "anyOf": [
+                                    {
+                                      "maxLength": 4096,
+                                      "minLength": 1,
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ],
+                                  "default": null
+                                },
+                                "metadata": {
+                                  "additionalProperties": true,
+                                  "type": "object"
+                                },
+                                "observed_at_epoch": {
+                                  "minimum": 0,
+                                  "type": "number"
+                                },
+                                "package_id": {
+                                  "maxLength": 256,
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "package_name": {
+                                  "maxLength": 256,
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "schema_version": {
+                                  "const": "jarvis.progress.v1",
+                                  "type": "string"
+                                },
+                                "sequence": {
+                                  "minimum": 0,
+                                  "type": "integer"
+                                },
+                                "state": {
+                                  "enum": [
+                                    "pending",
+                                    "starting",
+                                    "running",
+                                    "ready",
+                                    "completed",
+                                    "failed",
+                                    "canceled"
+                                  ],
+                                  "type": "string"
+                                },
+                                "total": {
+                                  "anyOf": [
+                                    {
+                                      "exclusiveMinimum": 0,
+                                      "type": "number"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ],
+                                  "default": null
+                                },
+                                "unit": {
+                                  "anyOf": [
+                                    {
+                                      "maxLength": 256,
+                                      "minLength": 1,
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ],
+                                  "default": null
+                                }
+                              },
+                              "required": [
+                                "schema_version",
+                                "package_name",
+                                "package_id",
+                                "execution_id",
+                                "label",
+                                "state",
+                                "sequence",
+                                "observed_at_epoch",
+                                "determinate",
+                                "metadata"
+                              ],
+                              "type": "object"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "package_id": {
+                          "maxLength": 256,
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "package_name": {
+                          "maxLength": 256,
+                          "minLength": 1,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "package_id",
+                        "package_name",
+                        "event_count",
+                        "latest"
+                      ],
+                      "type": "object"
+                    },
+                    "maxItems": 4096,
+                    "type": "array"
+                  },
+                  "pipeline_id": {
+                    "maxLength": 256,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "schema_version": {
+                    "const": "jarvis.execution.progress.v1",
+                    "type": "string"
+                  },
+                  "terminal": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "schema_version",
+                  "execution_id",
+                  "pipeline_id",
+                  "execution_state",
+                  "terminal",
+                  "packages"
+                ],
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "runtime_metadata": {
+            "additionalProperties": true,
+            "type": "object"
+          },
+          "schema_version": {
+            "const": "clio-kit.jarvis-execution.v2",
+            "type": "string"
+          },
+          "service_runtimes": {
+            "anyOf": [
+              {
+                "additionalProperties": false,
+                "description": "Execution-bound current service runtimes returned by JARVIS.",
+                "properties": {
+                  "execution_id": {
+                    "maxLength": 256,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "execution_state": {
+                    "enum": [
+                      "preparing",
+                      "scripted",
+                      "submitting",
+                      "submitted",
+                      "running",
+                      "completed",
+                      "failed",
+                      "canceled",
+                      "unknown"
+                    ],
+                    "type": "string"
+                  },
+                  "pipeline_id": {
+                    "maxLength": 256,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "schema_version": {
+                    "const": "jarvis.execution.service-runtimes.v1",
+                    "type": "string"
+                  },
+                  "service_runtimes": {
+                    "items": {
+                      "oneOf": [
+                        {
+                          "additionalProperties": false,
+                          "description": "Released unauthenticated service-runtime v1 document.",
+                          "properties": {
+                            "command_path": {
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "dataset_descriptor": {
+                              "additionalProperties": false,
+                              "description": "Intrinsic, recipe-free dataset identity owned by JARVIS.",
+                              "properties": {
+                                "arrays": {
+                                  "items": {
+                                    "additionalProperties": false,
+                                    "description": "One intrinsic array exposed by a JARVIS-owned service.",
+                                    "properties": {
+                                      "association": {
+                                        "enum": [
+                                          "point",
+                                          "cell",
+                                          "field"
+                                        ],
+                                        "type": "string"
+                                      },
+                                      "components": {
+                                        "maximum": 64,
+                                        "minimum": 1,
+                                        "type": "integer"
+                                      },
+                                      "name": {
+                                        "maxLength": 512,
+                                        "minLength": 1,
+                                        "type": "string"
+                                      },
+                                      "units": {
+                                        "anyOf": [
+                                          {
+                                            "maxLength": 256,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ],
+                                        "default": null
+                                      }
+                                    },
+                                    "required": [
+                                      "name",
+                                      "association",
+                                      "components"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "maxItems": 256,
+                                  "type": "array"
+                                },
+                                "bounds": {
+                                  "anyOf": [
+                                    {
+                                      "items": {
+                                        "type": "number"
+                                      },
+                                      "maxItems": 6,
+                                      "minItems": 6,
+                                      "type": "array"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ],
+                                  "default": null
+                                },
+                                "dataset_id": {
+                                  "maxLength": 256,
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "fingerprint": {
+                                  "additionalProperties": false,
+                                  "description": "Canonical identity digest for one bounded dataset descriptor.",
+                                  "properties": {
+                                    "algorithm": {
+                                      "const": "sha256",
+                                      "type": "string"
+                                    },
+                                    "digest": {
+                                      "pattern": "^[0-9a-f]{64}$",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "algorithm",
+                                    "digest"
+                                  ],
+                                  "type": "object"
+                                },
+                                "format": {
+                                  "maxLength": 256,
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "kind": {
+                                  "maxLength": 256,
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "members": {
+                                  "items": {
+                                    "additionalProperties": false,
+                                    "description": "One ordered member in a JARVIS service dataset descriptor.",
+                                    "properties": {
+                                      "index": {
+                                        "minimum": 0,
+                                        "type": "integer"
+                                      },
+                                      "location": {
+                                        "maxLength": 4096,
+                                        "minLength": 1,
+                                        "type": "string"
+                                      },
+                                      "timestep": {
+                                        "anyOf": [
+                                          {
+                                            "type": "number"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ],
+                                        "default": null
+                                      }
+                                    },
+                                    "required": [
+                                      "index",
+                                      "location"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "maxItems": 512,
+                                  "minItems": 1,
+                                  "type": "array"
+                                },
+                                "schema_version": {
+                                  "const": "jarvis.dataset-descriptor.v1",
+                                  "type": "string"
+                                },
+                                "source_artifact": {
+                                  "anyOf": [
+                                    {
+                                      "additionalProperties": false,
+                                      "description": "Optional content identity of a JARVIS-generated source artifact.",
+                                      "properties": {
+                                        "artifact_id": {
+                                          "pattern": "^art_[A-Za-z0-9_-]{22,86}$",
+                                          "type": "string"
+                                        },
+                                        "sha256": {
+                                          "pattern": "^[0-9a-f]{64}$",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "artifact_id",
+                                        "sha256"
+                                      ],
+                                      "type": "object"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ]
+                                }
+                              },
+                              "required": [
+                                "schema_version",
+                                "dataset_id",
+                                "kind",
+                                "format",
+                                "members",
+                                "arrays",
+                                "fingerprint",
+                                "source_artifact"
+                              ],
+                              "type": "object"
+                            },
+                            "delivery_mode": {
+                              "const": "push",
+                              "type": "string"
+                            },
+                            "events_path": {
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "execution_id": {
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "health_path": {
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "host": {
+                              "maxLength": 255,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "lifecycle": {
+                              "enum": [
+                                "starting",
+                                "ready",
+                                "degraded",
+                                "stopping",
+                                "stopped",
+                                "failed"
+                              ],
+                              "type": "string"
+                            },
+                            "live_data_path": {
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "message": {
+                              "anyOf": [
+                                {
+                                  "maxLength": 4096,
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ],
+                              "default": null
+                            },
+                            "observed_at_epoch": {
+                              "minimum": 0,
+                              "type": "number"
+                            },
+                            "package_id": {
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "package_name": {
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "port": {
+                              "maximum": 65535,
+                              "minimum": 1,
+                              "type": "integer"
+                            },
+                            "protocol": {
+                              "enum": [
+                                "http",
+                                "https"
+                              ],
+                              "type": "string"
+                            },
+                            "revision": {
+                              "minimum": 1,
+                              "type": "integer"
+                            },
+                            "schema_version": {
+                              "const": "jarvis.service-runtime.v1",
+                              "type": "string"
+                            },
+                            "service_instance_id": {
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "state_path": {
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "execution_id",
+                            "package_name",
+                            "package_id",
+                            "service_instance_id",
+                            "revision",
+                            "lifecycle",
+                            "host",
+                            "port",
+                            "protocol",
+                            "health_path",
+                            "live_data_path",
+                            "events_path",
+                            "state_path",
+                            "command_path",
+                            "delivery_mode",
+                            "dataset_descriptor",
+                            "observed_at_epoch",
+                            "schema_version"
+                          ],
+                          "type": "object"
+                        },
+                        {
+                          "additionalProperties": false,
+                          "description": "Service-runtime v2 document with a non-secret capability fingerprint.",
+                          "properties": {
+                            "authorization": {
+                              "additionalProperties": false,
+                              "description": "Non-secret fingerprint for an execution-owned runtime capability.",
+                              "properties": {
+                                "scheme": {
+                                  "const": "bearer",
+                                  "type": "string"
+                                },
+                                "token_sha256": {
+                                  "maxLength": 64,
+                                  "minLength": 64,
+                                  "pattern": "^[0-9a-f]{64}$",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "scheme",
+                                "token_sha256"
+                              ],
+                              "type": "object"
+                            },
+                            "command_path": {
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "dataset_descriptor": {
+                              "additionalProperties": false,
+                              "description": "Intrinsic, recipe-free dataset identity owned by JARVIS.",
+                              "properties": {
+                                "arrays": {
+                                  "items": {
+                                    "additionalProperties": false,
+                                    "description": "One intrinsic array exposed by a JARVIS-owned service.",
+                                    "properties": {
+                                      "association": {
+                                        "enum": [
+                                          "point",
+                                          "cell",
+                                          "field"
+                                        ],
+                                        "type": "string"
+                                      },
+                                      "components": {
+                                        "maximum": 64,
+                                        "minimum": 1,
+                                        "type": "integer"
+                                      },
+                                      "name": {
+                                        "maxLength": 512,
+                                        "minLength": 1,
+                                        "type": "string"
+                                      },
+                                      "units": {
+                                        "anyOf": [
+                                          {
+                                            "maxLength": 256,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ],
+                                        "default": null
+                                      }
+                                    },
+                                    "required": [
+                                      "name",
+                                      "association",
+                                      "components"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "maxItems": 256,
+                                  "type": "array"
+                                },
+                                "bounds": {
+                                  "anyOf": [
+                                    {
+                                      "items": {
+                                        "type": "number"
+                                      },
+                                      "maxItems": 6,
+                                      "minItems": 6,
+                                      "type": "array"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ],
+                                  "default": null
+                                },
+                                "dataset_id": {
+                                  "maxLength": 256,
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "fingerprint": {
+                                  "additionalProperties": false,
+                                  "description": "Canonical identity digest for one bounded dataset descriptor.",
+                                  "properties": {
+                                    "algorithm": {
+                                      "const": "sha256",
+                                      "type": "string"
+                                    },
+                                    "digest": {
+                                      "pattern": "^[0-9a-f]{64}$",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "algorithm",
+                                    "digest"
+                                  ],
+                                  "type": "object"
+                                },
+                                "format": {
+                                  "maxLength": 256,
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "kind": {
+                                  "maxLength": 256,
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "members": {
+                                  "items": {
+                                    "additionalProperties": false,
+                                    "description": "One ordered member in a JARVIS service dataset descriptor.",
+                                    "properties": {
+                                      "index": {
+                                        "minimum": 0,
+                                        "type": "integer"
+                                      },
+                                      "location": {
+                                        "maxLength": 4096,
+                                        "minLength": 1,
+                                        "type": "string"
+                                      },
+                                      "timestep": {
+                                        "anyOf": [
+                                          {
+                                            "type": "number"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ],
+                                        "default": null
+                                      }
+                                    },
+                                    "required": [
+                                      "index",
+                                      "location"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "maxItems": 512,
+                                  "minItems": 1,
+                                  "type": "array"
+                                },
+                                "schema_version": {
+                                  "const": "jarvis.dataset-descriptor.v1",
+                                  "type": "string"
+                                },
+                                "source_artifact": {
+                                  "anyOf": [
+                                    {
+                                      "additionalProperties": false,
+                                      "description": "Optional content identity of a JARVIS-generated source artifact.",
+                                      "properties": {
+                                        "artifact_id": {
+                                          "pattern": "^art_[A-Za-z0-9_-]{22,86}$",
+                                          "type": "string"
+                                        },
+                                        "sha256": {
+                                          "pattern": "^[0-9a-f]{64}$",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "artifact_id",
+                                        "sha256"
+                                      ],
+                                      "type": "object"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ]
+                                }
+                              },
+                              "required": [
+                                "schema_version",
+                                "dataset_id",
+                                "kind",
+                                "format",
+                                "members",
+                                "arrays",
+                                "fingerprint",
+                                "source_artifact"
+                              ],
+                              "type": "object"
+                            },
+                            "delivery_mode": {
+                              "const": "push",
+                              "type": "string"
+                            },
+                            "events_path": {
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "execution_id": {
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "health_path": {
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "host": {
+                              "maxLength": 255,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "lifecycle": {
+                              "enum": [
+                                "starting",
+                                "ready",
+                                "degraded",
+                                "stopping",
+                                "stopped",
+                                "failed"
+                              ],
+                              "type": "string"
+                            },
+                            "live_data_path": {
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "message": {
+                              "anyOf": [
+                                {
+                                  "maxLength": 4096,
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ],
+                              "default": null
+                            },
+                            "observed_at_epoch": {
+                              "minimum": 0,
+                              "type": "number"
+                            },
+                            "package_id": {
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "package_name": {
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "port": {
+                              "maximum": 65535,
+                              "minimum": 1,
+                              "type": "integer"
+                            },
+                            "protocol": {
+                              "enum": [
+                                "http",
+                                "https"
+                              ],
+                              "type": "string"
+                            },
+                            "revision": {
+                              "minimum": 1,
+                              "type": "integer"
+                            },
+                            "schema_version": {
+                              "const": "jarvis.service-runtime.v2",
+                              "type": "string"
+                            },
+                            "service_instance_id": {
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "state_path": {
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "execution_id",
+                            "package_name",
+                            "package_id",
+                            "service_instance_id",
+                            "revision",
+                            "lifecycle",
+                            "host",
+                            "port",
+                            "protocol",
+                            "health_path",
+                            "live_data_path",
+                            "events_path",
+                            "state_path",
+                            "command_path",
+                            "delivery_mode",
+                            "dataset_descriptor",
+                            "observed_at_epoch",
+                            "schema_version",
+                            "authorization"
+                          ],
+                          "type": "object"
+                        }
+                      ]
+                    },
+                    "maxItems": 4096,
+                    "type": "array"
+                  },
+                  "terminal": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "schema_version",
+                  "execution_id",
+                  "pipeline_id",
+                  "execution_state",
+                  "terminal",
+                  "service_runtimes"
+                ],
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "schema_version",
+          "pipeline_id",
+          "execution_id",
+          "execution_handle",
+          "execution_record",
+          "runtime_metadata",
+          "progress",
+          "artifact_page",
+          "service_runtimes"
+        ],
+        "type": "object"
+      },
+      "title": "Get Execution"
+    },
+    "jarvis_run": {
+      "_meta": {
+        "fastmcp": {
+          "tags": [
+            "jarvis",
+            "pipeline",
+            "user"
+          ]
+        }
+      },
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": null,
+        "readOnlyHint": false,
+        "title": null
+      },
+      "description": "Start a configured JARVIS pipeline and return its durable execution handle without waiting for workload completion. Optional execution intent selects local, cluster, or hostfile mode without exposing scheduler internals. For each runtime resolved with Spack, copy spack_locate.output.load_spec unchanged into one element of jarvis_run.input.spack_specs; do not derive an executable path from the Spack prefix. JARVIS resolves those specs into a filtered environment and persists it before direct or scheduler execution. Use jarvis_get_execution with the returned pipeline_id and execution_id to query lifecycle, progress, artifacts, and execution-owned service runtimes.",
+      "execution": null,
+      "icons": null,
+      "inputSchema": {
+        "additionalProperties": false,
+        "properties": {
+          "execution": {
+            "anyOf": [
+              {
+                "additionalProperties": false,
+                "description": "Validated, backend-neutral execution request for a JARVIS pipeline.",
+                "properties": {
+                  "account": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "cpus_per_task": {
+                    "anyOf": [
+                      {
+                        "exclusiveMinimum": 0,
+                        "type": "integer"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "error": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "exclusive": {
+                    "anyOf": [
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "gpus": {
+                    "anyOf": [
+                      {
+                        "exclusiveMinimum": 0,
+                        "type": "integer"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "gpus_per_node": {
+                    "anyOf": [
+                      {
+                        "exclusiveMinimum": 0,
+                        "type": "integer"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "hostfile": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "hosts": {
+                    "anyOf": [
+                      {
+                        "items": {
+                          "type": "string"
+                        },
+                        "minItems": 1,
+                        "type": "array"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "job_name": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "mode": {
+                    "default": "auto",
+                    "enum": [
+                      "auto",
+                      "local",
+                      "direct",
+                      "cluster",
+                      "scheduler",
+                      "hostfile"
+                    ],
+                    "type": "string"
+                  },
+                  "nodes": {
+                    "anyOf": [
+                      {
+                        "exclusiveMinimum": 0,
+                        "type": "integer"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "output": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "partition": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "qos": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "tasks": {
+                    "anyOf": [
+                      {
+                        "exclusiveMinimum": 0,
+                        "type": "integer"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "tasks_per_node": {
+                    "anyOf": [
+                      {
+                        "exclusiveMinimum": 0,
+                        "type": "integer"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "walltime": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  }
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "execution_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "pipeline_id": {
+            "type": "string"
+          },
+          "spack_specs": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Runtime identities supplied by Spack. Copy each spack_locate.output.load_spec unchanged into this list; do not pass spack_locate.output.prefix or an inferred executable path. JARVIS persists the resolved environment for the execution."
+          },
+          "submit": {
+            "default": true,
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "pipeline_id"
+        ],
+        "type": "object"
+      },
+      "name": "jarvis_run",
+      "outputSchema": {
+        "description": "Frozen top-level result envelope for ``jarvis_run``.",
+        "properties": {
+          "execution_handle": {
+            "description": "Stable JARVIS-CD execution-handle document.",
+            "properties": {
+              "cluster": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "execution_id": {
+                "type": "string"
+              },
+              "mode": {
+                "enum": [
+                  "direct",
+                  "scheduler"
+                ],
+                "type": "string"
+              },
+              "pipeline_id": {
+                "type": "string"
+              },
+              "scheduler_native_id": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "scheduler_provider": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "schema_version": {
+                "const": "jarvis.execution.handle.v1",
+                "type": "string"
+              }
+            },
+            "required": [
+              "schema_version",
+              "execution_id",
+              "pipeline_id",
+              "mode",
+              "scheduler_provider",
+              "scheduler_native_id",
+              "cluster"
+            ],
+            "type": "object"
+          },
+          "execution_id": {
+            "type": "string"
+          },
+          "execution_record": {
+            "description": "Stable JARVIS-CD durable execution-record document.",
+            "properties": {
+              "cluster": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "created_at": {
+                "type": "string"
+              },
+              "error": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "execution_id": {
+                "type": "string"
+              },
+              "metadata": {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              "mode": {
+                "enum": [
+                  "direct",
+                  "scheduler"
+                ],
+                "type": "string"
+              },
+              "pipeline_id": {
+                "type": "string"
+              },
+              "pipeline_name": {
+                "type": "string"
+              },
+              "return_code": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "scheduler_native_id": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "scheduler_provider": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "schema_version": {
+                "const": "jarvis.execution.record.v1",
+                "type": "string"
+              },
+              "state": {
+                "enum": [
+                  "preparing",
+                  "scripted",
+                  "submitting",
+                  "submitted",
+                  "running",
+                  "completed",
+                  "failed",
+                  "canceled",
+                  "unknown"
+                ],
+                "type": "string"
+              },
+              "submitted": {
+                "type": "boolean"
+              },
+              "terminal": {
+                "type": "boolean"
+              },
+              "updated_at": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "schema_version",
+              "execution_id",
+              "pipeline_id",
+              "pipeline_name",
+              "mode",
+              "scheduler_provider",
+              "scheduler_native_id",
+              "cluster",
+              "state",
+              "submitted",
+              "terminal",
+              "created_at",
+              "updated_at",
+              "return_code",
+              "error",
+              "metadata"
+            ],
+            "type": "object"
+          },
+          "mode": {
+            "enum": [
+              "direct",
+              "scheduler"
+            ],
+            "type": "string"
+          },
+          "pipeline_id": {
+            "type": "string"
+          },
+          "progress": {
+            "additionalProperties": false,
+            "description": "Stable aggregate returned by JARVIS-CD's execution progress API.",
+            "properties": {
+              "execution_id": {
+                "maxLength": 256,
+                "minLength": 1,
+                "type": "string"
+              },
+              "execution_state": {
+                "enum": [
+                  "preparing",
+                  "scripted",
+                  "submitting",
+                  "submitted",
+                  "running",
+                  "completed",
+                  "failed",
+                  "canceled",
+                  "unknown"
+                ],
+                "type": "string"
+              },
+              "packages": {
+                "items": {
+                  "additionalProperties": false,
+                  "description": "Latest stable progress observation for one package alias.",
+                  "properties": {
+                    "event_count": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "latest": {
+                      "anyOf": [
+                        {
+                          "additionalProperties": false,
+                          "description": "One closed, JARVIS-owned package progress observation.",
+                          "properties": {
+                            "current": {
+                              "anyOf": [
+                                {
+                                  "minimum": 0,
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ],
+                              "default": null
+                            },
+                            "determinate": {
+                              "type": "boolean"
+                            },
+                            "execution_id": {
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "label": {
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "message": {
+                              "anyOf": [
+                                {
+                                  "maxLength": 4096,
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ],
+                              "default": null
+                            },
+                            "metadata": {
+                              "additionalProperties": true,
+                              "type": "object"
+                            },
+                            "observed_at_epoch": {
+                              "minimum": 0,
+                              "type": "number"
+                            },
+                            "package_id": {
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "package_name": {
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "schema_version": {
+                              "const": "jarvis.progress.v1",
+                              "type": "string"
+                            },
+                            "sequence": {
+                              "minimum": 0,
+                              "type": "integer"
+                            },
+                            "state": {
+                              "enum": [
+                                "pending",
+                                "starting",
+                                "running",
+                                "ready",
+                                "completed",
+                                "failed",
+                                "canceled"
+                              ],
+                              "type": "string"
+                            },
+                            "total": {
+                              "anyOf": [
+                                {
+                                  "exclusiveMinimum": 0,
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ],
+                              "default": null
+                            },
+                            "unit": {
+                              "anyOf": [
+                                {
+                                  "maxLength": 256,
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ],
+                              "default": null
+                            }
+                          },
+                          "required": [
+                            "schema_version",
+                            "package_name",
+                            "package_id",
+                            "execution_id",
+                            "label",
+                            "state",
+                            "sequence",
+                            "observed_at_epoch",
+                            "determinate",
+                            "metadata"
+                          ],
+                          "type": "object"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "package_id": {
+                      "maxLength": 256,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "package_name": {
+                      "maxLength": 256,
+                      "minLength": 1,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "package_id",
+                    "package_name",
+                    "event_count",
+                    "latest"
+                  ],
+                  "type": "object"
+                },
+                "maxItems": 4096,
+                "type": "array"
+              },
+              "pipeline_id": {
+                "maxLength": 256,
+                "minLength": 1,
+                "type": "string"
+              },
+              "schema_version": {
+                "const": "jarvis.execution.progress.v1",
+                "type": "string"
+              },
+              "terminal": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "schema_version",
+              "execution_id",
+              "pipeline_id",
+              "execution_state",
+              "terminal",
+              "packages"
+            ],
+            "type": "object"
+          },
+          "runtime_metadata": {
+            "additionalProperties": true,
+            "type": "object"
+          },
+          "scheduler": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "schema_version": {
+            "const": "clio-kit.jarvis-run.v1",
+            "type": "string"
+          },
+          "script_path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "status": {
+            "enum": [
+              "preparing",
+              "scripted",
+              "submitting",
+              "submitted",
+              "running",
+              "completed",
+              "failed",
+              "canceled",
+              "unknown"
+            ],
+            "type": "string"
+          },
+          "wait": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "schema_version",
+          "pipeline_id",
+          "execution_id",
+          "status",
+          "mode",
+          "scheduler",
+          "script_path",
+          "wait",
+          "execution_handle",
+          "execution_record",
+          "progress",
+          "runtime_metadata"
+        ],
+        "type": "object"
+      },
+      "title": "Start Execution"
+    },
+    "jm_add_repo": {
+      "_meta": {
+        "fastmcp": {
+          "tags": [
+            "jarvis",
+            "management"
+          ]
+        }
+      },
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": null,
+        "readOnlyHint": false,
+        "title": null
+      },
+      "description": "Add a repository to JarvisManager.",
+      "execution": null,
+      "icons": null,
+      "inputSchema": {
+        "additionalProperties": false,
+        "properties": {
+          "force": {
+            "default": false,
+            "type": "boolean"
+          },
+          "path": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "path"
+        ],
+        "type": "object"
+      },
+      "name": "jm_add_repo",
+      "outputSchema": {
+        "properties": {
+          "result": {
+            "items": {},
+            "type": "array"
+          }
+        },
+        "required": [
+          "result"
+        ],
+        "type": "object",
+        "x-fastmcp-wrap-result": true
+      },
+      "title": "Add Repo"
+    },
+    "jm_bootstrap_from": {
+      "_meta": {
+        "fastmcp": {
+          "tags": [
+            "jarvis",
+            "management"
+          ]
+        }
+      },
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": null,
+        "readOnlyHint": false,
+        "title": null
+      },
+      "description": "Bootstrap Jarvis config from a machine template.",
+      "execution": null,
+      "icons": null,
+      "inputSchema": {
+        "additionalProperties": false,
+        "properties": {
+          "machine": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "machine"
+        ],
+        "type": "object"
+      },
+      "name": "jm_bootstrap_from",
+      "outputSchema": {
+        "properties": {
+          "result": {
+            "items": {},
+            "type": "array"
+          }
+        },
+        "required": [
+          "result"
+        ],
+        "type": "object",
+        "x-fastmcp-wrap-result": true
+      },
+      "title": "Bootstrap Machine"
+    },
+    "jm_bootstrap_list": {
+      "_meta": {
+        "fastmcp": {
+          "tags": [
+            "jarvis",
+            "management"
+          ]
+        }
+      },
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": null,
+        "readOnlyHint": true,
+        "title": null
+      },
+      "description": "List available bootstrap machine templates.",
+      "execution": null,
+      "icons": null,
+      "inputSchema": {
+        "additionalProperties": false,
+        "properties": {},
+        "type": "object"
+      },
+      "name": "jm_bootstrap_list",
+      "outputSchema": {
+        "properties": {
+          "result": {
+            "items": {},
+            "type": "array"
+          }
+        },
+        "required": [
+          "result"
+        ],
+        "type": "object",
+        "x-fastmcp-wrap-result": true
+      },
+      "title": "List Templates"
+    },
+    "jm_cd": {
+      "_meta": {
+        "fastmcp": {
+          "tags": [
+            "jarvis",
+            "management"
+          ]
+        }
+      },
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": null,
+        "readOnlyHint": false,
+        "title": null
+      },
+      "description": "Change current Jarvis pipeline context.",
+      "execution": null,
+      "icons": null,
+      "inputSchema": {
+        "additionalProperties": false,
+        "properties": {
+          "pipeline_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "pipeline_id"
+        ],
+        "type": "object"
+      },
+      "name": "jm_cd",
+      "outputSchema": {
+        "properties": {
+          "result": {
+            "items": {},
+            "type": "array"
+          }
+        },
+        "required": [
+          "result"
+        ],
+        "type": "object",
+        "x-fastmcp-wrap-result": true
+      },
+      "title": "Switch Pipeline"
+    },
+    "jm_construct_pkg": {
+      "_meta": {
+        "fastmcp": {
+          "tags": [
+            "jarvis",
+            "pipeline"
+          ]
+        }
+      },
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": null,
+        "readOnlyHint": false,
+        "title": null
+      },
+      "description": "Construct a package skeleton in JarvisManager.",
+      "execution": null,
+      "icons": null,
+      "inputSchema": {
+        "additionalProperties": false,
+        "properties": {
+          "pkg_type": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "pkg_type"
+        ],
+        "type": "object"
+      },
+      "name": "jm_construct_pkg",
+      "outputSchema": {
+        "properties": {
+          "result": {
+            "items": {},
+            "type": "array"
+          }
+        },
+        "required": [
+          "result"
+        ],
+        "type": "object",
+        "x-fastmcp-wrap-result": true
+      },
+      "title": "Construct Package"
+    },
+    "jm_create_config": {
+      "_meta": {
+        "fastmcp": {
+          "tags": [
+            "jarvis",
+            "management"
+          ]
+        }
+      },
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": null,
+        "readOnlyHint": false,
+        "title": null
+      },
+      "description": "Initialize JarvisManager config directories.",
+      "execution": null,
+      "icons": null,
+      "inputSchema": {
+        "additionalProperties": false,
+        "properties": {
+          "config_dir": {
+            "type": "string"
+          },
+          "private_dir": {
+            "type": "string"
+          },
+          "shared_dir": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          }
+        },
+        "required": [
+          "config_dir",
+          "private_dir"
+        ],
+        "type": "object"
+      },
+      "name": "jm_create_config",
+      "outputSchema": {
+        "properties": {
+          "result": {
+            "items": {},
+            "type": "array"
+          }
+        },
+        "required": [
+          "result"
+        ],
+        "type": "object",
+        "x-fastmcp-wrap-result": true
+      },
+      "title": "Initialize Config"
+    },
+    "jm_get_repo": {
+      "_meta": {
+        "fastmcp": {
+          "tags": [
+            "jarvis",
+            "monitoring"
+          ]
+        }
+      },
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": null,
+        "readOnlyHint": true,
+        "title": null
+      },
+      "description": "Get repository info from JarvisManager.",
+      "execution": null,
+      "icons": null,
+      "inputSchema": {
+        "additionalProperties": false,
+        "properties": {
+          "repo_name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "repo_name"
+        ],
+        "type": "object"
+      },
+      "name": "jm_get_repo",
+      "outputSchema": {
+        "additionalProperties": true,
+        "type": "object"
+      },
+      "title": "Get Repo"
+    },
+    "jm_graph_build": {
+      "_meta": {
+        "fastmcp": {
+          "tags": [
+            "jarvis",
+            "pipeline"
+          ]
+        }
+      },
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": null,
+        "readOnlyHint": false,
+        "title": null
+      },
+      "description": "Build or rebuild the resource graph with a net sleep interval.",
+      "execution": null,
+      "icons": null,
+      "inputSchema": {
+        "additionalProperties": false,
+        "properties": {
+          "net_sleep": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "net_sleep"
+        ],
+        "type": "object"
+      },
+      "name": "jm_graph_build",
+      "outputSchema": {
+        "properties": {
+          "result": {
+            "items": {},
+            "type": "array"
+          }
+        },
+        "required": [
+          "result"
+        ],
+        "type": "object",
+        "x-fastmcp-wrap-result": true
+      },
+      "title": "Build Graph"
+    },
+    "jm_graph_modify": {
+      "_meta": {
+        "fastmcp": {
+          "tags": [
+            "jarvis",
+            "pipeline"
+          ]
+        }
+      },
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": null,
+        "readOnlyHint": false,
+        "title": null
+      },
+      "description": "Modify the resource graph using a net sleep interval.",
+      "execution": null,
+      "icons": null,
+      "inputSchema": {
+        "additionalProperties": false,
+        "properties": {
+          "net_sleep": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "net_sleep"
+        ],
+        "type": "object"
+      },
+      "name": "jm_graph_modify",
+      "outputSchema": {
+        "properties": {
+          "result": {
+            "items": {},
+            "type": "array"
+          }
+        },
+        "required": [
+          "result"
+        ],
+        "type": "object",
+        "x-fastmcp-wrap-result": true
+      },
+      "title": "Modify Graph"
+    },
+    "jm_graph_show": {
+      "_meta": {
+        "fastmcp": {
+          "tags": [
+            "jarvis",
+            "monitoring"
+          ]
+        }
+      },
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": null,
+        "readOnlyHint": true,
+        "title": null
+      },
+      "description": "Print the current resource graph frames.",
+      "execution": null,
+      "icons": null,
+      "inputSchema": {
+        "additionalProperties": false,
+        "properties": {},
+        "type": "object"
+      },
+      "name": "jm_graph_show",
+      "outputSchema": {
+        "properties": {
+          "result": {
+            "items": {},
+            "type": "array"
+          }
+        },
+        "required": [
+          "result"
+        ],
+        "type": "object",
+        "x-fastmcp-wrap-result": true
+      },
+      "title": "Show Graph"
+    },
+    "jm_list_pipelines": {
+      "_meta": {
+        "fastmcp": {
+          "tags": [
+            "jarvis",
+            "monitoring"
+          ]
+        }
+      },
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": null,
+        "readOnlyHint": true,
+        "title": null
+      },
+      "description": "List all existing Jarvis pipelines.",
+      "execution": null,
+      "icons": null,
+      "inputSchema": {
+        "additionalProperties": false,
+        "properties": {},
+        "type": "object"
+      },
+      "name": "jm_list_pipelines",
+      "outputSchema": {
+        "additionalProperties": true,
+        "type": "object"
+      },
+      "title": "List Pipelines"
+    },
+    "jm_list_repos": {
+      "_meta": {
+        "fastmcp": {
+          "tags": [
+            "jarvis",
+            "monitoring"
+          ]
+        }
+      },
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": null,
+        "readOnlyHint": true,
+        "title": null
+      },
+      "description": "List all Jarvis repositories.",
+      "execution": null,
+      "icons": null,
+      "inputSchema": {
+        "additionalProperties": false,
+        "properties": {},
+        "type": "object"
+      },
+      "name": "jm_list_repos",
+      "outputSchema": {
+        "additionalProperties": true,
+        "type": "object"
+      },
+      "title": "List Repos"
+    },
+    "jm_load_config": {
+      "_meta": {
+        "fastmcp": {
+          "tags": [
+            "jarvis",
+            "management"
+          ]
+        }
+      },
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": null,
+        "readOnlyHint": true,
+        "title": null
+      },
+      "description": "Load existing JarvisManager configuration.",
+      "execution": null,
+      "icons": null,
+      "inputSchema": {
+        "additionalProperties": false,
+        "properties": {},
+        "type": "object"
+      },
+      "name": "jm_load_config",
+      "outputSchema": {
+        "properties": {
+          "result": {
+            "items": {},
+            "type": "array"
+          }
+        },
+        "required": [
+          "result"
+        ],
+        "type": "object",
+        "x-fastmcp-wrap-result": true
+      },
+      "title": "Load Config"
+    },
+    "jm_promote_repo": {
+      "_meta": {
+        "fastmcp": {
+          "tags": [
+            "jarvis",
+            "management"
+          ]
+        }
+      },
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": null,
+        "readOnlyHint": false,
+        "title": null
+      },
+      "description": "Promote a repository in JarvisManager.",
+      "execution": null,
+      "icons": null,
+      "inputSchema": {
+        "additionalProperties": false,
+        "properties": {
+          "repo_name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "repo_name"
+        ],
+        "type": "object"
+      },
+      "name": "jm_promote_repo",
+      "outputSchema": {
+        "properties": {
+          "result": {
+            "items": {},
+            "type": "array"
+          }
+        },
+        "required": [
+          "result"
+        ],
+        "type": "object",
+        "x-fastmcp-wrap-result": true
+      },
+      "title": "Promote Repo"
+    },
+    "jm_remove_repo": {
+      "_meta": {
+        "fastmcp": {
+          "tags": [
+            "jarvis",
+            "management"
+          ]
+        }
+      },
+      "annotations": {
+        "destructiveHint": true,
+        "idempotentHint": true,
+        "openWorldHint": null,
+        "readOnlyHint": false,
+        "title": null
+      },
+      "description": "Remove a repository from JarvisManager.",
+      "execution": null,
+      "icons": null,
+      "inputSchema": {
+        "additionalProperties": false,
+        "properties": {
+          "repo_name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "repo_name"
+        ],
+        "type": "object"
+      },
+      "name": "jm_remove_repo",
+      "outputSchema": {
+        "properties": {
+          "result": {
+            "items": {},
+            "type": "array"
+          }
+        },
+        "required": [
+          "result"
+        ],
+        "type": "object",
+        "x-fastmcp-wrap-result": true
+      },
+      "title": "Remove Repo"
+    },
+    "jm_reset": {
+      "_meta": {
+        "fastmcp": {
+          "tags": [
+            "jarvis",
+            "management"
+          ]
+        }
+      },
+      "annotations": {
+        "destructiveHint": true,
+        "idempotentHint": true,
+        "openWorldHint": null,
+        "readOnlyHint": false,
+        "title": null
+      },
+      "description": "Reset JarvisManager (destroy all pipelines and data).",
+      "execution": null,
+      "icons": null,
+      "inputSchema": {
+        "additionalProperties": false,
+        "properties": {},
+        "type": "object"
+      },
+      "name": "jm_reset",
+      "outputSchema": {
+        "properties": {
+          "result": {
+            "items": {},
+            "type": "array"
+          }
+        },
+        "required": [
+          "result"
+        ],
+        "type": "object",
+        "x-fastmcp-wrap-result": true
+      },
+      "title": "Reset Manager"
+    },
+    "jm_save_config": {
+      "_meta": {
+        "fastmcp": {
+          "tags": [
+            "jarvis",
+            "management"
+          ]
+        }
+      },
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": null,
+        "readOnlyHint": false,
+        "title": null
+      },
+      "description": "Save current JarvisManager configuration.",
+      "execution": null,
+      "icons": null,
+      "inputSchema": {
+        "additionalProperties": false,
+        "properties": {},
+        "type": "object"
+      },
+      "name": "jm_save_config",
+      "outputSchema": {
+        "properties": {
+          "result": {
+            "items": {},
+            "type": "array"
+          }
+        },
+        "required": [
+          "result"
+        ],
+        "type": "object",
+        "x-fastmcp-wrap-result": true
+      },
+      "title": "Save Config"
+    },
+    "jm_set_hostfile": {
+      "_meta": {
+        "fastmcp": {
+          "tags": [
+            "jarvis",
+            "management"
+          ]
+        }
+      },
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": null,
+        "readOnlyHint": false,
+        "title": null
+      },
+      "description": "Set hostfile path for JarvisManager.",
+      "execution": null,
+      "icons": null,
+      "inputSchema": {
+        "additionalProperties": false,
+        "properties": {
+          "path": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "path"
+        ],
+        "type": "object"
+      },
+      "name": "jm_set_hostfile",
+      "outputSchema": {
+        "properties": {
+          "result": {
+            "items": {},
+            "type": "array"
+          }
+        },
+        "required": [
+          "result"
+        ],
+        "type": "object",
+        "x-fastmcp-wrap-result": true
+      },
+      "title": "Set Hostfile"
+    },
+    "load_pipeline": {
+      "_meta": {
+        "fastmcp": {
+          "tags": [
+            "jarvis",
+            "pipeline"
+          ]
+        }
+      },
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": null,
+        "readOnlyHint": true,
+        "title": null
+      },
+      "description": "Load an existing Jarvis-CD pipeline environment.",
+      "execution": null,
+      "icons": null,
+      "inputSchema": {
+        "additionalProperties": false,
+        "properties": {
+          "pipeline_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          }
+        },
+        "type": "object"
+      },
+      "name": "load_pipeline",
+      "outputSchema": {
+        "additionalProperties": true,
+        "type": "object"
+      },
+      "title": "Load Pipeline"
+    },
+    "remove_pkg": {
+      "_meta": {
+        "fastmcp": {
+          "tags": [
+            "jarvis",
+            "pipeline"
+          ]
+        }
+      },
+      "annotations": {
+        "destructiveHint": true,
+        "idempotentHint": true,
+        "openWorldHint": null,
+        "readOnlyHint": false,
+        "title": null
+      },
+      "description": "Delete a package through JARVIS-CD's destructive removal API. Fails explicitly when the installed JARVIS-CD only supports non-destructive unlinking.",
+      "execution": null,
+      "icons": null,
+      "inputSchema": {
+        "additionalProperties": false,
+        "properties": {
+          "pipeline_id": {
+            "type": "string"
+          },
+          "pkg_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "pipeline_id",
+          "pkg_id"
+        ],
+        "type": "object"
+      },
+      "name": "remove_pkg",
+      "outputSchema": {
+        "additionalProperties": true,
+        "type": "object"
+      },
+      "title": "Remove Package"
+    },
+    "run_pipeline": {
+      "_meta": {
+        "fastmcp": {
+          "tags": [
+            "jarvis",
+            "pipeline"
+          ]
+        }
+      },
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": null,
+        "readOnlyHint": false,
+        "title": null
+      },
+      "description": "Execute a Jarvis-CD pipeline end-to-end.",
+      "execution": null,
+      "icons": null,
+      "inputSchema": {
+        "additionalProperties": false,
+        "properties": {
+          "pipeline_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "pipeline_id"
+        ],
+        "type": "object"
+      },
+      "name": "run_pipeline",
+      "outputSchema": {
+        "additionalProperties": true,
+        "type": "object"
+      },
+      "title": "Run Pipeline"
+    },
+    "unlink_pkg": {
+      "_meta": {
+        "fastmcp": {
+          "tags": [
+            "jarvis",
+            "pipeline"
+          ]
+        }
+      },
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": null,
+        "readOnlyHint": false,
+        "title": null
+      },
+      "description": "Unlink a package from a pipeline (preserve files).",
+      "execution": null,
+      "icons": null,
+      "inputSchema": {
+        "additionalProperties": false,
+        "properties": {
+          "pipeline_id": {
+            "type": "string"
+          },
+          "pkg_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "pipeline_id",
+          "pkg_id"
+        ],
+        "type": "object"
+      },
+      "name": "unlink_pkg",
+      "outputSchema": {
+        "additionalProperties": true,
+        "type": "object"
+      },
+      "title": "Unlink Package"
+    },
+    "update_pipeline": {
+      "_meta": {
+        "fastmcp": {
+          "tags": [
+            "jarvis",
+            "pipeline"
+          ]
+        }
+      },
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": null,
+        "readOnlyHint": false,
+        "title": null
+      },
+      "description": "Re-apply environment and configuration to every package in a pipeline.",
+      "execution": null,
+      "icons": null,
+      "inputSchema": {
+        "additionalProperties": false,
+        "properties": {
+          "pipeline_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "pipeline_id"
+        ],
+        "type": "object"
+      },
+      "name": "update_pipeline",
+      "outputSchema": {
+        "additionalProperties": true,
+        "type": "object"
+      },
+      "title": "Reapply Pipeline"
+    }
+  }
+}

--- a/clio-kit-mcp-servers/jarvis/tests/test_backward_compat_reexports.py
+++ b/clio-kit-mcp-servers/jarvis/tests/test_backward_compat_reexports.py
@@ -1,0 +1,244 @@
+"""Every name previously importable from ``jarvis_mcp.server`` still is.
+
+PR #364 review finding 3: the server.py owner-module split (clio-kit
+campaign #362, Slice 1) silently narrowed the module's public surface --
+``from jarvis_mcp.server import JarvisArtifactDocument`` used to work (the
+class was defined directly in server.py) and started raising ImportError
+once it moved to ``jarvis_mcp.models.artifact_documents`` without a
+compatibility re-export.
+
+``_PRESPLIT_TOP_LEVEL_NAMES`` is the COMPLETE, mechanically-extracted list of
+every top-level name (class, function, constant, or plain import) the
+pre-split ``server.py`` (commit ea232ac, the contract-pins commit
+immediately before the split) defined at module scope -- captured via
+``ast.parse`` over that commit's file content, not hand-transcribed. Every
+one of those 190 names must still resolve as a ``jarvis_mcp.server``
+attribute today, whether it still lives here or now lives in an owner
+module and is re-exported.
+"""
+
+from __future__ import annotations
+
+from jarvis_mcp import server
+
+# Mechanically extracted (ast.parse over every top-level ClassDef/FunctionDef/
+# Assign/AnnAssign/Import/ImportFrom binding) from
+# clio-kit-mcp-servers/jarvis/src/jarvis_mcp/server.py at commit ea232ac --
+# the full pre-split module surface. Do not hand-edit; regenerate the same
+# way if server.py's pre-split ancestor is ever revisited.
+_PRESPLIT_TOP_LEVEL_NAMES: tuple[str, ...] = (
+    "ADMIN_TOOLS",
+    "Annotated",
+    "Any",
+    "BaseModel",
+    "CONFIGURATION_INPUT_BINDING_SCHEMA",
+    "ConfigDict",
+    "Context",
+    "ExecutionArtifactQuery",
+    "ExecutionIntent",
+    "FastMCP",
+    "Field",
+    "JarvisArtifactDocument",
+    "JarvisArtifactLocationDocument",
+    "JarvisConfigurationInputBindingDocument",
+    "JarvisDatasetArrayDocument",
+    "JarvisDatasetDescriptorDocument",
+    "JarvisDatasetFingerprintDocument",
+    "JarvisDatasetMemberDocument",
+    "JarvisDatasetSourceArtifactDocument",
+    "JarvisDescribePackageResult",
+    "JarvisDescribePackageSearchResult",
+    "JarvisDescribePackagesResult",
+    "JarvisDescribePipelineResult",
+    "JarvisDescribeResult",
+    "JarvisDescribeStepResult",
+    "JarvisExecutionArtifactPageDocument",
+    "JarvisExecutionHandleDocument",
+    "JarvisExecutionRecordDocument",
+    "JarvisExecutionResult",
+    "JarvisManager",
+    "JarvisPackageConditionDocument",
+    "JarvisPackageConfigurationRuleDocument",
+    "JarvisPackageDeploymentDocument",
+    "JarvisPackageDescriptionDocument",
+    "JarvisPackageExecutionProfileDocument",
+    "JarvisPackageProgressDocument",
+    "JarvisPackageReadinessDocument",
+    "JarvisPackageSettingDocument",
+    "JarvisPackageSummaryDocument",
+    "JarvisProgressEventDocument",
+    "JarvisProgressSnapshotDocument",
+    "JarvisProviderQueryDocument",
+    "JarvisProviderResolutionDocument",
+    "JarvisRunResult",
+    "JarvisRuntimeRequirementDocument",
+    "JarvisRuntimeRequirementStatusDocument",
+    "JarvisServiceAuthorizationDocument",
+    "JarvisServiceRuntimeDocument",
+    "JarvisServiceRuntimeSnapshotDocument",
+    "JarvisServiceRuntimeV1Document",
+    "JarvisServiceRuntimeV2Document",
+    "Literal",
+    "MCP_METADATA_PROFILE",
+    "Mapping",
+    "Message",
+    "NotRequired",
+    "Optional",
+    "PACKAGE_DEPLOYMENT_SCHEMA",
+    "PACKAGE_DESCRIPTION_SCHEMA",
+    "PACKAGE_SEARCH_CURSOR_SCHEMA",
+    "PACKAGE_SEARCH_DEFAULT_PAGE_SIZE",
+    "PACKAGE_SEARCH_MAX_CURSOR_LENGTH",
+    "PACKAGE_SEARCH_MAX_DESCRIPTION_BYTES",
+    "PACKAGE_SEARCH_MAX_PAGE_SIZE",
+    "PACKAGE_SEARCH_MAX_RESULT_BYTES",
+    "PACKAGE_SEARCH_SCHEMA",
+    "Path",
+    "PurePosixPath",
+    "ToolError",
+    "TypedDict",
+    "USER_TOOLS",
+    "ValidationError",
+    "_ClosedDocument",
+    "_CurrentJarvisManager",
+    "_EXECUTION_MODES",
+    "_HOST_ENTRY",
+    "_JarvisServiceRuntimeDocumentBase",
+    "_PACKAGE_SEARCH_CURSOR_TEXT",
+    "_PACKAGE_SEARCH_SHA256",
+    "_PackageAgentMetadata",
+    "_PackageInventoryEntry",
+    "_SCHEDULER_EXECUTION_FIELDS",
+    "_SCHEDULER_TOKEN",
+    "_bounded_package_search_description",
+    "_bounded_single_line",
+    "_context_has_progress_token",
+    "_decode_package_search_cursor",
+    "_detect_scheduler_name",
+    "_discover_package_inventory",
+    "_discover_packages",
+    "_encode_package_search_cursor",
+    "_execution_intent_to_pipeline_config",
+    "_existing_directory_path",
+    "_find_package_description",
+    "_first_docstring_or_comment",
+    "_load_jarvis_manager_class",
+    "_manager",
+    "_package_agent_metadata",
+    "_package_configuration_search_text",
+    "_package_description_from_inventory",
+    "_package_from_pkg_file",
+    "_package_inventory_entry",
+    "_package_inventory_revision",
+    "_package_search_json_bytes",
+    "_package_search_rank",
+    "_package_search_terms",
+    "_protocol_stdout_to_stderr",
+    "_registered_tools",
+    "_reject_package_search_duplicate_keys",
+    "_search_packages",
+    "_setting_accepts_null",
+    "_setting_from_menu_item",
+    "_setting_is_agent_visible",
+    "_spack_command_path",
+    "_step_snapshot",
+    "_validated_execution_intent",
+    "add_jarvis_root_argument",
+    "add_spack_command_argument",
+    "admin_main",
+    "append_pkg",
+    "append_pkg_tool",
+    "apply_tool_profile",
+    "argparse",
+    "base64",
+    "binascii",
+    "build_pipeline_env",
+    "build_pipeline_env_tool",
+    "cast",
+    "configure_jarvis_root",
+    "configure_pkg",
+    "configure_pkg_tool",
+    "configure_spack_command",
+    "create_pipeline",
+    "create_pipeline_tool",
+    "create_pipeline_workflow",
+    "dataclass",
+    "destroy_pipeline",
+    "destroy_pipeline_tool",
+    "export_pipeline",
+    "export_pipeline_tool",
+    "field_validator",
+    "get_execution",
+    "get_manager",
+    "get_pkg_config",
+    "get_pkg_config_tool",
+    "hashlib",
+    "importlib",
+    "jarvis_add_step_tool",
+    "jarvis_capabilities",
+    "jarvis_create_pipeline_tool",
+    "jarvis_describe_tool",
+    "jarvis_edit_step_tool",
+    "jarvis_get_execution_tool",
+    "jarvis_run_tool",
+    "jm_add_repo",
+    "jm_bootstrap_from",
+    "jm_bootstrap_list",
+    "jm_cd",
+    "jm_construct_pkg",
+    "jm_create_config",
+    "jm_get_repo",
+    "jm_graph_build",
+    "jm_graph_modify",
+    "jm_graph_show",
+    "jm_list_pipelines",
+    "jm_list_repos",
+    "jm_load_config",
+    "jm_promote_repo",
+    "jm_remove_repo",
+    "jm_reset",
+    "jm_save_config",
+    "jm_set_hostfile",
+    "json",
+    "load_dotenv",
+    "load_pipeline",
+    "load_pipeline_tool",
+    "main",
+    "manager",
+    "mcp",
+    "model_validator",
+    "os",
+    "re",
+    "remove_pkg",
+    "remove_pkg_tool",
+    "run_pipeline",
+    "run_pipeline_tool",
+    "unlink_pkg",
+    "unlink_pkg_tool",
+    "update_pipeline",
+    "update_pipeline_tool",
+)
+
+
+def test_presplit_name_count_is_190() -> None:
+    """Guard the fixture itself: exactly the pre-split module's own symbol count."""
+    assert len(_PRESPLIT_TOP_LEVEL_NAMES) == 190
+    assert len(set(_PRESPLIT_TOP_LEVEL_NAMES)) == 190, "duplicate name in the fixture"
+
+
+def test_every_presplit_name_is_still_importable_from_server() -> None:
+    """``from jarvis_mcp.server import X`` must keep working for every X."""
+    missing = [name for name in _PRESPLIT_TOP_LEVEL_NAMES if not hasattr(server, name)]
+    assert not missing, (
+        f"{len(missing)} name(s) that used to be importable from "
+        f"jarvis_mcp.server no longer are: {missing}"
+    )
+
+
+def test_every_presplit_name_is_declared_in_dunder_all() -> None:
+    """``__all__`` documents the full compatibility surface, not a subset of it."""
+    undeclared = sorted(set(_PRESPLIT_TOP_LEVEL_NAMES) - set(server.__all__))
+    assert not undeclared, (
+        f"{len(undeclared)} previously-importable name(s) are missing from "
+        f"server.__all__: {undeclared}"
+    )

--- a/clio-kit-mcp-servers/jarvis/tests/test_contract_pins.py
+++ b/clio-kit-mcp-servers/jarvis/tests/test_contract_pins.py
@@ -1,0 +1,233 @@
+"""Wire-contract pins for the jarvis MCP server (clio-kit campaign #362, Slice 1).
+
+These pins capture the server's wire surface as it stood before the
+``server.py`` / ``jarvis_handler.py`` owner-module split: the full
+``tools/list`` registration -- every tool's LITERAL wire record
+(``Tool.model_dump(mode="json", by_alias=True)``: name, title, description,
+inputSchema, outputSchema, annotations, icons, execution, and ``_meta``
+including ``_meta.fastmcp.tags``) in actual registration order -- and the
+full ``tools/call`` result envelope (``content``, ``structured_content``,
+``meta``, ``is_error``) of four representative tools. They are the
+refactor's safety net -- committed BEFORE any file was split, they must stay
+green, unmodified, across it. Any wire-visible drift (a renamed tool, a
+reshaped schema, a reordered registration, a changed result envelope) fails
+here first, independent of every other test in this suite.
+
+Pinning the literal ``model_dump`` output (rather than a hand-picked field
+subset) is deliberate: an earlier version of this pin reconstructed
+``tags`` as a top-level field and dropped ``execution``/``icons``/``_meta``
+entirely, silently blessing a lossy projection of the wire contract (PR #364
+review finding 1). Pinning ``result.data`` alone made the same mistake for
+tools/call (finding 2) -- ``data`` is a client-side convenience view derived
+from ``structured_content``, not what the server puts on the wire.
+
+The four representative tools were chosen to cover the code this campaign
+moves:
+
+- ``jarvis_describe`` (target=package_search) exercises the package
+  inventory/search path (moving to ``jarvis_mcp.package_discovery``).
+- ``jarvis_create_pipeline`` exercises the thin pipeline-tool wrapping that
+  stays in ``server.py``.
+- ``jarvis_run`` exercises ``JarvisRunResult`` (moving to
+  ``jarvis_mcp.models.execution``) as an MCP tool OUTPUT SCHEMA -- FastMCP
+  validates the return value against it before it goes on the wire.
+- ``jarvis_get_execution`` exercises ``JarvisExecutionResult.model_validate``
+  (moving to ``jarvis_mcp.models.execution``), the one tool that re-validates
+  its handler's raw dict through Pydantic before returning it.
+
+Both fixtures were verified byte-for-byte identical when captured against
+the pre-split commit (ea232ac, before server.py's owner-module split) and
+the post-split tree -- see the PR #364 wave-1 description for the
+verification method (a throwaway git worktree at the pre-split commit,
+diffed against the same capture run post-split).
+
+Regenerate a pin only when the wire contract is DELIBERATELY changing (never
+to make a refactor "pass"). To regenerate: reproduce the capture harness
+described in the clio-kit campaign #362 wave-1 PR description, or hand-edit
+the JSON fixture and confirm the diff is the intended, reviewed wire change.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+from fastmcp import Client
+
+from jarvis_mcp import server
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+TOOLS_LIST_PIN = FIXTURES_DIR / "jarvis_tools_list_pin.json"
+TOOL_CALL_PINS = FIXTURES_DIR / "jarvis_tool_call_pins.json"
+
+
+@pytest.mark.asyncio
+async def test_tools_list_contract_pin() -> None:
+    """The full 36-tool registry -- every field, in registration order -- matches the pin.
+
+    Reloads ``jarvis_mcp.server`` for a clean, unfiltered 36-tool registry
+    regardless of test order (mirrors test_tool_titles.py's rationale:
+    ``apply_tool_profile`` permanently mutates the shared ``mcp`` singleton).
+    """
+    fresh_server = importlib.reload(server)
+    try:
+        async with Client(fresh_server.mcp) as client:
+            tools = await client.list_tools()
+        actual_order = [tool.name for tool in tools]
+        actual_by_name = {
+            tool.name: tool.model_dump(mode="json", by_alias=True) for tool in tools
+        }
+    finally:
+        importlib.reload(server)
+
+    pinned = json.loads(TOOLS_LIST_PIN.read_text(encoding="utf-8"))
+    pinned_order: list[str] = pinned["order"]
+    pinned_by_name: dict[str, dict] = pinned["tools"]
+
+    assert actual_order == pinned_order, (
+        "jarvis tool REGISTRATION ORDER drifted from the contract pin -- a "
+        "tool was added, removed, renamed, or reordered. If this is "
+        f"deliberate, regenerate {TOOLS_LIST_PIN.name}.\n"
+        f"pinned:  {pinned_order}\n"
+        f"actual:  {actual_order}"
+    )
+    assert set(actual_by_name) == set(pinned_by_name)
+    for name in pinned_order:
+        assert actual_by_name[name] == pinned_by_name[name], (
+            f"tool {name!r} FULL wire record drifted from the pin:\n"
+            f"pinned:  {json.dumps(pinned_by_name[name], indent=2, sort_keys=True)}\n"
+            f"actual:  {json.dumps(actual_by_name[name], indent=2, sort_keys=True)}"
+        )
+
+
+_RUN_RESULT = {
+    "schema_version": "clio-kit.jarvis-run.v1",
+    "pipeline_id": "pin_pipeline",
+    "execution_id": "pin-exec-0001",
+    "status": "running",
+    "mode": "direct",
+    "scheduler": None,
+    "script_path": None,
+    "wait": False,
+    "execution_handle": {
+        "schema_version": "jarvis.execution.handle.v1",
+        "execution_id": "pin-exec-0001",
+        "pipeline_id": "pin_pipeline",
+        "mode": "direct",
+        "scheduler_provider": None,
+        "scheduler_native_id": None,
+        "cluster": None,
+    },
+    "execution_record": {
+        "schema_version": "jarvis.execution.record.v1",
+        "execution_id": "pin-exec-0001",
+        "pipeline_id": "pin_pipeline",
+        "pipeline_name": "pin_pipeline",
+        "mode": "direct",
+        "scheduler_provider": None,
+        "scheduler_native_id": None,
+        "cluster": None,
+        "state": "running",
+        "submitted": False,
+        "terminal": False,
+        "created_at": "2026-08-01T00:00:00Z",
+        "updated_at": "2026-08-01T00:00:01Z",
+        "return_code": None,
+        "error": None,
+        "metadata": {},
+    },
+    "progress": {
+        "schema_version": "jarvis.execution.progress.v1",
+        "execution_id": "pin-exec-0001",
+        "pipeline_id": "pin_pipeline",
+        "execution_state": "running",
+        "terminal": False,
+        "packages": [],
+    },
+    "runtime_metadata": {"source": "jarvis_mcp", "schema_version": "jarvis.runtime.v1"},
+}
+
+_EXECUTION_RESULT = {
+    "schema_version": "clio-kit.jarvis-execution.v2",
+    "pipeline_id": "pin_pipeline",
+    "execution_id": "pin-exec-0001",
+    "execution_handle": _RUN_RESULT["execution_handle"],
+    "execution_record": _RUN_RESULT["execution_record"],
+    "runtime_metadata": _RUN_RESULT["runtime_metadata"],
+    "progress": _RUN_RESULT["progress"],
+    "artifact_page": None,
+    "service_runtimes": None,
+}
+
+
+@pytest.fixture
+def tool_call_pins() -> dict:
+    return json.loads(TOOL_CALL_PINS.read_text(encoding="utf-8"))
+
+
+def _envelope(result) -> dict:
+    """Project a CallToolResult onto the full wire envelope this pin covers."""
+    return {
+        "content": [item.model_dump(mode="json") for item in result.content],
+        "structured_content": result.structured_content,
+        "meta": result.meta,
+        "is_error": result.is_error,
+    }
+
+
+@pytest.mark.asyncio
+async def test_jarvis_describe_package_search_call_pin(tool_call_pins) -> None:
+    """Package-search discovery result envelope (the code moving to package_discovery.py)."""
+    pin = tool_call_pins["jarvis_describe_package_search"]
+    with (
+        patch("jarvis_mcp.server.JarvisManager") as mock_manager_class,
+        patch("jarvis_mcp.server._manager", None),
+        patch("jarvis_mcp.server.manager", None),
+    ):
+        mock_manager = Mock()
+        mock_manager.list_repos.return_value = ["repo1", "repo2"]
+        mock_manager_class.get_instance.return_value = mock_manager
+
+        async with Client(server.mcp) as client:
+            result = await client.call_tool("jarvis_describe", pin["args"])
+
+    assert _envelope(result) == pin["result"]
+
+
+@pytest.mark.asyncio
+async def test_jarvis_create_pipeline_call_pin(tool_call_pins) -> None:
+    """The thin pipeline-tool wrapping that stays in server.py."""
+    pin = tool_call_pins["jarvis_create_pipeline"]
+    with patch("jarvis_mcp.server.create_pipeline") as mock_create:
+        mock_create.return_value = {"pipeline_id": "pin_pipeline", "status": "created"}
+        async with Client(server.mcp) as client:
+            result = await client.call_tool("jarvis_create_pipeline", pin["args"])
+
+    assert _envelope(result) == pin["result"]
+
+
+@pytest.mark.asyncio
+async def test_jarvis_run_call_pin(tool_call_pins) -> None:
+    """JarvisRunResult as a validated MCP tool OUTPUT SCHEMA, full envelope."""
+    pin = tool_call_pins["jarvis_run"]
+    with patch("jarvis_mcp.server.run_pipeline") as mock_run:
+        mock_run.return_value = dict(_RUN_RESULT)
+        async with Client(server.mcp) as client:
+            result = await client.call_tool("jarvis_run", pin["args"])
+
+    assert _envelope(result) == pin["result"]
+
+
+@pytest.mark.asyncio
+async def test_jarvis_get_execution_call_pin(tool_call_pins) -> None:
+    """JarvisExecutionResult.model_validate re-validation, full envelope."""
+    pin = tool_call_pins["jarvis_get_execution"]
+    with patch("jarvis_mcp.server.get_execution") as mock_get:
+        mock_get.return_value = dict(_EXECUTION_RESULT)
+        async with Client(server.mcp) as client:
+            result = await client.call_tool("jarvis_get_execution", pin["args"])
+
+    assert _envelope(result) == pin["result"]

--- a/clio-kit-mcp-servers/jarvis/tests/test_package_search.py
+++ b/clio-kit-mcp-servers/jarvis/tests/test_package_search.py
@@ -58,7 +58,9 @@ async def test_named_package_loads_settings_for_only_the_selected_package(
 
     with (
         patch("jarvis_mcp.server.get_manager", return_value=_manager_for(repo)),
-        patch("jarvis_mcp.server._package_agent_metadata", side_effect=metadata),
+        patch(
+            "jarvis_mcp.package_discovery._package_agent_metadata", side_effect=metadata
+        ),
     ):
         short = await jarvis_describe_tool("package", package_name="PARAVIEW")
         canonical = await jarvis_describe_tool(
@@ -316,7 +318,9 @@ async def test_ambiguous_short_name_fails_with_canonical_candidates(
 
     with (
         patch("jarvis_mcp.server.get_manager", return_value=_manager_for(repo)),
-        patch("jarvis_mcp.server._package_agent_metadata", side_effect=metadata),
+        patch(
+            "jarvis_mcp.package_discovery._package_agent_metadata", side_effect=metadata
+        ),
     ):
         with pytest.raises(
             ToolError,
@@ -358,7 +362,7 @@ async def test_package_search_is_ranked_summary_only_and_cursor_bound(
     with (
         patch("jarvis_mcp.server.get_manager", return_value=_manager_for(repo)),
         patch(
-            "jarvis_mcp.server._package_agent_metadata",
+            "jarvis_mcp.package_discovery._package_agent_metadata",
             side_effect=AssertionError("search must not load settings"),
         ),
     ):
@@ -419,7 +423,7 @@ async def test_package_search_enforces_response_byte_ceiling(tmp_path: Path) -> 
     with (
         patch("jarvis_mcp.server.get_manager", return_value=_manager_for(repo)),
         patch(
-            "jarvis_mcp.server._package_agent_metadata",
+            "jarvis_mcp.package_discovery._package_agent_metadata",
             side_effect=AssertionError("search must not load settings"),
         ),
     ):
@@ -499,7 +503,7 @@ async def test_package_search_finds_packages_by_declared_input_binding(
     with (
         patch("jarvis_mcp.server.get_manager", return_value=_manager_for(repo)),
         patch(
-            "jarvis_mcp.server._package_configuration_search_text",
+            "jarvis_mcp.package_discovery._package_configuration_search_text",
             side_effect=configuration_text,
         ),
     ):
@@ -627,7 +631,9 @@ async def test_legacy_packages_target_remains_exhaustive_with_settings(
 
     with (
         patch("jarvis_mcp.server.get_manager", return_value=_manager_for(repo)),
-        patch("jarvis_mcp.server._package_agent_metadata", side_effect=metadata),
+        patch(
+            "jarvis_mcp.package_discovery._package_agent_metadata", side_effect=metadata
+        ),
     ):
         result = await jarvis_describe_tool("packages")
 

--- a/clio-kit-mcp-servers/jarvis/tests/test_server_direct.py
+++ b/clio-kit-mcp-servers/jarvis/tests/test_server_direct.py
@@ -1256,7 +1256,7 @@ class TestPipelineToolsDirect:
         pkg_file = pkg_dir / "pkg.py"
         pkg_file.write_text('"""Demo."""\n')
         with patch(
-            "jarvis_mcp.server._package_agent_metadata",
+            "jarvis_mcp.package_discovery._package_agent_metadata",
             return_value=_PackageAgentMetadata(
                 settings=[{"name": "x"}],
                 deployment=None,
@@ -1307,7 +1307,7 @@ class TestPipelineToolsDirect:
         with (
             patch("jarvis_mcp.server.get_manager", return_value=manager),
             patch(
-                "jarvis_mcp.server._package_agent_metadata",
+                "jarvis_mcp.package_discovery._package_agent_metadata",
                 return_value=_PackageAgentMetadata(settings=None, deployment=None),
             ),
         ):
@@ -1354,7 +1354,7 @@ class TestPipelineToolsDirect:
         with (
             patch("jarvis_mcp.server.get_manager", return_value=manager),
             patch(
-                "jarvis_mcp.server._package_agent_metadata",
+                "jarvis_mcp.package_discovery._package_agent_metadata",
                 return_value=_PackageAgentMetadata(settings=None, deployment=None),
             ),
         ):

--- a/clio-kit-mcp-servers/lmod/server.json
+++ b/clio-kit-mcp-servers/lmod/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.2",
+      "version": "2.8.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/ndp/server.json
+++ b/clio-kit-mcp-servers/ndp/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.2",
+      "version": "2.8.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/node-hardware/server.json
+++ b/clio-kit-mcp-servers/node-hardware/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.2",
+      "version": "2.8.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/pandas/server.json
+++ b/clio-kit-mcp-servers/pandas/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.2",
+      "version": "2.8.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/parallel-sort/server.json
+++ b/clio-kit-mcp-servers/parallel-sort/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.2",
+      "version": "2.8.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/paraview/server.json
+++ b/clio-kit-mcp-servers/paraview/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.2",
+      "version": "2.8.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/parquet/server.json
+++ b/clio-kit-mcp-servers/parquet/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.2",
+      "version": "2.8.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/plot/server.json
+++ b/clio-kit-mcp-servers/plot/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.2",
+      "version": "2.8.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/sac/server.json
+++ b/clio-kit-mcp-servers/sac/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.2",
+      "version": "2.8.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/scientific-catalog/server.json
+++ b/clio-kit-mcp-servers/scientific-catalog/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.2",
+      "version": "2.8.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/seismic/server.json
+++ b/clio-kit-mcp-servers/seismic/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.2",
+      "version": "2.8.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/slurm/server.json
+++ b/clio-kit-mcp-servers/slurm/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.2",
+      "version": "2.8.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/spack/server.json
+++ b/clio-kit-mcp-servers/spack/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.2",
+      "version": "2.8.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/terrain/server.json
+++ b/clio-kit-mcp-servers/terrain/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.2",
+      "version": "2.8.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/web/.claude-plugin/plugin.json
+++ b/clio-kit-mcp-servers/web/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "clio-web",
   "description": "Web MCP server providing curated fetch + search tools for agentic web access",
-  "version": "1.0.0"
+  "version": "1.1.0"
 }

--- a/clio-kit-mcp-servers/web/README.md
+++ b/clio-kit-mcp-servers/web/README.md
@@ -38,9 +38,14 @@ Query a configurable web-search provider and return ranked results.
   `search` and gets back a small list of `{title, url, snippet}` rows to triage
   and then `fetch`.
 - **Providers:** keyless **DuckDuckGo** (`ddg`, default, via the `ddgs`
-  package); optional BYO-key **Brave** and **Tavily**. Selecting a keyed
-  provider without its key raises a typed error naming the missing config — it
-  never silently falls back to `ddg`.
+  package); self-hosted **SearXNG** (`searxng`); optional BYO-key **Brave** and
+  **Tavily**. Selecting an unconfigured provider raises a typed error naming
+  the missing config — it never silently falls back to `ddg`.
+- **SearXNG selectors:** `category` (`general` / `science` / `it`), exact
+  `engines`, `language`, `time_range`, `pageno`, and `safesearch`. These are
+  rejected for other providers instead of being silently discarded. An exact
+  `engines` list takes precedence over `category`, because SearXNG otherwise
+  treats the two selectors as a broader union.
 - **Returns:** `{ok, provider, query, results: [{title, url, snippet}], count}`.
 
 ## Configuration
@@ -51,7 +56,8 @@ recommended path is a single source of config with clear defaults.
 
 | Field | Env var | Default | Meaning |
 | --- | --- | --- | --- |
-| `search_provider` | `WEB_SEARCH_PROVIDER` | `"ddg"` | Active search provider (`ddg` / `brave` / `tavily`). |
+| `search_provider` | `WEB_SEARCH_PROVIDER` | `"ddg"` | Active search provider (`ddg` / `searxng` / `brave` / `tavily`). |
+| `searxng_base_url` | `WEB_SEARXNG_BASE_URL` | `None` | Root URL of the self-hosted SearXNG instance (required for `searxng`). |
 | `brave_api_key` | `WEB_BRAVE_API_KEY` | `None` | Brave Search API key (required for `brave`). |
 | `tavily_api_key` | `WEB_TAVILY_API_KEY` | `None` | Tavily API key (required for `tavily`). |
 | `max_bytes` | `WEB_MAX_BYTES` | `5242880` | Fetch size cap in bytes (5 MiB). |
@@ -85,3 +91,15 @@ Real-network checks are opt-in and skipped by default:
 ```bash
 WEB_MCP_LIVE=1 uv run pytest -m integration
 ```
+
+To make the self-hosted instance the active backend:
+
+```bash
+WEB_SEARCH_PROVIDER=searxng \
+WEB_SEARXNG_BASE_URL=http://10.0.0.102:8088 \
+uv run web-mcp
+```
+
+No paid-provider credential is needed for SearXNG. The server forwards native
+selectors to the deployment and returns `engines_answered` plus normalized
+`unresponsive_engines` alongside the stable `{title, url, snippet}` rows.

--- a/clio-kit-mcp-servers/web/docs/web_tools.md
+++ b/clio-kit-mcp-servers/web/docs/web_tools.md
@@ -21,14 +21,26 @@ inline `content`, or — with `to_file=True` — writes it under the artifacts r
 - **`(url, prompt)` extraction** is the agent's job (an MCP server has no model access): use
   `to_file=True` and pipe the saved file through the agent's own model.
 
-## `search(query, *, provider=None, count=5)`
+## `search(query, *, provider=None, count=5, category=None, engines=None, language=None, time_range=None, pageno=None, safesearch=None)`
 
-Search via a configurable provider. Keyless **DuckDuckGo** (`ddg`) by default; BYO-key **Brave**
-(`WEB_BRAVE_API_KEY`) / **Tavily** (`WEB_TAVILY_API_KEY`). Selecting a keyed provider without its
-key is a typed error — never a silent fallback to `ddg`. `count` is capped at 25. Returns
+Search via a configurable provider. Keyless **DuckDuckGo** (`ddg`) is the default;
+self-hosted **SearXNG** (`searxng`) uses `WEB_SEARXNG_BASE_URL`; optional **Brave**
+and **Tavily** retain their BYO-key configuration. Selecting an unconfigured provider is a
+typed error — never a silent fallback to `ddg`. `count` is capped at 25. Returns
 `{title, url, snippet}` results.
+
+SearXNG accepts native `category` (`general`, `science`, or `it`), exact `engines`,
+`language`, `time_range` (`day`, `month`, or `year`), `pageno` (1 through 3), and
+`safesearch` (0 through 2) selectors. Its response also includes `engines_answered` and
+normalized `unresponsive_engines`. An explicit `engines` list takes precedence over
+`category`, avoiding SearXNG's broader union of both selectors. Passing these selectors to
+another provider is an error.
 
 ## Configuration (`WEB_`-prefixed env or a `.env`)
 
-`WEB_SEARCH_PROVIDER`, `WEB_BRAVE_API_KEY`, `WEB_TAVILY_API_KEY`, `WEB_MAX_BYTES`,
-`WEB_CONNECT_TIMEOUT_S`, `WEB_READ_TIMEOUT_S`, `WEB_ARTIFACTS_ROOT`, `WEB_ALLOW_PRIVATE_HOSTS`.
+`WEB_SEARCH_PROVIDER`, `WEB_SEARXNG_BASE_URL`, `WEB_BRAVE_API_KEY`, `WEB_TAVILY_API_KEY`,
+`WEB_MAX_BYTES`, `WEB_CONNECT_TIMEOUT_S`, `WEB_READ_TIMEOUT_S`, `WEB_ARTIFACTS_ROOT`,
+`WEB_ALLOW_PRIVATE_HOSTS`.
+
+For the LAN deployment, set `WEB_SEARCH_PROVIDER=searxng` and
+`WEB_SEARXNG_BASE_URL=http://10.0.0.102:8088`. No paid-provider credential is required.

--- a/clio-kit-mcp-servers/web/pyproject.toml
+++ b/clio-kit-mcp-servers/web/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "web-mcp"
-version = "1.0.0"
+version = "1.1.0"
 description = "Web MCP server providing curated fetch + search tools for agentic web access"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/clio-kit-mcp-servers/web/server.json
+++ b/clio-kit-mcp-servers/web/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.iowarp/web-mcp",
   "title": "CLIO Web",
   "description": "Web MCP server providing curated fetch + search tools for agentic web access",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "repository": {
     "url": "https://github.com/iowarp/clio-kit",
     "source": "github"
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.7.2",
+      "version": "2.8.0",
       "transport": {
         "type": "stdio"
       },
@@ -35,7 +35,7 @@
     },
     {
       "name": "search",
-      "description": "Search the web via a configurable provider (keyless DuckDuckGo by default; optional BYO-key Brave or Tavily) and return ranked results."
+      "description": "Search the web via a configurable provider (keyless DuckDuckGo by default; self-hosted SearXNG; optional BYO-key Brave or Tavily) and return ranked results. SearXNG supports category, engine, language, time-range, page, and safe-search selectors."
     }
   ],
   "resources": [

--- a/clio-kit-mcp-servers/web/src/web_mcp/__init__.py
+++ b/clio-kit-mcp-servers/web/src/web_mcp/__init__.py
@@ -9,4 +9,4 @@ It is the seed of CLIO's web tooling and the test instrument for the sandbox
 campaign's egress recording.
 """
 
-__version__ = "1.0.0"
+__version__ = "1.1.0"

--- a/clio-kit-mcp-servers/web/src/web_mcp/searxng.py
+++ b/clio-kit-mcp-servers/web/src/web_mcp/searxng.py
@@ -1,0 +1,125 @@
+"""Self-hosted SearXNG JSON API adapter for the web MCP server."""
+
+from __future__ import annotations
+
+from typing import Any
+from urllib.parse import urlparse
+
+import httpx
+from fastmcp.exceptions import ToolError
+
+
+def _search_endpoint(base_url: str | None) -> str:
+    """Return the configured SearXNG search endpoint or raise a typed error."""
+    value = (base_url or "").strip()
+    parsed = urlparse(value)
+    if not value:
+        raise ToolError(
+            "search provider 'searxng' requires its deployment URL. "
+            "Set WEB_SEARXNG_BASE_URL (Settings.searxng_base_url)."
+        )
+    if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+        raise ToolError(f"WEB_SEARXNG_BASE_URL must be an absolute http(s) URL; got {value!r}.")
+    if parsed.query or parsed.fragment:
+        raise ToolError("WEB_SEARXNG_BASE_URL must not contain a query string or fragment.")
+    return f"{value.rstrip('/')}/search"
+
+
+def _normalize_unresponsive_engines(value: Any) -> list[dict[str, str]]:
+    """Normalize SearXNG's ``[engine, reason]`` pairs for MCP callers."""
+    if not isinstance(value, list):
+        return []
+    normalized: list[dict[str, str]] = []
+    for item in value:
+        if isinstance(item, (list, tuple)) and len(item) >= 2:
+            normalized.append({"engine": str(item[0]), "reason": str(item[1])})
+        elif isinstance(item, dict) and item.get("engine"):
+            normalized.append(
+                {
+                    "engine": str(item["engine"]),
+                    "reason": str(item.get("reason") or "unknown"),
+                }
+            )
+    return normalized
+
+
+async def search_searxng(
+    query: str,
+    count: int,
+    *,
+    base_url: str | None,
+    connect_timeout_s: float,
+    read_timeout_s: float,
+    category: str | None,
+    engines: list[str] | None,
+    language: str | None,
+    time_range: str | None,
+    pageno: int,
+    safesearch: int | None,
+) -> tuple[list[dict[str, str]], list[str], list[dict[str, str]]]:
+    """Search a configured self-hosted SearXNG instance via its JSON API."""
+    endpoint = _search_endpoint(base_url)
+    params: dict[str, str | int] = {"q": query, "format": "json"}
+    selected_engines = [name.strip() for name in engines or [] if name.strip()]
+    if selected_engines:
+        params["engines"] = ",".join(selected_engines)
+    elif category:
+        params["categories"] = category
+    if language and language.strip():
+        params["language"] = language.strip()
+    if time_range:
+        params["time_range"] = time_range
+    params["pageno"] = pageno
+    if safesearch is not None:
+        params["safesearch"] = safesearch
+
+    timeout = httpx.Timeout(read_timeout_s, connect=connect_timeout_s)
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            response = await client.get(endpoint, params=params)
+    except httpx.HTTPError as exc:
+        raise ToolError(f"Could not query SearXNG at {endpoint}: {exc}") from exc
+
+    if response.status_code == 403:
+        raise ToolError(
+            "SearXNG returned HTTP 403 for its JSON API. Ensure 'json' is enabled "
+            "under search.formats in settings.yml."
+        )
+    try:
+        response.raise_for_status()
+    except httpx.HTTPStatusError as exc:
+        raise ToolError(
+            f"SearXNG search failed with HTTP {response.status_code} at {endpoint}."
+        ) from exc
+    try:
+        payload = response.json()
+    except ValueError as exc:
+        raise ToolError(
+            "SearXNG did not return JSON. Ensure the JSON format is enabled and "
+            "WEB_SEARXNG_BASE_URL points to the instance root."
+        ) from exc
+    if not isinstance(payload, dict) or not isinstance(payload.get("results"), list):
+        raise ToolError("SearXNG returned malformed JSON: expected a results list.")
+
+    results: list[dict[str, str]] = []
+    engines_answered: set[str] = set()
+    for item in payload["results"]:
+        if not isinstance(item, dict):
+            continue
+        item_engines = item.get("engines")
+        if isinstance(item_engines, list):
+            engines_answered.update(str(name) for name in item_engines if name)
+        elif item.get("engine"):
+            engines_answered.add(str(item["engine"]))
+        results.append(
+            {
+                "title": str(item.get("title") or ""),
+                "url": str(item.get("url") or ""),
+                "snippet": str(item.get("content") or item.get("snippet") or ""),
+            }
+        )
+        if len(results) >= count:
+            break
+
+    unresponsive = _normalize_unresponsive_engines(payload.get("unresponsive_engines"))
+    return results, sorted(engines_answered), unresponsive

--- a/clio-kit-mcp-servers/web/src/web_mcp/server.py
+++ b/clio-kit-mcp-servers/web/src/web_mcp/server.py
@@ -6,7 +6,7 @@ This is a proper v1 web-tooling surface for CLIO. Two tools are exposed:
   convert HTML to Markdown (trafilatura -> readability -> plain-text strip),
   and either return the content inline or write it to a local file.
 * ``search`` -- query a configurable web-search provider (keyless DuckDuckGo by
-  default, optional BYO-key Brave / Tavily).
+  default, self-hosted SearXNG, or optional BYO-key Brave / Tavily).
 
 Documented extension points (NOT implemented in v1 -- honest, typed gaps, never
 a silent fallback):
@@ -27,7 +27,7 @@ import ipaddress
 import os
 import re
 from pathlib import Path
-from typing import Annotated, Any
+from typing import Annotated, Any, Literal
 from urllib.parse import urlparse
 
 import httpx
@@ -39,6 +39,8 @@ from fastmcp.prompts import Message
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from readability import Document as ReadabilityDocument
+
+from web_mcp.searxng import search_searxng
 
 # Environment setup
 load_dotenv()
@@ -61,8 +63,10 @@ class Settings(BaseSettings):
     model_config = SettingsConfigDict(env_prefix="WEB_", env_file=".env", extra="ignore")
 
     # Search provider selection. Keyless "ddg" is the default so search works
-    # out of the box; "brave"/"tavily" are opt-in and require their own key.
+    # out of the box; self-hosted "searxng" requires its deployment URL, while
+    # "brave"/"tavily" are opt-in and require their own key.
     search_provider: str = "ddg"
+    searxng_base_url: str | None = None
     brave_api_key: str | None = None
     tavily_api_key: str | None = None
 
@@ -650,18 +654,38 @@ async def _search_tavily(query: str, count: int) -> list[dict[str, str]]:
     title="Search Web",
     description=(
         "Search the web via a configurable provider (keyless DuckDuckGo by "
-        "default; optional BYO-key Brave or Tavily) and return ranked results."
+        "default; self-hosted SearXNG; optional BYO-key Brave or Tavily) and "
+        "return ranked results. SearXNG supports category, engine, language, "
+        "time-range, page, and safe-search selectors."
     ),
     annotations={"readOnlyHint": True, "destructiveHint": False, "idempotentHint": False},
     tags={"web", "search"},
 )
 async def search(
     query: Annotated[str, Field(description="The search query.")],
-    provider: Annotated[
-        str | None,
-        Field(description="Override the configured provider: 'ddg', 'brave', or 'tavily'."),
-    ] = None,
+    provider: Annotated[str | None, Field(description="Search provider override.")] = None,
     count: Annotated[int, Field(description="Maximum number of results to return.")] = 5,
+    category: Annotated[
+        Literal["general", "science", "it"] | None,
+        Field(description="SearXNG category: general, science, or it."),
+    ] = None,
+    engines: Annotated[
+        list[str] | None,
+        Field(description="Exact SearXNG engines; takes precedence over category."),
+    ] = None,
+    language: Annotated[str | None, Field(description="SearXNG result language.")] = None,
+    time_range: Annotated[
+        Literal["day", "month", "year"] | None,
+        Field(description="SearXNG recency: day, month, or year."),
+    ] = None,
+    pageno: Annotated[
+        int | None,
+        Field(description="SearXNG-only result page, 1 through 3.", ge=1, le=3),
+    ] = None,
+    safesearch: Annotated[
+        int | None,
+        Field(description="SearXNG safe-search level, 0 through 2.", ge=0, le=2),
+    ] = None,
 ) -> dict[str, Any]:
     """Search the web and return ``{title, url, snippet}`` results.
 
@@ -674,25 +698,60 @@ async def search(
         raise ToolError("A non-empty query is required.")
     effective_count = min(count if count and count > 0 else 5, _MAX_SEARCH_COUNT)
     selected = (provider or settings.search_provider or "ddg").lower()
+    has_searxng_selectors = any(
+        (
+            category is not None,
+            bool(engines),
+            bool(language and language.strip()),
+            time_range is not None,
+            pageno is not None,
+            safesearch is not None,
+        )
+    )
+    if selected != "searxng" and has_searxng_selectors:
+        raise ToolError(
+            "category, engines, language, time_range, pageno, and safesearch are "
+            "only supported by provider 'searxng'."
+        )
 
+    engines_answered: list[str] = []
+    unresponsive_engines: list[dict[str, str]] = []
     if selected == "ddg":
         results = await _search_ddg(text, effective_count)
     elif selected == "brave":
         results = await _search_brave(text, effective_count)
     elif selected == "tavily":
         results = await _search_tavily(text, effective_count)
+    elif selected == "searxng":
+        results, engines_answered, unresponsive_engines = await search_searxng(
+            text,
+            effective_count,
+            base_url=settings.searxng_base_url,
+            connect_timeout_s=settings.connect_timeout_s,
+            read_timeout_s=settings.read_timeout_s,
+            category=category,
+            engines=engines,
+            language=language,
+            time_range=time_range,
+            pageno=pageno or 1,
+            safesearch=safesearch,
+        )
     else:
         raise ToolError(
-            f"Unknown search provider {selected!r}. Supported: 'ddg', 'brave', 'tavily'."
+            f"Unknown search provider {selected!r}. Supported: 'ddg', 'searxng', 'brave', 'tavily'."
         )
 
-    return {
+    response: dict[str, Any] = {
         "ok": True,
         "provider": selected,
         "query": text,
         "results": results,
         "count": len(results),
     }
+    if selected == "searxng":
+        response["engines_answered"] = engines_answered
+        response["unresponsive_engines"] = unresponsive_engines
+    return response
 
 
 @mcp.resource("web://providers")
@@ -700,8 +759,9 @@ def search_providers() -> dict[str, Any]:
     """The active + available web-search providers and current fetch limits."""
     return {
         "active_provider": settings.search_provider,
-        "available_providers": ["ddg", "brave", "tavily"],
+        "available_providers": ["ddg", "searxng", "brave", "tavily"],
         "keyless_default": "ddg",
+        "searxng_configured": bool((settings.searxng_base_url or "").strip()),
         "max_bytes": settings.max_bytes,
         "allow_private_hosts": settings.allow_private_hosts,
     }

--- a/clio-kit-mcp-servers/web/tests/test_init.py
+++ b/clio-kit-mcp-servers/web/tests/test_init.py
@@ -18,7 +18,7 @@ class TestPackageMetadata:
 
     def test_version_value(self):
         """Test that version has expected value."""
-        assert web_mcp.__version__ == "1.0.0"
+        assert web_mcp.__version__ == "1.1.0"
 
     def test_docstring_exists(self):
         """Test that package has a docstring."""

--- a/clio-kit-mcp-servers/web/tests/test_integration.py
+++ b/clio-kit-mcp-servers/web/tests/test_integration.py
@@ -13,11 +13,13 @@ import os
 import pytest
 from fastmcp import Client
 
-from web_mcp.server import mcp
+from web_mcp import server
+from web_mcp.server import Settings, mcp
 
 from .helpers import parse_result
 
 _LIVE = os.getenv("WEB_MCP_LIVE") == "1"
+_SEARXNG_URL = os.getenv("WEB_SEARXNG_BASE_URL")
 
 pytestmark = [
     pytest.mark.integration,
@@ -44,3 +46,36 @@ async def test_live_search_ddg() -> None:
     data = parse_result(result)
     assert data["ok"] is True
     assert data["provider"] == "ddg"
+
+
+@pytest.mark.skipif(
+    not _SEARXNG_URL,
+    reason="set WEB_SEARXNG_BASE_URL to run the live SearXNG integration test",
+)
+@pytest.mark.asyncio
+async def test_live_search_searxng(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Exercise category and engine selectors against the deployed instance."""
+    monkeypatch.setattr(
+        server,
+        "settings",
+        Settings(search_provider="searxng", searxng_base_url=_SEARXNG_URL),
+    )
+    async with Client(mcp) as client:
+        result = await client.call_tool(
+            "search",
+            {
+                "query": "parallel I/O",
+                "count": 3,
+                "category": "science",
+                "engines": ["arxiv", "crossref"],
+                "language": "en",
+                "safesearch": 0,
+            },
+        )
+    data = parse_result(result)
+    assert data["ok"] is True
+    assert data["provider"] == "searxng"
+    assert data["count"] > 0
+    assert data["results"]
+    assert "engines_answered" in data
+    assert "unresponsive_engines" in data

--- a/clio-kit-mcp-servers/web/tests/test_registration.py
+++ b/clio-kit-mcp-servers/web/tests/test_registration.py
@@ -7,7 +7,8 @@ import json
 import pytest
 from fastmcp import Client
 
-from web_mcp.server import mcp
+from web_mcp import server
+from web_mcp.server import Settings, mcp
 
 
 @pytest.mark.asyncio
@@ -28,3 +29,26 @@ async def test_providers_resource_reports_active_backend() -> None:
     payload = json.loads(result[0].text)  # resource contents expose .text (JSON)
     assert payload["active_provider"] == "ddg"  # keyless default
     assert "brave" in payload["available_providers"] and "tavily" in payload["available_providers"]
+    assert "searxng" in payload["available_providers"]
+    assert payload["searxng_configured"] is False
+
+
+@pytest.mark.asyncio
+async def test_providers_resource_reports_configured_searxng(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Discovery reports SearXNG readiness without exposing its deployment URL."""
+    monkeypatch.setattr(
+        server,
+        "settings",
+        Settings(
+            search_provider="searxng",
+            searxng_base_url="http://10.0.0.102:8088",
+        ),
+    )
+    async with Client(mcp) as client:
+        result = await client.read_resource("web://providers")
+    payload = json.loads(result[0].text)
+    assert payload["active_provider"] == "searxng"
+    assert payload["searxng_configured"] is True
+    assert "10.0.0.102" not in result[0].text

--- a/clio-kit-mcp-servers/web/tests/test_search.py
+++ b/clio-kit-mcp-servers/web/tests/test_search.py
@@ -132,6 +132,122 @@ async def test_search_tavily_without_key_raises(monkeypatch: pytest.MonkeyPatch)
 
 
 @pytest.mark.asyncio
+async def test_search_searxng_maps_results_and_native_selectors(
+    monkeypatch: pytest.MonkeyPatch, httpx_mock: HTTPXMock
+) -> None:
+    """SearXNG receives native selectors and exposes engine provenance."""
+    monkeypatch.setattr(
+        server,
+        "settings",
+        Settings(search_provider="searxng", searxng_base_url="http://10.0.0.102:8088"),
+    )
+    httpx_mock.add_response(
+        url=(
+            "http://10.0.0.102:8088/search?q=parallel+io&format=json"
+            "&engines=arxiv%2Ccrossref&language=en"
+            "&time_range=year&pageno=2&safesearch=0"
+        ),
+        json={
+            "results": [
+                {
+                    "title": "Parallel I/O Paper",
+                    "url": "https://example.org/paper",
+                    "content": "A scientific result.",
+                    "engines": ["arxiv", "crossref"],
+                },
+                {
+                    "title": "Second Result",
+                    "url": "https://example.org/second",
+                    "content": "Not returned because count is one.",
+                    "engine": "arxiv",
+                },
+            ],
+            "unresponsive_engines": [["semantic scholar", "timeout"]],
+        },
+    )
+
+    async with Client(mcp) as client:
+        result = await client.call_tool(
+            "search",
+            {
+                "query": "parallel io",
+                "count": 1,
+                "category": "science",
+                "engines": ["arxiv", "crossref"],
+                "language": "en",
+                "time_range": "year",
+                "pageno": 2,
+                "safesearch": 0,
+            },
+        )
+    data = parse_result(result)
+
+    assert data["provider"] == "searxng"
+    assert data["count"] == 1
+    assert data["results"] == [
+        {
+            "title": "Parallel I/O Paper",
+            "url": "https://example.org/paper",
+            "snippet": "A scientific result.",
+        }
+    ]
+    assert data["engines_answered"] == ["arxiv", "crossref"]
+    assert data["unresponsive_engines"] == [{"engine": "semantic scholar", "reason": "timeout"}]
+
+
+@pytest.mark.asyncio
+async def test_search_searxng_requires_base_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Selecting SearXNG without its deployment URL fails explicitly."""
+    monkeypatch.setattr(server, "settings", Settings(search_provider="searxng"))
+    async with Client(mcp) as client:
+        with pytest.raises(Exception) as excinfo:
+            await client.call_tool("search", {"query": "anything"})
+    assert "WEB_SEARXNG_BASE_URL" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_search_searxng_reports_disabled_json(
+    monkeypatch: pytest.MonkeyPatch, httpx_mock: HTTPXMock
+) -> None:
+    """A 403 identifies the disabled SearXNG JSON API instead of falling back."""
+    monkeypatch.setattr(
+        server,
+        "settings",
+        Settings(search_provider="searxng", searxng_base_url="http://10.0.0.102:8088"),
+    )
+    httpx_mock.add_response(status_code=403)
+    async with Client(mcp) as client:
+        with pytest.raises(Exception) as excinfo:
+            await client.call_tool("search", {"query": "anything"})
+    assert "JSON" in str(excinfo.value)
+    assert "403" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("provider", ["ddg", "brave", "tavily"])
+@pytest.mark.parametrize(
+    "selector",
+    [
+        {"category": "science"},
+        {"engines": ["arxiv"]},
+        {"language": "en"},
+        {"time_range": "year"},
+        {"pageno": 1},
+        {"safesearch": 0},
+    ],
+)
+async def test_searxng_selectors_rejected_for_other_providers(
+    monkeypatch: pytest.MonkeyPatch, provider: str, selector: dict[str, Any]
+) -> None:
+    """Provider-specific selectors are never silently discarded."""
+    monkeypatch.setattr(server, "settings", Settings(search_provider=provider))
+    async with Client(mcp) as client:
+        with pytest.raises(Exception) as excinfo:
+            await client.call_tool("search", {"query": "x", **selector})
+    assert "only supported by provider 'searxng'" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
 async def test_search_provider_override_beats_config(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/clio-kit-mcp-servers/web/tests/test_searxng.py
+++ b/clio-kit-mcp-servers/web/tests/test_searxng.py
@@ -1,0 +1,120 @@
+"""Focused unit coverage for the self-hosted SearXNG adapter."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+from fastmcp.exceptions import ToolError
+from pytest_httpx import HTTPXMock
+
+from web_mcp.searxng import (
+    _normalize_unresponsive_engines,
+    _search_endpoint,
+    search_searxng,
+)
+
+
+async def _search(
+    *, category: str | None = None
+) -> tuple[list[dict[str, str]], list[str], list[dict[str, str]]]:
+    """Call the adapter with deterministic defaults."""
+    return await search_searxng(
+        "query",
+        3,
+        base_url="http://10.0.0.102:8088",
+        connect_timeout_s=1.0,
+        read_timeout_s=2.0,
+        category=category,
+        engines=None,
+        language=None,
+        time_range=None,
+        pageno=1,
+        safesearch=None,
+    )
+
+
+@pytest.mark.parametrize(
+    ("url", "message"),
+    [
+        ("not-a-url", r"absolute http\(s\) URL"),
+        ("http://10.0.0.102:8088?bad=1", "query string or fragment"),
+    ],
+)
+def test_search_endpoint_rejects_invalid_roots(url: str, message: str) -> None:
+    """The configured root must be an absolute URL without query state."""
+    with pytest.raises(ToolError, match=message):
+        _search_endpoint(url)
+
+
+def test_normalize_unresponsive_engines_handles_dicts_and_other_values() -> None:
+    """Dict-form failures are normalized and non-list payloads are ignored."""
+    assert _normalize_unresponsive_engines(None) == []
+    assert _normalize_unresponsive_engines(
+        [{"engine": "arxiv"}, {"engine": "crossref", "reason": "timeout"}, {}]
+    ) == [
+        {"engine": "arxiv", "reason": "unknown"},
+        {"engine": "crossref", "reason": "timeout"},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_search_category_maps_single_engine_and_skips_invalid_rows(
+    httpx_mock: HTTPXMock,
+) -> None:
+    """Category-only calls are forwarded and alternate result fields are mapped."""
+    httpx_mock.add_response(
+        url=("http://10.0.0.102:8088/search?q=query&format=json&categories=it&pageno=1"),
+        json={
+            "results": [
+                "invalid",
+                {
+                    "title": "Repository",
+                    "url": "https://github.com/iowarp/clio-agent",
+                    "snippet": "Fallback snippet.",
+                    "engine": "github",
+                },
+            ]
+        },
+    )
+    results, engines, unresponsive = await _search(category="it")
+    assert results == [
+        {
+            "title": "Repository",
+            "url": "https://github.com/iowarp/clio-agent",
+            "snippet": "Fallback snippet.",
+        }
+    ]
+    assert engines == ["github"]
+    assert unresponsive == []
+
+
+@pytest.mark.asyncio
+async def test_search_reports_transport_failure(httpx_mock: HTTPXMock) -> None:
+    """Connection failures become typed SearXNG errors."""
+    httpx_mock.add_exception(httpx.ConnectError("offline"))
+    with pytest.raises(ToolError, match="Could not query SearXNG"):
+        await _search()
+
+
+@pytest.mark.asyncio
+async def test_search_reports_non_403_http_failure(httpx_mock: HTTPXMock) -> None:
+    """Non-403 HTTP failures retain the status code in a typed error."""
+    httpx_mock.add_response(status_code=500)
+    with pytest.raises(ToolError, match="HTTP 500"):
+        await _search()
+
+
+@pytest.mark.asyncio
+async def test_search_reports_non_json_response(httpx_mock: HTTPXMock) -> None:
+    """HTML or text responses cannot masquerade as a successful search."""
+    httpx_mock.add_response(text="not json", headers={"content-type": "text/plain"})
+    with pytest.raises(ToolError, match="did not return JSON"):
+        await _search()
+
+
+@pytest.mark.asyncio
+async def test_search_reports_malformed_json(httpx_mock: HTTPXMock) -> None:
+    """JSON without a result list is rejected explicitly."""
+    httpx_mock.add_response(json={"results": {}})
+    with pytest.raises(ToolError, match="malformed JSON"):
+        await _search()

--- a/clio-kit-mcp-servers/web/tests/test_settings.py
+++ b/clio-kit-mcp-servers/web/tests/test_settings.py
@@ -18,6 +18,7 @@ class TestSettingsDefaults:
         cfg = Settings()
         assert cfg.brave_api_key is None
         assert cfg.tavily_api_key is None
+        assert cfg.searxng_base_url is None
 
     def test_default_max_bytes_is_5_mib(self):
         cfg = Settings()
@@ -40,6 +41,7 @@ class TestSettingsOverride:
         cfg = Settings(
             search_provider="brave",
             brave_api_key="secret",
+            searxng_base_url="http://10.0.0.102:8088",
             max_bytes=123,
             connect_timeout_s=1.5,
             read_timeout_s=9.0,
@@ -47,6 +49,7 @@ class TestSettingsOverride:
         )
         assert cfg.search_provider == "brave"
         assert cfg.brave_api_key == "secret"
+        assert cfg.searxng_base_url == "http://10.0.0.102:8088"
         assert cfg.max_bytes == 123
         assert cfg.connect_timeout_s == 1.5
         assert cfg.read_timeout_s == 9.0
@@ -54,7 +57,9 @@ class TestSettingsOverride:
 
     def test_override_via_env_prefix(self, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.setenv("WEB_SEARCH_PROVIDER", "tavily")
+        monkeypatch.setenv("WEB_SEARXNG_BASE_URL", "http://10.0.0.102:8088")
         monkeypatch.setenv("WEB_MAX_BYTES", "2048")
         cfg = Settings()
         assert cfg.search_provider == "tavily"
+        assert cfg.searxng_base_url == "http://10.0.0.102:8088"
         assert cfg.max_bytes == 2048

--- a/clio-kit-mcp-servers/web/uv.lock
+++ b/clio-kit-mcp-servers/web/uv.lock
@@ -2895,7 +2895,7 @@ wheels = [
 
 [[package]]
 name = "web-mcp"
-version = "1.0.0"
+version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "ddgs" },

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "clio-kit",
-  "version": "2.7.2",
+  "version": "2.8.0",
   "mcpServers": {
     "clio-adios": {
       "command": "clio-kit",

--- a/mcp-server-versions.toml
+++ b/mcp-server-versions.toml
@@ -8,12 +8,12 @@ schema-version = 1
 # change, add it here WITH a real version bump under [servers] in the same
 # PR, then remove it again once published.
 [mcp-registry-release]
-publish = []
+publish = ["web"]
 
 # Generated website metadata must not depend on the wall clock. Advance this
 # date intentionally whenever current contract metadata is regenerated.
 [documentation]
-updated = "2026-07-22"
+updated = "2026-08-11"
 
 # MCP Registry server versions describe each agent-facing contract. They are
 # intentionally independent of the clio-kit PyPI distribution version, which
@@ -42,4 +42,4 @@ seismic = "2.2.3"
 slurm = "3.0.0"
 spack = "2.1.0"
 terrain = "2.2.3"
-web = "1.0.0"
+web = "1.1.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "clio-kit"
-version = "2.7.2"
+version = "2.8.0"
 description = "CLIO Kit - MCP Servers, Clients, and Tools for AI Agents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/scripts/check_baseline_diff.py
+++ b/scripts/check_baseline_diff.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""CI-only guard: catch same-commit ratchet-baseline inflation and rename laundering.
+
+``scripts/check_file_size.py``'s static checker can only see ONE commit's
+state -- the current ``RATCHET_BASELINE`` dict and the current file tree. It
+cannot see whether a baseline entry moved because a review-worthy growth
+happened. Two attacks slip past it silently (PR #364 review finding 4,
+round 2):
+
+1. Grow a file's line count AND bump its ``RATCHET_BASELINE`` entry to the
+   exact new value in the same commit -- the static checker sees an exact
+   match, not a change; nothing fails.
+2. Rename an oversized file to a fresh path and mint a brand-new baseline
+   entry at its current (grown) size -- the checker sees a "new" entry,
+   which only fails if it lands above the cap; a value at or under the cap
+   passes with zero history-aware signal, and the file's lineage (it used to
+   be smaller, under a different name) is gone.
+
+Neither is visible to a script that only ever reads one tree. This module
+closes both by comparing the embedded ``RATCHET_BASELINE`` dict between two
+versions of ``check_file_size.py`` -- in CI, the PR head and the merge-base
+with the target branch -- and reporting a violation for any entry that
+increased, or any brand-new entry above the cap. Decreases and removals are
+never violations (a file leaving the baseline, or shrinking, is exactly what
+the ratchet wants).
+
+This is deliberately a SEPARATE module from ``check_file_size.py``: the
+static checker stays a pure, single-tree, ref-independent check (usable
+locally with no git history at all); this module is PR-context-only (it
+needs two versions of the same file to diff) and is wired into CI as its own
+guard, not folded into the static checker's own logic.
+
+The cap a brand-new entry must stay under is read from ``DEFAULT_MAX_LINES``
+in the BASE (merge-base) file's source, never imported from
+``check_file_size.py`` live and never read from the head file (PR #364
+review, round 3): a PR controls its own head content, so a PR that raised
+its own ``DEFAULT_MAX_LINES`` alongside a brand-new over-cap baseline entry
+must not get to grade its own homework with its own inflated cap.
+
+If ``RATCHET_BASELINE`` did not exist at the base version at all (the target
+branch has never had this file -- i.e. this PR is introducing the ratchet
+system itself), there is no prior baseline to launder against; the CI step
+that invokes this script skips calling it entirely in that case (see
+``quality_control.yml``'s ``ratchet-baseline-diff-guard`` job), so this
+module never has to special-case a base file that legitimately doesn't
+exist -- ``base_file`` is always assumed to exist and parse correctly by the
+time ``main`` runs.
+
+Run as part of CI (PR-context only, blocking) or locally::
+
+    uv run python scripts/check_baseline_diff.py base_check_file_size.py scripts/check_file_size.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class BaselineViolation:
+    """One baseline entry that changed in a way the diff guard rejects."""
+
+    rel: str
+    kind: str  # "increased" | "new_over_cap"
+    base_value: int | None  # None for "new_over_cap" (no prior entry existed)
+    head_value: int
+
+
+class MissingConstantError(ValueError):
+    """A required top-level constant could not be found in checker source."""
+
+
+def extract_baseline(source: str) -> dict[str, int]:
+    """Parse the ``RATCHET_BASELINE`` dict literal out of checker source, safely.
+
+    Uses ``ast`` (parse + ``literal_eval``), never ``exec``/``import``, so
+    this is safe to run against untrusted historical file content. Raises
+    :class:`MissingConstantError` if no such assignment is found -- a
+    malformed edit, since the CI step never calls this for a base file that
+    legitimately doesn't exist (see the module docstring).
+    """
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.AnnAssign):
+            continue
+        target = node.target
+        if isinstance(target, ast.Name) and target.id == "RATCHET_BASELINE":
+            if node.value is None:
+                break
+            value = ast.literal_eval(node.value)
+            if not isinstance(value, dict):
+                break
+            return {str(k): int(v) for k, v in value.items()}
+    raise MissingConstantError(
+        "RATCHET_BASELINE: dict[str, int] = {...} assignment not found"
+    )
+
+
+def extract_default_max_lines(source: str) -> int:
+    """Parse ``DEFAULT_MAX_LINES = <int>`` out of checker source, safely.
+
+    Callers must pass the BASE (merge-base) file's source here, never the
+    head file's -- see the module docstring for why the cap must come from
+    history the PR itself cannot have edited.
+    """
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign):
+            continue
+        if any(
+            isinstance(target, ast.Name) and target.id == "DEFAULT_MAX_LINES"
+            for target in node.targets
+        ):
+            value = ast.literal_eval(node.value)
+            if isinstance(value, int):
+                return value
+    raise MissingConstantError("DEFAULT_MAX_LINES = <int> assignment not found")
+
+
+def diff_baselines(
+    base: dict[str, int], head: dict[str, int], *, cap: int
+) -> list[BaselineViolation]:
+    """Compare two baseline dicts and report every same-commit-inflation violation.
+
+    Args:
+        base: The baseline as it stood at the merge-base with the target branch.
+        head: The baseline as it stands at the PR head (or the tree under test).
+        cap: The line-count cap a brand-new entry must stay at or under. Callers
+            must derive this from the BASE side (see :func:`extract_default_max_lines`),
+            never from head -- there is no safe default here on purpose.
+
+    Returns:
+        One :class:`BaselineViolation` per offending entry, sorted by path.
+        An entry that decreased, was removed, or is new and at/under the cap
+        produces no violation.
+    """
+    violations: list[BaselineViolation] = []
+    for rel in sorted(head):
+        head_value = head[rel]
+        base_value = base.get(rel)
+        if base_value is None:
+            if head_value > cap:
+                violations.append(
+                    BaselineViolation(rel, "new_over_cap", None, head_value)
+                )
+            continue
+        if head_value > base_value:
+            violations.append(
+                BaselineViolation(rel, "increased", base_value, head_value)
+            )
+    return violations
+
+
+def _print_report(violations: list[BaselineViolation], cap: int) -> None:
+    if not violations:
+        print(
+            "OK: no RATCHET_BASELINE entry increased, and no new entry landed "
+            f"above the cap ({cap}), since the merge-base."
+        )
+        return
+    print(
+        f"FAIL: {len(violations)} RATCHET_BASELINE change(s) look like same-commit "
+        "inflation or rename laundering (#364 review finding 4):"
+    )
+    for violation in violations:
+        if violation.kind == "increased":
+            print(
+                f"  {violation.rel}: baseline raised {violation.base_value} -> "
+                f"{violation.head_value} in this PR. A baseline entry may only "
+                "ratchet down; if the file genuinely needs to be larger, that "
+                "growth needs its own reviewed justification, not a same-commit "
+                "bump to match."
+            )
+        else:
+            print(
+                f"  {violation.rel}: new RATCHET_BASELINE entry at "
+                f"{violation.head_value} lines, above the cap ({cap}). If this "
+                "path is a rename of a file that was already baselined, that "
+                "history is invisible to this diff -- split the file (or lower "
+                f"this entry to <= {cap} and drop it) instead of re-baselining "
+                "it under a new name."
+            )
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point. Return 0 if the diff guard holds, 1 on any violation."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "base_file", type=Path, help="check_file_size.py content at the merge-base"
+    )
+    parser.add_argument(
+        "head_file", type=Path, help="check_file_size.py content at the PR head"
+    )
+    parser.add_argument(
+        "--cap",
+        type=int,
+        default=None,
+        help=(
+            "Override the cap a brand-new entry must stay under. Defaults to "
+            "DEFAULT_MAX_LINES read from base_file (the merge-base version) -- "
+            "NEVER head_file -- so a PR cannot raise its own cap and bless its "
+            "own brand-new over-cap baseline entry."
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    base_source = args.base_file.read_text(encoding="utf-8")
+    head_source = args.head_file.read_text(encoding="utf-8")
+    base = extract_baseline(base_source)
+    head = extract_baseline(head_source)
+    cap = args.cap if args.cap is not None else extract_default_max_lines(base_source)
+    violations = diff_baselines(base, head, cap=cap)
+    _print_report(violations, cap)
+    return 1 if violations else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_file_size.py
+++ b/scripts/check_file_size.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python3
+"""Ratchet guard against god-files across clio-kit's packages.
+
+Ported from clio-agent's ``scripts/check_file_size.py`` (iowarp/clio-agent,
+#714/#767) for clio-kit campaign #362 ("server code health"), Slice 1, and
+then hardened past what that script enforces (PR #364 review finding 4):
+clio-agent's version treats a baseline sitting ABOVE a file's real line count
+as merely advisory (an "OK (ratchet down)" message, exit 0) -- which means a
+single commit can grow a file AND raise its baseline to match, banking unused
+headroom with zero build signal. This version does not tolerate that gap: a
+baseline entry must be an EXACT mirror of reality at all times.
+
+Walks every package's ``src/`` tree -- the root ``clio_kit`` package plus one
+per ``clio-kit-mcp-servers/<name>`` (any directory with a ``pyproject.toml``)
+plus ``clio-agentic-search`` -- and enforces a per-file line-count ratchet:
+
+* A file **not** in :data:`RATCHET_BASELINE` may not exceed
+  :data:`DEFAULT_MAX_LINES` -- a brand-new god-file fails the check.
+* A file **in** :data:`RATCHET_BASELINE` (a known-oversized module awaiting
+  decomposition) must match its recorded line count EXACTLY:
+
+  - Grow past it ("regressed") -- FAILS.
+  - Sit below it ("padded" -- the baseline claims more lines than the file
+    actually has, whether from an un-recorded shrink or a same-commit
+    baseline bump that outpaced the real growth) -- FAILS. There is no
+    advisory-only path here; every gram of ratchet headroom must be spent
+    the moment it's earned, never banked for later.
+  - A baseline entry pointing at a file that no longer exists ("stale") --
+    FAILS. A deleted or renamed file's old allowance must be removed in the
+    same change, so nothing can later resurrect at that path and inherit
+    unearned headroom.
+
+The baseline may only ratchet DOWN, and every entry must be live and exact.
+When a file shrinks, lower its :data:`RATCHET_BASELINE` number to match (or
+drop the entry once it falls under :data:`DEFAULT_MAX_LINES`) in the SAME
+change that shrank it -- the check fails until you do.
+
+Run as part of CI (blocking) and locally::
+
+    uv run python scripts/check_file_size.py
+    uv run python scripts/check_file_size.py --max 600
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import NamedTuple
+
+# Default maximum number of lines a single *non-baselined* source module may
+# contain. New files must stay under this cap.
+DEFAULT_MAX_LINES = 800
+
+# Per-file ratchet baseline: the known-oversized modules at their EXACT
+# current line counts (measured on campaign/362-kit-health, 2026-08-10/11),
+# recorded so they cannot regrow. These are the files awaiting further
+# decomposition (clio-kit campaign #362, Slice 1). Every entry must equal its
+# file's real line count at all times -- the check fails on any mismatch in
+# either direction (see the module docstring). Paths are relative to the
+# repository root and use forward slashes.
+RATCHET_BASELINE: dict[str, int] = {
+    # #362 wave 1: server.py's 44 model classes + package-discovery/search
+    # helpers moved to owner modules (jarvis_mcp/models/*, package_discovery.py),
+    # 3109 -> 1323, then +259 (PR #364 review findings 1/3: the contract pins'
+    # full tool-record capture plus the FULL backward-compatibility re-export
+    # surface -- every name importable from the pre-split server.py, not a
+    # hand-picked subset; see server.py's own header comment). The remaining
+    # size is the `@mcp.tool` registration surface for 30+ tools, the CLI
+    # entry points, and that compatibility re-export block; ratchets down
+    # with a further per-concern tool-registration split if one is ever
+    # justified (the re-export block would move with it).
+    "clio-kit-mcp-servers/jarvis/src/jarvis_mcp/server.py": 1582,
+    # #362 wave 1: NOT split this wave (deferred -- see the wave-1 PR
+    # description). Still the 6-class monolith measured at campaign kickoff.
+    # Next wave: split into owner modules by concern (pipeline lifecycle,
+    # execution/progress, artifacts) the same way server.py was split.
+    "clio-kit-mcp-servers/jarvis/src/jarvis_mcp/capabilities/jarvis_handler.py": 3521,
+    # #362: NOT split this wave -- out of wave-1 scope (jarvis-only). Flat
+    # FastMCP function surface, no god-class; still needs an owner-module cut.
+    "clio-kit-mcp-servers/hdf5/src/hdf5_mcp/server.py": 2415,
+    # #362: NOT split this wave -- out of wave-1 scope. Single
+    # VisualizationEngine god-class.
+    "clio-kit-mcp-servers/paraview/src/paraview_mcp/implementation/paraview_capabilities.py": 2202,
+    "clio-kit-mcp-servers/pandas/src/pandas_mcp/server.py": 1274,
+    "clio-kit-mcp-servers/paraview/src/paraview_mcp/server.py": 1091,
+    "clio-kit-mcp-servers/spack/src/spack_mcp/backend.py": 925,
+    # #362 (PR #364 review finding 5): discovery previously excluded the root
+    # `clio_kit` package (the `clio-kit` launcher CLI itself) entirely --
+    # these three were never scanned. Baselined at their measured counts, not
+    # split this wave.
+    "src/clio_kit/__init__.py": 958,
+    "src/clio_kit/mcp_contracts.py": 921,
+    "src/clio_kit/env_cache.py": 843,
+    "clio-kit-mcp-servers/darshan/src/darshan_mcp/capabilities/darshan_parser.py": 857,
+    "clio-kit-mcp-servers/parquet/src/parquet_mcp/capabilities/parquet_handler.py": 839,
+    "clio-kit-mcp-servers/node-hardware/src/node_hardware_mcp/mcp_handlers.py": 819,
+}
+
+# Directory holding every MCP server package (one subdirectory per server).
+MCP_SERVERS_ROOT = "clio-kit-mcp-servers"
+
+# Additional package roots outside clio-kit-mcp-servers, checked for a `src/`
+# tree the same way. clio-agentic-search is a standalone service (not an MCP
+# server) but is still a first-class package in this repo's code-health
+# scope; the repository root itself ships the `clio_kit` launcher package
+# (its own `pyproject.toml` + `src/clio_kit/`) and was previously the one
+# first-class package this scan silently skipped (PR #364 review finding 5).
+EXTRA_PACKAGE_ROOTS = (".", "clio-agentic-search")
+
+
+class Failure(NamedTuple):
+    """A file (or baseline entry) that breaks the ratchet (fails the check)."""
+
+    rel: str
+    line_count: int | None  # None only for "stale" -- the file does not exist
+    kind: str  # "new" | "regressed" | "padded" | "stale"
+    limit: int | None  # the cap/baseline it broke; None only for "new" with no baseline
+
+
+def _repo_root() -> Path:
+    """Return the repository root (parent of the ``scripts`` directory)."""
+    return Path(__file__).resolve().parent.parent
+
+
+def _count_lines(path: Path) -> int:
+    """Return the number of lines in ``path``."""
+    with path.open("r", encoding="utf-8", errors="replace") as handle:
+        return sum(1 for _ in handle)
+
+
+def _is_test_file(path: Path) -> bool:
+    """Return whether ``path`` is a test file (never ratchet-guarded)."""
+    parts = path.parts
+    if "tests" in parts or "test" in parts:
+        return True
+    return path.name.startswith("test_") or path.name.endswith("_test.py")
+
+
+def discover_package_src_roots(repo_root: Path) -> list[Path]:
+    """Discover every package's ``src/`` tree.
+
+    The repository root's own ``src/`` (the ``clio_kit`` launcher package,
+    if ``repo_root/pyproject.toml`` exists), one per
+    ``clio-kit-mcp-servers/<name>`` directory that has a ``pyproject.toml``
+    (mirroring ``.github/workflows/quality_control.yml``'s ``discover-mcps``
+    step, minus its Chronolog exclusion -- this is a code-health scan, not a
+    release gate, and Chronolog can grow a god-file same as any other
+    package), plus any other :data:`EXTRA_PACKAGE_ROOTS` that have a
+    ``src/`` tree of their own.
+    """
+    roots: list[Path] = []
+    for extra in EXTRA_PACKAGE_ROOTS:
+        pkg_dir = repo_root / extra
+        if not (pkg_dir / "pyproject.toml").is_file():
+            continue
+        src_dir = pkg_dir / "src"
+        if src_dir.is_dir():
+            roots.append(src_dir)
+    servers_dir = repo_root / MCP_SERVERS_ROOT
+    if servers_dir.is_dir():
+        for pkg_dir in sorted(servers_dir.iterdir()):
+            if not pkg_dir.is_dir() or not (pkg_dir / "pyproject.toml").is_file():
+                continue
+            src_dir = pkg_dir / "src"
+            if src_dir.is_dir():
+                roots.append(src_dir)
+    return roots
+
+
+def check_file_size(
+    scan_roots: list[Path],
+    *,
+    rel_to: Path,
+    max_lines: int = DEFAULT_MAX_LINES,
+    baseline: dict[str, int] | None = None,
+) -> list[Failure]:
+    """Evaluate the per-file line-count ratchet under every root in ``scan_roots``.
+
+    Args:
+        scan_roots: Directory trees to walk for ``*.py`` files (one per
+            package's ``src/`` directory).
+        rel_to: Base directory used to compute the forward-slash relative
+            path that keys into ``baseline`` (the repository root).
+        max_lines: Cap applied to files not present in ``baseline``.
+        baseline: Per-file EXACT recorded line counts. Defaults to
+            :data:`RATCHET_BASELINE`.
+
+    Returns:
+        Every offense: a brand-new god-file, a baselined file that grew past
+        its recorded count, a baselined file that no longer matches its
+        recorded count exactly (in either direction), or a baseline entry
+        whose file no longer exists. Empty means the ratchet holds.
+    """
+    if baseline is None:
+        baseline = RATCHET_BASELINE
+
+    failures: list[Failure] = []
+    seen: set[str] = set()
+    for scan_root in scan_roots:
+        for path in sorted(scan_root.rglob("*.py")):
+            if _is_test_file(path):
+                continue
+            rel = path.relative_to(rel_to).as_posix()
+            if rel in seen:
+                continue
+            seen.add(rel)
+            count = _count_lines(path)
+            recorded = baseline.get(rel)
+            if recorded is None:
+                if count > max_lines:
+                    failures.append(Failure(rel, count, "new", max_lines))
+                continue
+            if count > recorded:
+                failures.append(Failure(rel, count, "regressed", recorded))
+            elif count < recorded:
+                failures.append(Failure(rel, count, "padded", recorded))
+            # count == recorded: the baseline is exact -- no failure.
+
+    for rel, recorded in baseline.items():
+        if rel not in seen:
+            failures.append(Failure(rel, None, "stale", recorded))
+
+    return failures
+
+
+def _print_report(failures: list[Failure], max_lines: int) -> None:
+    """Print the ratchet report."""
+    if not failures:
+        print(
+            "OK: every ratchet baseline entry exactly matches its file's real "
+            f"line count, and no new file exceeds the cap ({max_lines})."
+        )
+        return
+
+    print(f"FAIL: {len(failures)} file(s) break the size ratchet (#362):")
+    for failure in failures:
+        if failure.kind == "new":
+            print(
+                f"  {failure.rel}:{failure.line_count} "
+                f"(new file exceeds cap {failure.limit})"
+            )
+        elif failure.kind == "regressed":
+            print(
+                f"  {failure.rel}:{failure.line_count} "
+                f"(regressed past recorded baseline {failure.limit})"
+            )
+        elif failure.kind == "padded":
+            assert failure.line_count is not None
+            if failure.line_count <= max_lines:
+                print(
+                    f"  {failure.rel}:{failure.line_count} (baseline claims "
+                    f"{failure.limit} but the file is only {failure.line_count} "
+                    f"lines, under the {max_lines} cap -- remove its "
+                    "RATCHET_BASELINE entry in scripts/check_file_size.py)"
+                )
+            else:
+                print(
+                    f"  {failure.rel}:{failure.line_count} (baseline claims "
+                    f"{failure.limit} but the file is only {failure.line_count} "
+                    f"lines -- lower its RATCHET_BASELINE entry to "
+                    f"{failure.line_count} in scripts/check_file_size.py)"
+                )
+        elif failure.kind == "stale":
+            print(
+                f"  {failure.rel} (baselined at {failure.limit} lines but the "
+                "file no longer exists -- remove its RATCHET_BASELINE entry "
+                "in scripts/check_file_size.py)"
+            )
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point. Return 0 if the ratchet holds, 1 on any failure."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--max",
+        type=int,
+        default=DEFAULT_MAX_LINES,
+        help=f"Cap for non-baselined files (default: {DEFAULT_MAX_LINES}).",
+    )
+    args = parser.parse_args(argv)
+
+    repo_root = _repo_root()
+    scan_roots = discover_package_src_roots(repo_root)
+    failures = check_file_size(
+        scan_roots,
+        rel_to=repo_root,
+        max_lines=args.max,
+    )
+    _print_report(failures, args.max)
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_check_baseline_diff.py
+++ b/tests/test_check_baseline_diff.py
@@ -1,0 +1,266 @@
+"""Tests for the PR-context ratchet-baseline diff guard (#364 review finding 4).
+
+scripts/check_file_size.py's static checker can only ever see ONE tree; these
+tests are the meta-test the review asked for on the CROSS-COMMIT half of the
+guard: growing a file and its baseline entry together, or renaming an
+oversized file into a fresh baseline entry, only becomes visible when two
+versions of the baseline are diffed against each other -- which is what
+scripts/check_baseline_diff.py does and what this file proves. Round 3 added
+the cap-provenance meta-test: the cap must come from the BASE (merge-base)
+file, never the head file, so a PR cannot raise its own cap alongside a
+brand-new over-cap entry and have the guard bless it.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+
+def _load_module() -> ModuleType:
+    script = Path(__file__).resolve().parents[1] / "scripts" / "check_baseline_diff.py"
+    spec = importlib.util.spec_from_file_location(
+        "clio_kit_check_baseline_diff", script
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load baseline-diff guard: {script}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_GUARD = _load_module()
+BaselineViolation = _GUARD.BaselineViolation
+MissingConstantError = _GUARD.MissingConstantError
+diff_baselines = _GUARD.diff_baselines
+extract_baseline = _GUARD.extract_baseline
+extract_default_max_lines = _GUARD.extract_default_max_lines
+main = _GUARD.main
+
+
+def _checker_source(entries: dict[str, int], *, default_max_lines: int = 800) -> str:
+    """Render a minimal check_file_size.py-shaped source with the given baseline."""
+    lines = "\n".join(f'    "{rel}": {count},' for rel, count in entries.items())
+    return (
+        f"DEFAULT_MAX_LINES = {default_max_lines}\n\n"
+        f"RATCHET_BASELINE: dict[str, int] = {{\n{lines}\n}}\n"
+    )
+
+
+# --- diff_baselines: the pure comparison logic -----------------------------
+
+
+def test_no_changes_is_clean() -> None:
+    base = {"pkg/a.py": 1000}
+    head = {"pkg/a.py": 1000}
+    assert diff_baselines(base, head, cap=800) == []
+
+
+def test_increased_entry_is_a_violation() -> None:
+    base = {"pkg/a.py": 1000}
+    head = {"pkg/a.py": 1200}
+
+    violations = diff_baselines(base, head, cap=800)
+
+    assert violations == [BaselineViolation("pkg/a.py", "increased", 1000, 1200)]
+
+
+def test_same_commit_inflation_is_caught_even_when_the_static_checker_would_pass() -> (
+    None
+):
+    """The exact attack finding 4 named: grow the file AND its baseline together
+    to a matching value. The static checker sees base==actual and is happy;
+    this diff guard only looks at the baseline NUMBER moving, so it still
+    catches it.
+    """
+    base = {"pkg/legacy.py": 1000}
+    head = {"pkg/legacy.py": 1500}  # baseline bumped to match a grown file
+
+    violations = diff_baselines(base, head, cap=800)
+
+    assert len(violations) == 1
+    assert violations[0].kind == "increased"
+    assert violations[0].base_value == 1000
+    assert violations[0].head_value == 1500
+
+
+def test_decreased_entry_is_not_a_violation() -> None:
+    base = {"pkg/a.py": 1000}
+    head = {"pkg/a.py": 900}
+    assert diff_baselines(base, head, cap=800) == []
+
+
+def test_removed_entry_is_not_a_violation() -> None:
+    base = {"pkg/a.py": 1000}
+    head: dict[str, int] = {}
+    assert diff_baselines(base, head, cap=800) == []
+
+
+def test_new_entry_at_or_under_cap_is_not_a_violation() -> None:
+    base: dict[str, int] = {}
+    head = {"pkg/new.py": 800}
+    assert diff_baselines(base, head, cap=800) == []
+
+
+def test_new_entry_over_cap_is_a_violation() -> None:
+    base: dict[str, int] = {}
+    head = {"pkg/new.py": 801}
+
+    violations = diff_baselines(base, head, cap=800)
+
+    assert violations == [BaselineViolation("pkg/new.py", "new_over_cap", None, 801)]
+
+
+def test_rename_laundering_is_caught_as_a_new_over_cap_entry() -> None:
+    """The other attack finding 4 named: rename an oversized file and mint a
+    fresh baseline entry, shedding its lineage. From the diff's point of
+    view this is "old key removed" (fine) + "new key added over cap" (caught).
+    """
+    base = {"pkg/old_name.py": 1200}
+    head = {"pkg/new_name.py": 1200}  # same size, different path -- a rename
+
+    violations = diff_baselines(base, head, cap=800)
+
+    assert violations == [
+        BaselineViolation("pkg/new_name.py", "new_over_cap", None, 1200)
+    ]
+
+
+def test_multiple_entries_each_evaluated_independently() -> None:
+    base = {"a.py": 1000, "b.py": 900, "c.py": 1100}
+    head = {
+        "a.py": 1000,  # unchanged
+        "b.py": 700,  # decreased, fine
+        # c.py removed, fine
+        "d.py": 850,  # new, over cap, violation
+    }
+
+    violations = diff_baselines(base, head, cap=800)
+
+    assert violations == [BaselineViolation("d.py", "new_over_cap", None, 850)]
+
+
+# --- extract_baseline: parsing real check_file_size.py-shaped source -------
+
+
+def test_extract_baseline_parses_a_real_shaped_source() -> None:
+    source = _checker_source({"pkg/a.py": 1000, "pkg/b.py": 900})
+    assert extract_baseline(source) == {"pkg/a.py": 1000, "pkg/b.py": 900}
+
+
+def test_extract_baseline_handles_an_empty_dict() -> None:
+    source = "RATCHET_BASELINE: dict[str, int] = {}\n"
+    assert extract_baseline(source) == {}
+
+
+def test_extract_baseline_raises_when_assignment_is_absent() -> None:
+    with pytest.raises(MissingConstantError):
+        extract_baseline("DEFAULT_MAX_LINES = 800\n")
+
+
+def test_extract_baseline_does_not_execute_the_source() -> None:
+    """ast.literal_eval, never exec/import -- a hostile historical revision
+    of this file must not be able to run code just by being diffed.
+    """
+    hostile = (
+        "import os\n"
+        "os.environ['PWNED'] = '1'\n"
+        "RATCHET_BASELINE: dict[str, int] = {'a.py': 900}\n"
+    )
+    assert extract_baseline(hostile) == {"a.py": 900}
+    import os as _os
+
+    assert "PWNED" not in _os.environ
+
+
+# --- extract_default_max_lines: the cap must come from the BASE file -------
+
+
+def test_extract_default_max_lines_parses_a_real_shaped_source() -> None:
+    source = _checker_source({}, default_max_lines=800)
+    assert extract_default_max_lines(source) == 800
+
+
+def test_extract_default_max_lines_parses_a_non_default_value() -> None:
+    source = _checker_source({}, default_max_lines=650)
+    assert extract_default_max_lines(source) == 650
+
+
+def test_extract_default_max_lines_raises_when_assignment_is_absent() -> None:
+    with pytest.raises(MissingConstantError):
+        extract_default_max_lines("RATCHET_BASELINE: dict[str, int] = {}\n")
+
+
+# --- CLI end-to-end ----------------------------------------------------------
+
+
+def test_cli_passes_on_a_clean_diff(tmp_path: Path) -> None:
+    base_file = tmp_path / "base.py"
+    head_file = tmp_path / "head.py"
+    base_file.write_text(_checker_source({"a.py": 1000}), encoding="utf-8")
+    head_file.write_text(_checker_source({"a.py": 900}), encoding="utf-8")
+
+    assert main([str(base_file), str(head_file)]) == 0
+
+
+def test_cli_fails_on_same_commit_inflation(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    base_file = tmp_path / "base.py"
+    head_file = tmp_path / "head.py"
+    base_file.write_text(_checker_source({"a.py": 1000}), encoding="utf-8")
+    head_file.write_text(_checker_source({"a.py": 1500}), encoding="utf-8")
+
+    assert main([str(base_file), str(head_file)]) == 1
+    out = capsys.readouterr().out
+    assert "a.py" in out
+    assert "1000" in out and "1500" in out
+
+
+def test_cli_fails_on_rename_laundering(tmp_path: Path) -> None:
+    base_file = tmp_path / "base.py"
+    head_file = tmp_path / "head.py"
+    base_file.write_text(_checker_source({"old.py": 1200}), encoding="utf-8")
+    head_file.write_text(_checker_source({"new.py": 1200}), encoding="utf-8")
+
+    assert main([str(base_file), str(head_file)]) == 1
+
+
+def test_cli_respects_custom_cap(tmp_path: Path) -> None:
+    base_file = tmp_path / "base.py"
+    head_file = tmp_path / "head.py"
+    base_file.write_text(_checker_source({}), encoding="utf-8")
+    head_file.write_text(_checker_source({"a.py": 500}), encoding="utf-8")
+
+    assert main([str(base_file), str(head_file), "--cap", "400"]) == 1
+    assert main([str(base_file), str(head_file), "--cap", "600"]) == 0
+
+
+def test_cli_ignores_a_head_side_cap_increase(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The meta-test PR #364 review round 3 asked for: a PR that raises its
+    OWN DEFAULT_MAX_LINES alongside a brand-new, over-(old-)cap baseline
+    entry must not get to grade its own homework. The cap is read from
+    base_file (DEFAULT_MAX_LINES=800, the merge-base's real cap), never from
+    head_file (DEFAULT_MAX_LINES=999999, the PR's own inflated one) -- so the
+    new entry at 5000 lines still fails even though it's comfortably under
+    the PR's self-raised cap.
+    """
+    base_file = tmp_path / "base.py"
+    head_file = tmp_path / "head.py"
+    base_file.write_text(_checker_source({}, default_max_lines=800), encoding="utf-8")
+    head_file.write_text(
+        _checker_source({"pkg/new_god_file.py": 5000}, default_max_lines=999999),
+        encoding="utf-8",
+    )
+
+    assert main([str(base_file), str(head_file)]) == 1
+    out = capsys.readouterr().out
+    assert "pkg/new_god_file.py" in out
+    assert "800" in out  # the cap actually applied is the base's, not 999999

--- a/tests/test_check_file_size.py
+++ b/tests/test_check_file_size.py
@@ -1,0 +1,360 @@
+"""Tests for the per-package god-file size ratchet (campaign #362, Slice 1).
+
+PR #364 review finding 4 hardened this checker past a straight port of
+clio-agent's script: a baseline sitting ABOVE a file's real line count used
+to be advisory-only (an "OK (ratchet down)" message, exit 0). These tests
+prove that specific gap is closed: at any ONE tree, every baseline entry
+must exactly mirror its file's real line count, in both directions, or the
+check fails -- no padding/slack is tolerated even when it looks directionally
+plausible (see test_exact_match_invariant_rejects_padding_even_when_it_looks_
+like_a_legitimate_bump).
+
+What this module's checker does NOT, and structurally cannot, prove on its
+own: whether a baseline NUMBER rose between two real commits (grow a file
+and bump its baseline to an exact new match in the same commit -- padding
+never enters into it, so the exact-match invariant alone does not catch
+this). That is a cross-commit question a single-tree checker has no way to
+answer; scripts/check_baseline_diff.py (tests/test_check_baseline_diff.py)
+closes it by diffing the baseline between two commits instead.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+
+def _load_checker() -> ModuleType:
+    """Load the CI checker from its repository script path."""
+    script = Path(__file__).resolve().parents[1] / "scripts" / "check_file_size.py"
+    spec = importlib.util.spec_from_file_location("clio_kit_check_file_size", script)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load file-size checker: {script}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_CHECKER = _load_checker()
+check_file_size = _CHECKER.check_file_size
+discover_package_src_roots = _CHECKER.discover_package_src_roots
+main = _CHECKER.main
+
+
+def _write_lines(path: Path, count: int) -> Path:
+    """Write ``count`` trivial lines to ``path``, creating parent dirs."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("x = 1\n" * count, encoding="utf-8")
+    return path
+
+
+def test_clean_tree_with_no_baseline_passes(tmp_path: Path) -> None:
+    src = tmp_path / "pkg" / "src"
+    _write_lines(src / "small.py", 10)
+
+    failures = check_file_size([src], rel_to=tmp_path, max_lines=800, baseline={})
+
+    assert failures == []
+
+
+def test_new_file_over_default_cap_fails(tmp_path: Path) -> None:
+    src = tmp_path / "pkg" / "src"
+    _write_lines(src / "god_file.py", 801)
+
+    failures = check_file_size([src], rel_to=tmp_path, max_lines=800, baseline={})
+
+    assert len(failures) == 1
+    failure = failures[0]
+    assert failure.rel == "pkg/src/god_file.py"
+    assert failure.line_count == 801
+    assert failure.kind == "new"
+    assert failure.limit == 800
+
+
+def test_baselined_file_at_recorded_count_passes(tmp_path: Path) -> None:
+    src = tmp_path / "pkg" / "src"
+    _write_lines(src / "legacy.py", 1000)
+    baseline = {"pkg/src/legacy.py": 1000}
+
+    failures = check_file_size([src], rel_to=tmp_path, max_lines=800, baseline=baseline)
+
+    assert failures == []
+
+
+def test_baselined_file_growing_past_recorded_count_fails(tmp_path: Path) -> None:
+    """The sabotage case: growing a known-oversized file past its pin must fail."""
+    src = tmp_path / "pkg" / "src"
+    _write_lines(src / "legacy.py", 1005)
+    baseline = {"pkg/src/legacy.py": 1000}
+
+    failures = check_file_size([src], rel_to=tmp_path, max_lines=800, baseline=baseline)
+
+    assert len(failures) == 1
+    failure = failures[0]
+    assert failure.rel == "pkg/src/legacy.py"
+    assert failure.line_count == 1005
+    assert failure.kind == "regressed"
+    assert failure.limit == 1000
+
+
+def test_baseline_may_only_ratchet_down_never_silently_grow(tmp_path: Path) -> None:
+    """A baseline higher than the file's real count is NEVER rewarded silently.
+
+    (PR #364 review finding 7: this test used to assert the opposite -- zero
+    failures on an inflated baseline -- which blessed exactly the bypass its
+    name claimed to prevent. Finding 4 closed the gap this test now proves:
+    "padded" baselines fail the build, full stop, no advisory-only path.)
+    """
+    src = tmp_path / "pkg" / "src"
+    _write_lines(src / "legacy.py", 500)
+    baseline = {"pkg/src/legacy.py": 1000}
+
+    failures = check_file_size([src], rel_to=tmp_path, max_lines=800, baseline=baseline)
+
+    assert len(failures) == 1
+    failure = failures[0]
+    assert failure.rel == "pkg/src/legacy.py"
+    assert failure.kind == "padded"
+    assert failure.line_count == 500
+    assert failure.limit == 1000
+
+
+def test_baselined_file_shrinking_still_over_cap_fails_as_padded(
+    tmp_path: Path,
+) -> None:
+    """Shrinking but staying over the cap: still fails until the baseline is lowered."""
+    src = tmp_path / "pkg" / "src"
+    _write_lines(src / "legacy.py", 900)
+    baseline = {"pkg/src/legacy.py": 1000}
+
+    failures = check_file_size([src], rel_to=tmp_path, max_lines=800, baseline=baseline)
+
+    assert len(failures) == 1
+    assert failures[0].kind == "padded"
+    assert failures[0].line_count == 900
+    assert failures[0].limit == 1000
+
+
+def test_baselined_file_shrinking_under_cap_fails_until_entry_removed(
+    tmp_path: Path,
+) -> None:
+    src = tmp_path / "pkg" / "src"
+    _write_lines(src / "legacy.py", 700)
+    baseline = {"pkg/src/legacy.py": 1000}
+
+    failures = check_file_size([src], rel_to=tmp_path, max_lines=800, baseline=baseline)
+
+    assert len(failures) == 1
+    assert failures[0].kind == "padded"
+    assert failures[0].line_count == 700
+
+
+def test_stale_baseline_entry_for_a_deleted_file_fails(tmp_path: Path) -> None:
+    """A baseline entry for a file that no longer exists must be removed, not linger.
+
+    Closes the resurrect-below-old-allowance gap (PR #364 review finding 4b):
+    without this, deleting a baselined file leaves its old headroom
+    unclaimed in RATCHET_BASELINE, and a LATER, unrelated file created at
+    that same path would silently inherit an allowance it never earned.
+    """
+    src = tmp_path / "pkg" / "src"
+    src.mkdir(parents=True)
+    baseline = {"pkg/src/gone.py": 1200}
+
+    failures = check_file_size([src], rel_to=tmp_path, max_lines=800, baseline=baseline)
+
+    assert len(failures) == 1
+    failure = failures[0]
+    assert failure.rel == "pkg/src/gone.py"
+    assert failure.kind == "stale"
+    assert failure.line_count is None
+    assert failure.limit == 1200
+
+
+def test_exact_match_invariant_rejects_padding_even_when_it_looks_like_a_legitimate_bump(
+    tmp_path: Path,
+) -> None:
+    """What the STATIC checker (this module) actually guarantees, precisely:
+    at any ONE (file, baseline) snapshot, a baseline entry must equal the
+    file's real line count EXACTLY -- never "at or above". This function has
+    no concept of "before" or "after" at all; each call here is an
+    independent, self-contained check of one (file-on-disk, baseline-dict)
+    pair, not a simulated commit sequence.
+
+    The baseline used below (1600, for a file that happens to be 1500 lines)
+    is deliberately chosen to LOOK like a plausible bump -- growth is the
+    direction a file's size usually moves in, so a reader could mistake a
+    passing result here for "the checker tolerates a baseline that's ahead of
+    the file, as long as the file might catch up." It does not: 1600 != 1500
+    fails as "padded" on this single snapshot alone, for the same reason
+    500 (under the file's real count) would also fail -- the invariant is
+    EXACT match, full stop, with no directional exception.
+
+    What this test does NOT and CANNOT prove: that a baseline NUMBER rising
+    between two real commits (the same-commit "grow the file and its
+    baseline together" attack, PR #364 review finding 4) is caught. That is
+    a CROSS-COMMIT question -- it requires comparing the baseline dict as it
+    stood at a PRIOR commit against its current value, which a checker that
+    only ever reads one tree structurally cannot do. That protection lives
+    in scripts/check_baseline_diff.py instead; see
+    tests/test_check_baseline_diff.py, in particular
+    test_same_commit_inflation_is_caught_even_when_the_static_checker_would_pass
+    and the CLI meta-test test_cli_ignores_a_head_side_cap_increase.
+    """
+    src = tmp_path / "pkg" / "src"
+    _write_lines(src / "legacy.py", 1500)
+
+    padded_baseline = {"pkg/src/legacy.py": 1600}
+    failures = check_file_size(
+        [src], rel_to=tmp_path, max_lines=800, baseline=padded_baseline
+    )
+
+    assert len(failures) == 1
+    failure = failures[0]
+    assert failure.kind == "padded"
+    assert failure.line_count == 1500
+    assert failure.limit == 1600
+
+    # The only baseline that passes for THIS snapshot is the exact real count.
+    exact_baseline = {"pkg/src/legacy.py": 1500}
+    assert (
+        check_file_size([src], rel_to=tmp_path, max_lines=800, baseline=exact_baseline)
+        == []
+    )
+
+
+def test_test_files_are_never_ratchet_guarded(tmp_path: Path) -> None:
+    """A huge test_*.py, or anything under a tests/ directory, is out of scope."""
+    src = tmp_path / "pkg" / "src"
+    _write_lines(src / "test_something.py", 5000)
+    _write_lines(src / "tests" / "big_fixture.py", 5000)
+
+    failures = check_file_size([src], rel_to=tmp_path, max_lines=800, baseline={})
+
+    assert failures == []
+
+
+def test_multiple_scan_roots_are_all_checked(tmp_path: Path) -> None:
+    src_a = tmp_path / "pkg_a" / "src"
+    src_b = tmp_path / "pkg_b" / "src"
+    _write_lines(src_a / "big.py", 900)
+    _write_lines(src_b / "also_big.py", 900)
+
+    failures = check_file_size(
+        [src_a, src_b], rel_to=tmp_path, max_lines=800, baseline={}
+    )
+
+    offending = sorted(failure.rel for failure in failures)
+    assert offending == ["pkg_a/src/big.py", "pkg_b/src/also_big.py"]
+
+
+def test_discover_package_src_roots_finds_repo_root_pyproject_packages_and_agentic_search(
+    tmp_path: Path,
+) -> None:
+    """PR #364 review finding 5: the repo root's own `src/` (the `clio_kit`
+    launcher package) must be scanned too, not just clio-kit-mcp-servers/*.
+    """
+    (tmp_path / "pyproject.toml").write_text("", encoding="utf-8")
+    (tmp_path / "src").mkdir()
+
+    servers = tmp_path / "clio-kit-mcp-servers"
+    (servers / "jarvis" / "src").mkdir(parents=True)
+    (servers / "jarvis" / "pyproject.toml").write_text("", encoding="utf-8")
+    # A directory without pyproject.toml is not a package and must be skipped.
+    (servers / "not_a_package" / "src").mkdir(parents=True)
+    # A package without a src/ tree contributes no root.
+    (servers / "no_src_pkg" / "pyproject.toml").parent.mkdir(
+        parents=True, exist_ok=True
+    )
+    (servers / "no_src_pkg" / "pyproject.toml").write_text("", encoding="utf-8")
+    (tmp_path / "clio-agentic-search" / "src").mkdir(parents=True)
+    (tmp_path / "clio-agentic-search" / "pyproject.toml").write_text(
+        "", encoding="utf-8"
+    )
+
+    roots = discover_package_src_roots(tmp_path)
+
+    assert (tmp_path / "src") in roots
+    assert (servers / "jarvis" / "src") in roots
+    assert (tmp_path / "clio-agentic-search" / "src") in roots
+    assert (servers / "not_a_package" / "src") not in roots
+    assert len(roots) == 3
+
+
+def test_discover_package_src_roots_skips_repo_root_without_pyproject(
+    tmp_path: Path,
+) -> None:
+    """A bare src/ at the repo root with no pyproject.toml is not a package."""
+    (tmp_path / "src").mkdir()
+
+    roots = discover_package_src_roots(tmp_path)
+
+    assert roots == []
+
+
+def test_cli_main_exit_code_reflects_the_ratchet(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Sabotage the CLI end-to-end: a fresh god-file must fail, then revert to pass."""
+    src = tmp_path / "clio-kit-mcp-servers" / "widget" / "src"
+    (tmp_path / "clio-kit-mcp-servers" / "widget" / "pyproject.toml").parent.mkdir(
+        parents=True, exist_ok=True
+    )
+    (tmp_path / "clio-kit-mcp-servers" / "widget" / "pyproject.toml").write_text(
+        "", encoding="utf-8"
+    )
+    target = _write_lines(src / "server.py", 10)
+
+    monkeypatch.setattr(_CHECKER, "_repo_root", lambda: tmp_path)
+    monkeypatch.setattr(_CHECKER, "RATCHET_BASELINE", {})
+
+    assert main([]) == 0
+    capsys.readouterr()
+
+    _write_lines(target, 801)
+    assert main([]) == 1
+    out = capsys.readouterr().out
+    assert "clio-kit-mcp-servers/widget/src/server.py" in out
+
+    _write_lines(target, 10)
+    assert main([]) == 0
+
+
+def test_real_tree_holds_at_recorded_baseline() -> None:
+    """The live repository tree passes at the checked-in, exact baseline.
+
+    Mirrors clio-agent's test_check_file_size.py::test_real_tree_holds_at_
+    recorded_baseline -- a regression pin over the ACTUAL repo, not a
+    synthetic fixture, run in addition to (never instead of) the synthetic
+    cases above.
+    """
+    repo_root = Path(__file__).resolve().parents[1]
+    scan_roots = discover_package_src_roots(repo_root)
+    failures = check_file_size(scan_roots, rel_to=repo_root)
+    assert failures == [], failures
+
+
+def test_baseline_entries_all_exist_and_are_exact() -> None:
+    """Every baselined path must point at a real file whose count matches exactly.
+
+    Mirrors clio-agent's test_baseline_entries_all_exist -- extended (per PR
+    #364 review finding 4) to check the count is EXACT, not merely that the
+    file exists, since this checker no longer tolerates any drift.
+    """
+    repo_root = Path(__file__).resolve().parents[1]
+    missing = [
+        rel for rel in _CHECKER.RATCHET_BASELINE if not (repo_root / rel).is_file()
+    ]
+    assert not missing, missing
+
+    mismatched = {}
+    for rel, recorded in _CHECKER.RATCHET_BASELINE.items():
+        actual = _CHECKER._count_lines(repo_root / rel)
+        if actual != recorded:
+            mismatched[rel] = {"recorded": recorded, "actual": actual}
+    assert not mismatched, mismatched

--- a/tests/test_generate_server_json_contract.py
+++ b/tests/test_generate_server_json_contract.py
@@ -99,7 +99,7 @@ def test_every_committed_server_has_an_agent_runnable_package_coordinate() -> No
     assert manifests == [project / "server.json" for project in projects]
     assert list(expected_server_versions) == sorted(expected_server_versions)
     assert set(expected_server_versions) == {project.name for project in projects}
-    assert publish_servers == ()
+    assert publish_servers == ("web",)
     assert marketplace["metadata"]["version"] == expected_version
     assert set(marketplace_plugins) == set(expected_server_versions)
     assert gemini_extension["version"] == expected_version

--- a/uv.lock
+++ b/uv.lock
@@ -61,7 +61,7 @@ wheels = [
 
 [[package]]
 name = "clio-kit"
-version = "2.7.2"
+version = "2.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Release scope

Promote the tested `develop` tip for CLIO Kit 2.8.0.

- #364: JARVIS owner-module split, contract pins, ArXiv resilience, and repository file-size/baseline ratchets
- #366: self-hosted SearXNG support in web MCP 1.1.0, including provider-scoped selectors and live LAN verification
- queue only web MCP 1.1.0 for MCP Registry publication

## Release verification

- #366 completed 195 successful checks with zero failures or pending checks
- web offline suite: 86 passed, 3 live tests deselected; SearXNG adapter at 100% line coverage, web package at 93%
- web live suite: 3 passed, zero skips
- root suite: 153 passed, zero skips
- Ruff, format, mypy, file-size ratchet, manifest generation, constrained build, and Twine validation passed
- the locally built 2.8.0 wheel was installed in a fresh uv tool environment and its `clio-kit mcp-server web` command returned real results from the deployed SearXNG instance over MCP stdio

After this promotion is independently green, `v2.8.0` will publish the wheel and sdist, create the immutable GitHub release, and publish web MCP 1.1.0.
