### PR TITLE
#359 skills: cross-server workflows, shipped as a plugin and validatable

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -332,6 +332,23 @@
       "keywords": [],
       "license": "BSD-3-Clause",
       "repository": "https://github.com/iowarp/clio-kit"
+    },
+    {
+      "name": "clio-skills",
+      "source": "./",
+      "description": "Cross-server workflows for CLIO Kit's MCP servers: analyzing-scientific-datasets, diagnosing-io-performance, running-spack-packages-with-jarvis, surveying-research-literature, tracking-cluster-runs",
+      "version": "2.8.0",
+      "category": "workflows",
+      "keywords": [
+        "skills",
+        "workflows",
+        "data analysis",
+        "hpc",
+        "performance",
+        "research"
+      ],
+      "license": "BSD-3-Clause",
+      "repository": "https://github.com/iowarp/clio-kit"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,16 @@
+{
+  "name": "clio-skills",
+  "description": "Cross-server workflows for CLIO Kit's MCP servers: analyzing-scientific-datasets, diagnosing-io-performance, running-spack-packages-with-jarvis, surveying-research-literature, tracking-cluster-runs",
+  "version": "2.8.0",
+  "skills": "./skills/",
+  "keywords": [
+    "skills",
+    "workflows",
+    "data analysis",
+    "hpc",
+    "performance",
+    "research"
+  ],
+  "license": "BSD-3-Clause",
+  "repository": "https://github.com/iowarp/clio-kit"
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,8 @@ clio-kit/                           # Monorepo root
 │   ├── plot/                          # Data visualization
 │   ├── adios/                         # ADIOS2 data I/O
 │   └── [each has its own pyproject.toml, dependencies, tests]
+├── skills/                         # Cross-server workflows (see CONTRIBUTING.md)
+│   └── <name>/SKILL.md             # Generated into .claude-plugin/plugin.json
 ├── clio-agentic-search/             # Standalone hybrid retrieval engine (not an MCP server)
 ├── clio-kit-website/                # Docusaurus documentation site
 ├── scripts/                           # Utility scripts (generate_docs.py, etc)
@@ -115,6 +117,24 @@ uv run hdf5-mcp
 # List all available MCPs
 uvx clio-kit
 ```
+
+### Using Skills
+
+Skills are markdown workflows that span more than one MCP server. Anything a
+single server can sequence belongs in that server's MCP prompt instead.
+
+```bash
+clio-kit skills                  # shipped workflows, grouped by category
+clio-kit skill <name>            # print one SKILL.md
+clio-kit skills-install          # copy into ~/.claude/skills for Claude Code
+clio-kit skills-validate [path]  # check skills against the servers this kit ships
+```
+
+`scripts/generate_server_json.py` reads each `SKILL.md`'s frontmatter and
+generates `.claude-plugin/plugin.json` plus the marketplace entry, so a new
+skill needs no manual registration. Authoring rules are in `CONTRIBUTING.md`;
+`skills-validate` and `tests/test_skills.py` enforce them through one shared
+implementation, so an externally authored skill is held to the same rules.
 
 ### Code Formatting & Fixing
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -310,6 +310,106 @@ uvx clio-kit
 uvx clio-kit my-server
 ```
 
+## Adding a Skill
+
+A **skill** is a markdown workflow that spans more than one MCP server. Anything
+a single server can sequence on its own belongs in that server's MCP prompt
+instead, where it ships and versions with the server's contract.
+
+### 1. Create the directory
+
+Use the gerund form, matching the frontmatter `name`:
+
+```bash
+mkdir -p skills/profiling-memory-usage
+```
+
+### 2. Write `SKILL.md`
+
+```markdown
+---
+name: profiling-memory-usage
+description: Profiles a job's memory use and correlates it with the node it ran on. Use when a run was killed for memory, when the user asks how much memory a workload needs, or when they mention OOM, resident set size, or memory limits.
+category: Performance
+servers: clio-node-hardware, clio-pandas
+tools: clio-node-hardware:get_memory_info, clio-pandas:optimize_memory
+---
+
+# Profiling memory usage
+
+[Steps, referencing every tool as `clio-<server>:<tool>`]
+```
+
+All five frontmatter fields are required.
+
+- **`name`** must equal the directory name: lowercase, hyphens, 64 characters
+  max, gerund form.
+- **`description`** must say *what the skill does* **and** *when to use it*, in
+  third person, within 1024 characters. Only the name and description are loaded
+  until a skill triggers, so the "Use when" half is what makes it discoverable.
+- **`category`** groups it in `clio-kit skills`.
+- **`servers`** must list at least two, named as clients see them: `clio-<name>`.
+- **`tools`** must be fully qualified, `clio-<server>:<tool>`. Bare names are
+  ambiguous — `identify_io_bottlenecks` exists on both darshan and hdf5 and
+  means different things.
+
+Keep the body under 500 lines and assume the reader is already competent; do not
+explain what HDF5 or BibTeX are.
+
+### 3. Regenerate and validate
+
+```bash
+uv run python scripts/generate_server_json.py clio-kit-mcp-servers
+uv run clio-kit skills-validate
+uv run pytest tests/test_skills.py -v
+```
+
+The generator picks the skill up automatically: it appears in `clio-kit skills`,
+in `.claude-plugin/plugin.json`, and in the marketplace entry with no manual
+edit anywhere.
+
+### What is enforced
+
+`clio-kit skills-validate` and the test suite share one implementation, so the
+same rules apply to a skill written anywhere:
+
+| Rule | Why |
+|---|---|
+| Spans more than one server | single-server sequencing belongs in that server's MCP prompt |
+| Every declared tool exists on the server named | catches renames and tools moving between servers |
+| Every declared tool is used in the steps | the declaration cannot drift from the prose |
+| Every tool used in the steps is declared | otherwise it is invisible to the checks above |
+| No bare tool names | two servers can define the same tool name |
+| Description contains "Use when" | it is all that is loaded until the skill triggers |
+
+### Using a skill
+
+`clio-kit skills-install --scope user` copies the collection into
+`~/.claude/skills` (or `--scope project` for `.claude/skills`), where Claude Code
+discovers it. Installing through the plugin marketplace does the same thing:
+
+```
+/plugin marketplace add iowarp/clio-kit
+/plugin install clio-skills@iowarp-clio-kit
+```
+
+Either way the agent loads each skill's name and description at startup and
+reads the body only when a request matches.
+
+### Skills from elsewhere
+
+Claude Code merges skills from `~/.claude/skills`, `.claude/skills`, and every
+installed plugin, so a skill from another source needs nothing from this kit —
+`skills-install` replaces only the skills it ships and leaves the rest alone.
+
+If an external skill drives these servers, hold it to the same rules:
+
+```bash
+uv run clio-kit skills-validate /path/to/your/skills
+```
+
+---
+
 ## Issue Reporting
 
 ### Bug Reports

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,14 +79,14 @@ packages = ["src/clio_kit"]
 [tool.hatch.build.targets.wheel.shared-data]
 "clio-kit-mcp-servers" = "clio-kit-mcp-servers"
 "clio-agentic-search" = "clio-agentic-search"
-"prompts" = "prompts"
+"skills" = "skills"
 
 [tool.hatch.build.targets.sdist]
 include = [
     "src/",
     "clio-kit-mcp-servers/",
     "clio-agentic-search/",
-    "prompts/",
+    "skills/",
     "README.md",
     "mcp-server-versions.toml",
     "pyproject.toml"

--- a/scripts/check_file_size.py
+++ b/scripts/check_file_size.py
@@ -89,7 +89,7 @@ RATCHET_BASELINE: dict[str, int] = {
     # `clio_kit` package (the `clio-kit` launcher CLI itself) entirely --
     # these three were never scanned. Baselined at their measured counts, not
     # split this wave.
-    "src/clio_kit/__init__.py": 857,
+    "src/clio_kit/__init__.py": 832,
     "src/clio_kit/mcp_contracts.py": 921,
     "src/clio_kit/env_cache.py": 843,
     "clio-kit-mcp-servers/darshan/src/darshan_mcp/capabilities/darshan_parser.py": 857,

--- a/scripts/check_file_size.py
+++ b/scripts/check_file_size.py
@@ -89,7 +89,7 @@ RATCHET_BASELINE: dict[str, int] = {
     # `clio_kit` package (the `clio-kit` launcher CLI itself) entirely --
     # these three were never scanned. Baselined at their measured counts, not
     # split this wave.
-    "src/clio_kit/__init__.py": 958,
+    "src/clio_kit/__init__.py": 857,
     "src/clio_kit/mcp_contracts.py": 921,
     "src/clio_kit/env_cache.py": 843,
     "clio-kit-mcp-servers/darshan/src/darshan_mcp/capabilities/darshan_parser.py": 857,

--- a/scripts/generate_server_json.py
+++ b/scripts/generate_server_json.py
@@ -22,6 +22,7 @@ from pathlib import Path
 from typing import Any, cast
 
 from clio_kit.mcp_contracts import generate_user_contract_artifacts
+from clio_kit.skills import parse_frontmatter as parse_skill_frontmatter
 
 try:
     import tomllib
@@ -260,6 +261,56 @@ def write_claude_plugin_files(
     _write_json(server_dir / ".mcp.json", mcp_json)
 
 
+def read_shipped_skills(repo_root: Path) -> list[dict[str, str]]:
+    """Read the skill collection's frontmatter, sorted by name.
+
+    Skills are cross-server by construction, so they cannot belong to any one
+    server's plugin; they ship as a single kit-level plugin instead.
+    """
+    skills_root = repo_root / "skills"
+    collected: list[dict[str, str]] = []
+    for manifest in sorted(skills_root.glob("*/SKILL.md")):
+        fields = parse_skill_frontmatter(manifest.read_text(encoding="utf-8"))
+        missing = [
+            key for key in ("name", "description", "category") if not fields.get(key)
+        ]
+        if missing:
+            raise ValueError(f"{manifest} is missing frontmatter: {', '.join(missing)}")
+        if fields["name"] != manifest.parent.name:
+            raise ValueError(
+                f"{manifest} declares name {fields['name']!r} "
+                f"but lives in {manifest.parent.name!r}"
+            )
+        collected.append(fields)
+    return collected
+
+
+def build_skills_plugin_json(
+    skills: list[dict[str, str]],
+    *,
+    pypi_version: str,
+) -> dict[str, Any]:
+    """Build the kit-level plugin manifest that carries the skill collection.
+
+    `skills` points Claude Code at the repository's top-level directory, which
+    is already the documented plugin layout (<plugin root>/skills/<name>/
+    SKILL.md), so installing this plugin registers every shipped workflow.
+    """
+    categories = sorted({skill["category"] for skill in skills})
+    return {
+        "name": "clio-skills",
+        "description": (
+            "Cross-server workflows for CLIO Kit's MCP servers: "
+            + ", ".join(skill["name"] for skill in skills)
+        ),
+        "version": pypi_version,
+        "skills": "./skills/",
+        "keywords": ["skills", "workflows", *(c.lower() for c in categories)],
+        "license": "BSD-3-Clause",
+        "repository": REPO_URL,
+    }
+
+
 def build_marketplace_json(
     server_entries: list[dict[str, Any]],
     *,
@@ -417,6 +468,25 @@ def generate_all(mcps_dir: str) -> None:
         )
 
         generated.append(server_name)
+
+    # Kit-level skills plugin: one entry carrying every cross-server workflow
+    skills = read_shipped_skills(repo_root)
+    if skills:
+        skills_plugin = build_skills_plugin_json(skills, pypi_version=pypi_version)
+        _write_json(repo_root / ".claude-plugin" / "plugin.json", skills_plugin)
+        marketplace_plugins.append(
+            {
+                "name": skills_plugin["name"],
+                "source": "./",
+                "description": skills_plugin["description"],
+                "version": pypi_version,
+                "category": "workflows",
+                "keywords": skills_plugin["keywords"],
+                "license": "BSD-3-Clause",
+                "repository": REPO_URL,
+            }
+        )
+        print(f"  Wrote .claude-plugin/plugin.json ({len(skills)} skills)")
 
     # Claude Code marketplace manifest
     marketplace = build_marketplace_json(

--- a/skills/analyzing-scientific-datasets/SKILL.md
+++ b/skills/analyzing-scientific-datasets/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: analyzing-scientific-datasets
+description: Inspects a scientific data file, loads the part that matters into a dataframe, computes statistics, and renders a chart. Use when the user asks what is inside an HDF5, Parquet, or ADIOS BP5 file, wants a dataset summarized, correlated, or plotted, or mentions .h5, .hdf5, .parquet, or .bp files.
+category: Data Analysis
+servers: clio-hdf5, clio-parquet, clio-adios, clio-pandas, clio-plot
+tools: clio-hdf5:list_keys, clio-hdf5:get_shape, clio-hdf5:read_partial_dataset, clio-hdf5:export_dataset, clio-parquet:summarize_tool, clio-parquet:read_slice_tool, clio-parquet:aggregate_column_tool, clio-adios:inspect_variables, clio-adios:read_variable_at_step, clio-pandas:load_data, clio-pandas:profile_data, clio-pandas:statistical_summary, clio-pandas:correlation_analysis, clio-plot:plot_timeseries, clio-plot:scatter_plot, clio-plot:histogram_plot, clio-hdf5:read_full_dataset, clio-pandas:profile_csv, clio-pandas:hypothesis_testing
+---
+
+# Analyzing a scientific dataset
+
+Scientific files are usually far larger than the question being asked of them.
+Inspect the structure first, read only the slice that answers the question, then
+analyse and plot. Loading a whole file to compute one mean is the failure this
+workflow exists to prevent.
+
+## Workflow
+
+```
+- [ ] 1. Identify the format and inspect its structure
+- [ ] 2. Read only the slice needed
+- [ ] 3. Profile before analysing
+- [ ] 4. Compute the specific statistic
+- [ ] 5. Plot only if it adds something a number cannot
+```
+
+## 1. Inspect structure before reading anything
+
+Pick the server by file extension. Do not read data in this step.
+
+| Extension | Inspect with |
+|---|---|
+| `.h5`, `.hdf5` | `clio-hdf5:list_keys`, then `clio-hdf5:get_shape` on the interesting dataset |
+| `.parquet` | `clio-parquet:summarize_tool` — schema, row count, file size in one call |
+| `.bp` | `clio-adios:inspect_variables` — type, shape, and available steps |
+| `.csv`, `.xlsx` | `clio-pandas:profile_csv` |
+
+Shape and dtype decide the next step. A dataset of a few thousand rows can be
+read whole; anything larger should be sliced.
+
+## 2. Read only what the question needs
+
+- HDF5: `clio-hdf5:read_partial_dataset` with an explicit slice. Reach for
+  `clio-hdf5:read_full_dataset` only after `clio-hdf5:get_shape` shows the
+  dataset is small.
+- Parquet: `clio-parquet:read_slice_tool` with a column projection. If the
+  question is a single aggregate, use `clio-parquet:aggregate_column_tool`
+  instead and skip loading rows entirely.
+- ADIOS: `clio-adios:read_variable_at_step` — BP5 data is per-step, so a step
+  is required, not optional.
+
+## 3. Profile before analysing
+
+Call `clio-pandas:profile_data` (or `clio-pandas:load_data` then
+`clio-pandas:profile_data`) once. It reports missing values, dtypes and
+distributions in a single pass.
+
+Missing values change what the next step means: a correlation over a column that
+is 40% null is not the correlation the user asked for. Say so rather than
+silently computing it.
+
+## 4. Compute the specific statistic
+
+Choose one, do not run all three:
+
+- `clio-pandas:statistical_summary` — distribution, outliers, per-column
+- `clio-pandas:correlation_analysis` — relationships between numeric columns
+- `clio-pandas:hypothesis_testing` — when the user asks whether a difference is
+  real, not merely how large it is
+
+## 5. Plot only when a chart says more than a number
+
+- Values over time → `clio-plot:plot_timeseries`
+- Relationship between two variables → `clio-plot:scatter_plot`
+- Distribution shape → `clio-plot:histogram_plot`
+
+`clio-plot` reads CSV and Excel. For HDF5 or BP5 data, write the slice out with
+`clio-hdf5:export_dataset` first rather than trying to point the plot server at
+a format it cannot open.
+
+## What not to do
+
+- Do not read a whole dataset to compute one aggregate — Parquet and HDF5 both
+  answer aggregate questions without materialising rows.
+- Do not report a statistic without saying what the profile showed about
+  missing data.
+- Do not plot a chart the user did not ask for; a single number is often the
+  whole answer.

--- a/skills/diagnosing-io-performance/SKILL.md
+++ b/skills/diagnosing-io-performance/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: diagnosing-io-performance
+description: Traces a slow HPC job from its Darshan log to the specific dataset layout and node conditions causing the stall. Use when a run was slower than expected, when the user has a Darshan log or mentions I/O bottlenecks, POSIX or MPI-IO behaviour, small-write patterns, or chunking, or when a job's wall time is dominated by reads and writes rather than compute.
+category: Performance
+servers: clio-darshan, clio-hdf5, clio-adios, clio-node-hardware
+tools: clio-darshan:load_darshan_log, clio-darshan:get_job_summary, clio-darshan:identify_io_bottlenecks, clio-darshan:get_io_performance_metrics, clio-darshan:analyze_file_access_patterns, clio-darshan:analyze_posix_operations, clio-darshan:analyze_mpiio_operations, clio-darshan:get_timeline_analysis, clio-darshan:compare_darshan_logs, clio-hdf5:get_chunks, clio-hdf5:get_shape, clio-adios:inspect_variables, clio-node-hardware:get_disk_info, clio-node-hardware:get_remote_node_info, clio-hdf5:identify_io_bottlenecks
+---
+
+# Diagnosing I/O performance
+
+A Darshan log says *what* the I/O looked like. It cannot say *why* the file was
+laid out that way, and it cannot see the node the job ran on. The diagnosis is
+only complete when the trace, the file layout, and the hardware agree on a
+story.
+
+Note that `identify_io_bottlenecks` exists on two servers and they mean
+different things. `clio-darshan:identify_io_bottlenecks` analyses a captured
+trace; `clio-hdf5:identify_io_bottlenecks` inspects a file. Always qualify it.
+
+## Workflow
+
+```
+- [ ] 1. Load the trace and read the job summary
+- [ ] 2. Find where the time went
+- [ ] 3. Classify the access pattern
+- [ ] 4. Check the file layout that produced it
+- [ ] 5. Rule the hardware in or out
+- [ ] 6. Report cause, evidence, and one change
+```
+
+## 1. Load the trace
+
+`clio-darshan:load_darshan_log`, then `clio-darshan:get_job_summary` for
+runtime, process count and total I/O volume.
+
+Compute the ratio of I/O time to wall time before going further. If I/O is a
+small fraction of the run, stop and say so — the job is not I/O bound and the
+rest of this workflow will produce a confident answer to the wrong question.
+
+## 2. Find where the time went
+
+`clio-darshan:identify_io_bottlenecks` first, then
+`clio-darshan:get_io_performance_metrics` for bandwidth, IOPS and request
+sizes.
+
+Small mean request size with high operation count is the signature worth
+chasing: many small writes rather than few large ones.
+
+## 3. Classify the access pattern
+
+`clio-darshan:analyze_file_access_patterns` for sequential versus random, then
+the interface-specific view:
+
+- `clio-darshan:analyze_posix_operations` — plain reads and writes
+- `clio-darshan:analyze_mpiio_operations` — collective versus independent
+
+Independent MPI-IO where collective was available is a common and fixable
+cause. `clio-darshan:get_timeline_analysis` shows whether the cost is spread
+across the run or concentrated in one phase.
+
+## 4. Check the layout that produced the pattern
+
+The trace shows small reads; the file explains them.
+
+- HDF5: `clio-hdf5:get_chunks` and `clio-hdf5:get_shape`. A chunk shape
+  orthogonal to the access pattern turns one logical read into many physical
+  ones. This is the single most common finding.
+- ADIOS: `clio-adios:inspect_variables` for shape and step count. Per-step reads
+  across many steps behave like small-request I/O regardless of variable size.
+
+## 5. Rule the hardware in or out
+
+`clio-node-hardware:get_disk_info` on the node that ran the job, or
+`clio-node-hardware:get_remote_node_info` with `host` for a remote one.
+
+This step exists to prevent a wrong conclusion, not to find one: a saturated
+local disk or a full filesystem produces the same trace signature as a bad
+chunk layout, and the fix is entirely different.
+
+## 6. Report
+
+State the cause, the evidence from at least two of the three sources above, and
+**one** change. If a previous log exists, `clio-darshan:compare_darshan_logs`
+turns the recommendation into a measurement.
+
+## What not to do
+
+- Do not recommend a chunk shape without reading the current one.
+- Do not conclude "slow disk" from the trace alone; check the node.
+- Do not report more than one change at a time — two simultaneous changes make
+  the follow-up comparison unreadable.
+- Do not use the unqualified `identify_io_bottlenecks`; two servers define it.

--- a/skills/run-spack-package-in-jarvis/SKILL.md
+++ b/skills/run-spack-package-in-jarvis/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: run-spack-package-in-jarvis
+description: Resolve a Spack-installed package and run it as a JARVIS pipeline, carrying the exact spec across both servers.
+servers: spack, jarvis
+tools: spack_find, spack_install, spack_locate, jarvis_create_pipeline, jarvis_describe, jarvis_add_step, jarvis_run, jarvis_get_execution
+---
+
+# Run a Spack package as a JARVIS pipeline
+
+Use this when a workload needs software from Spack and has to run through
+JARVIS. It spans two servers, and the handoff between them is the part that goes
+wrong: the Spack server deliberately refuses to load anything into an
+environment, because a load performed inside a tool call dies with that call.
+JARVIS owns the runtime environment instead.
+
+`spack://capabilities` states this directly — `stateful_load_exposed: false`,
+`runtime_owner: jarvis_run`.
+
+## Steps
+
+**1. Find out whether the package is already installed.**
+
+Call `spack_find` with the constraint. No matches is a *successful* result with
+`count=0`, not an error — do not retry it as if the call failed.
+
+**2. Install only if it is missing.**
+
+Call `spack_install` with an explicit concretization choice. Skip this step
+entirely when step 1 already found a match; installing is slow and reinstalling
+a present package wastes a scheduler slot.
+
+**3. Resolve the exact spec.**
+
+Call `spack_locate`. Its `output.load_spec` is the value the next step needs.
+
+> Copy `spack_locate.output.load_spec` **unchanged**. Do not build a path from
+> the returned prefix, do not append `/bin/<binary>`, do not simplify the spec
+> string. The hash in it is what makes the environment reproducible, and a
+> derived path silently drops it.
+
+**4. Create the pipeline.**
+
+Call `jarvis_create_pipeline` with a `pipeline_id` you choose. Pass execution
+intent here if the workload needs a cluster rather than the local host.
+
+**5. Inspect the package before configuring it.**
+
+Call `jarvis_describe` with `target='package'` for the package you intend to
+add. Its configuration keys are the canonical ones; guessing key names is the
+most common way step 6 fails.
+
+**6. Add the step.**
+
+Call `jarvis_add_step` with the `pipeline_id`, the package, and a config built
+from the keys step 5 returned.
+
+**7. Run it, passing the Spack spec.**
+
+Call `jarvis_run` with the `pipeline_id`, putting the `load_spec` string from
+step 3 into one element of `input.spack_specs`. JARVIS persists that runtime
+environment for the execution.
+
+`jarvis_run` returns a durable execution handle and does **not** wait for the
+workload to finish.
+
+**8. Follow the execution.**
+
+Call `jarvis_get_execution` with the `pipeline_id` and the handle. Poll it
+rather than assuming the run completed when `jarvis_run` returned.
+
+## What not to do
+
+- Do not look for a `spack_load` tool. There isn't one, on purpose.
+- Do not treat `spack_find` returning zero packages as a failure.
+- Do not pass an executable path where `spack_specs` expects a load spec.
+- Do not skip `jarvis_describe` and guess configuration keys.
+- Do not report the workload as finished because `jarvis_run` succeeded — it
+  returns a handle, not a result.

--- a/skills/running-spack-packages-with-jarvis/SKILL.md
+++ b/skills/running-spack-packages-with-jarvis/SKILL.md
@@ -1,8 +1,9 @@
 ---
-name: run-spack-package-in-jarvis
-description: Resolve a Spack-installed package and run it as a JARVIS pipeline, carrying the exact spec across both servers.
-servers: spack, jarvis
-tools: spack_find, spack_install, spack_locate, jarvis_create_pipeline, jarvis_describe, jarvis_add_step, jarvis_run, jarvis_get_execution
+name: running-spack-packages-with-jarvis
+description: Resolves a Spack-installed package and runs it as a JARVIS pipeline, carrying the exact load spec across both servers. Use when a workload needs Spack-provided software, when a Spack package must be run rather than merely located, or when the user mentions spack specs, module loading for a run, or JARVIS pipeline execution.
+category: HPC
+servers: clio-spack, clio-jarvis
+tools: clio-spack:spack_find, clio-spack:spack_install, clio-spack:spack_locate, clio-jarvis:jarvis_create_pipeline, clio-jarvis:jarvis_describe, clio-jarvis:jarvis_add_step, clio-jarvis:jarvis_run, clio-jarvis:jarvis_get_execution
 ---
 
 # Run a Spack package as a JARVIS pipeline
@@ -20,18 +21,18 @@ JARVIS owns the runtime environment instead.
 
 **1. Find out whether the package is already installed.**
 
-Call `spack_find` with the constraint. No matches is a *successful* result with
+Call `clio-spack:spack_find` with the constraint. No matches is a *successful* result with
 `count=0`, not an error — do not retry it as if the call failed.
 
 **2. Install only if it is missing.**
 
-Call `spack_install` with an explicit concretization choice. Skip this step
+Call `clio-spack:spack_install` with an explicit concretization choice. Skip this step
 entirely when step 1 already found a match; installing is slow and reinstalling
 a present package wastes a scheduler slot.
 
 **3. Resolve the exact spec.**
 
-Call `spack_locate`. Its `output.load_spec` is the value the next step needs.
+Call `clio-spack:spack_locate`. Its `output.load_spec` is the value the next step needs.
 
 > Copy `spack_locate.output.load_spec` **unchanged**. Do not build a path from
 > the returned prefix, do not append `/bin/<binary>`, do not simplify the spec
@@ -40,39 +41,39 @@ Call `spack_locate`. Its `output.load_spec` is the value the next step needs.
 
 **4. Create the pipeline.**
 
-Call `jarvis_create_pipeline` with a `pipeline_id` you choose. Pass execution
+Call `clio-jarvis:jarvis_create_pipeline` with a `pipeline_id` you choose. Pass execution
 intent here if the workload needs a cluster rather than the local host.
 
 **5. Inspect the package before configuring it.**
 
-Call `jarvis_describe` with `target='package'` for the package you intend to
+Call `clio-jarvis:jarvis_describe` with `target='package'` for the package you intend to
 add. Its configuration keys are the canonical ones; guessing key names is the
 most common way step 6 fails.
 
 **6. Add the step.**
 
-Call `jarvis_add_step` with the `pipeline_id`, the package, and a config built
+Call `clio-jarvis:jarvis_add_step` with the `pipeline_id`, the package, and a config built
 from the keys step 5 returned.
 
 **7. Run it, passing the Spack spec.**
 
-Call `jarvis_run` with the `pipeline_id`, putting the `load_spec` string from
+Call `clio-jarvis:jarvis_run` with the `pipeline_id`, putting the `load_spec` string from
 step 3 into one element of `input.spack_specs`. JARVIS persists that runtime
 environment for the execution.
 
-`jarvis_run` returns a durable execution handle and does **not** wait for the
+`clio-jarvis:jarvis_run` returns a durable execution handle and does **not** wait for the
 workload to finish.
 
 **8. Follow the execution.**
 
-Call `jarvis_get_execution` with the `pipeline_id` and the handle. Poll it
-rather than assuming the run completed when `jarvis_run` returned.
+Call `clio-jarvis:jarvis_get_execution` with the `pipeline_id` and the handle. Poll it
+rather than assuming the run completed when `clio-jarvis:jarvis_run` returned.
 
 ## What not to do
 
 - Do not look for a `spack_load` tool. There isn't one, on purpose.
-- Do not treat `spack_find` returning zero packages as a failure.
+- Do not treat `clio-spack:spack_find` returning zero packages as a failure.
 - Do not pass an executable path where `spack_specs` expects a load spec.
-- Do not skip `jarvis_describe` and guess configuration keys.
-- Do not report the workload as finished because `jarvis_run` succeeded — it
+- Do not skip `clio-jarvis:jarvis_describe` and guess configuration keys.
+- Do not report the workload as finished because `clio-jarvis:jarvis_run` succeeded — it
   returns a handle, not a result.

--- a/skills/surveying-research-literature/SKILL.md
+++ b/skills/surveying-research-literature/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: surveying-research-literature
+description: Builds a literature survey from ArXiv and locates the datasets behind it on the National Data Platform, ending in a citable bibliography and staged local files. Use when the user asks what has been published on a topic, wants papers on a subject or by an author, asks for a BibTeX bibliography, or wants the data underlying a paper rather than only the paper.
+category: Research
+servers: clio-arxiv, clio-ndp
+tools: clio-arxiv:search_arxiv, clio-arxiv:search_by_abstract, clio-arxiv:search_papers_by_author, clio-arxiv:search_date_range, clio-arxiv:get_paper_details, clio-arxiv:find_similar_papers, clio-arxiv:export_to_bibtex, clio-arxiv:download_paper_pdf, clio-ndp:search_datasets, clio-ndp:get_dataset_details, clio-ndp:stage_resource, clio-arxiv:get_pdf_url
+---
+
+# Surveying research literature
+
+A survey that stops at titles is not a survey. The value is in narrowing
+deliberately, then following the good results into their data.
+
+## Workflow
+
+```
+- [ ] 1. Search broadly, then narrow
+- [ ] 2. Read details for the shortlist only
+- [ ] 3. Expand from the best result, not the query
+- [ ] 4. Export the bibliography
+- [ ] 5. Follow the work to its data
+```
+
+## 1. Search, then narrow
+
+Start with `clio-arxiv:search_arxiv` on the topic. Then narrow using whichever
+axis the question actually implies:
+
+| The user is asking about | Use |
+|---|---|
+| a topic or concept | `clio-arxiv:search_by_abstract` — matches content, not just titles |
+| a person's work | `clio-arxiv:search_papers_by_author` |
+| recent developments | `clio-arxiv:search_date_range` |
+
+Prefer abstract search over title search for concepts. Titles are marketing;
+abstracts contain the method.
+
+## 2. Read details for the shortlist only
+
+`clio-arxiv:get_paper_details` per paper, on the handful worth keeping. Do not
+fetch details for every hit — a search returning 50 papers does not justify 50
+calls.
+
+## 3. Expand from the best result
+
+Once one clearly relevant paper is identified, `clio-arxiv:find_similar_papers`
+on it. This finds neighbours a keyword query misses, and is more productive than
+rewording the original search.
+
+## 4. Export the bibliography
+
+`clio-arxiv:export_to_bibtex` over the final set. Do this before fetching PDFs:
+the bibliography is the deliverable, the PDFs are optional bulk.
+
+`clio-arxiv:download_paper_pdf` only when the user wants the full text. For a
+link rather than a file, `clio-arxiv:get_pdf_url` avoids the download entirely.
+
+## 5. Follow the work to its data
+
+Papers describe datasets; the National Data Platform may hold them.
+
+1. `clio-ndp:search_datasets` using terms from the papers — instrument names,
+   campaign names and locations work better than paper titles.
+2. `clio-ndp:get_dataset_details` on candidates, to check coverage and format
+   before committing to a download.
+3. `clio-ndp:stage_resource` to bring a file local.
+
+Once staged, the file is an ordinary local dataset — hand it to the
+`analyzing-scientific-datasets` skill rather than analysing it here.
+
+## What not to do
+
+- Do not call `get_paper_details` across a whole result set.
+- Do not download PDFs when the user asked for a bibliography.
+- Do not search NDP with paper titles; search with the terms the data would be
+  catalogued under.
+- Do not present a search result as a survey without reading the abstracts.

--- a/skills/tracking-cluster-runs/SKILL.md
+++ b/skills/tracking-cluster-runs/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: tracking-cluster-runs
+description: Starts a JARVIS pipeline on a cluster and follows it to completion through the Slurm queue, keeping the pipeline handle and the scheduler job distinct. Use when a run must go to a cluster rather than the local host, when the user asks whether a job is queued, running, or finished, or when they mention squeue, partitions, pending jobs, or cancelling a run.
+category: HPC
+servers: clio-jarvis, clio-slurm, clio-node-hardware
+tools: clio-jarvis:jarvis_run, clio-jarvis:jarvis_get_execution, clio-slurm:slurm_cluster, clio-slurm:slurm_list, clio-slurm:slurm_describe, clio-slurm:slurm_cancel, clio-node-hardware:get_remote_node_info
+---
+
+# Tracking a cluster run
+
+Two different identifiers are in play and confusing them is the main failure
+mode. `clio-jarvis:jarvis_run` returns a **pipeline execution handle**; Slurm
+returns a **scheduler job ID**. The handle tracks the workload's lifecycle; the
+job ID tracks its place in the queue. Neither answers the other's question.
+
+## Workflow
+
+```
+- [ ] 1. Check the partition can take the job
+- [ ] 2. Start the run with cluster intent
+- [ ] 3. Follow the execution handle
+- [ ] 4. Use Slurm when the handle says "queued"
+- [ ] 5. Report state, not completion
+```
+
+## 1. Check the partition first
+
+`clio-slurm:slurm_cluster` returns partitions and queue depth. A run submitted
+into a saturated partition is not broken, it is waiting — and knowing that
+before starting prevents diagnosing a queue as a failure.
+
+## 2. Start with cluster intent
+
+`clio-jarvis:jarvis_run` with execution intent set to cluster. It returns
+immediately with a durable handle and does **not** wait for the workload.
+
+Treating the return of `jarvis_run` as completion is the most common error this
+skill prevents.
+
+## 3. Follow the handle
+
+`clio-jarvis:jarvis_get_execution` with the pipeline id and the handle. This is
+the authoritative view of the workload: lifecycle state, progress, and runtime
+metadata.
+
+Poll it. Do not infer completion from elapsed time.
+
+## 4. Drop to Slurm only for queue questions
+
+When the handle reports the work as queued or not yet started, the useful
+question is a scheduler question:
+
+- `clio-slurm:slurm_list` — bounded listing, filter by user, state or partition
+- `clio-slurm:slurm_describe` — one job's scheduler state and properties
+- `clio-node-hardware:get_remote_node_info` with `host` — whether the allocated
+  node is actually healthy, when a job is running but producing nothing
+
+Go back to the JARVIS handle for anything about the workload itself. Slurm knows
+the job is running; it does not know whether the pipeline step succeeded.
+
+## 5. Cancelling
+
+`clio-slurm:slurm_cancel` requires `confirm_job_id` to repeat `job_id` exactly.
+That is a deliberate guard on a destructive action — do not work around it by
+guessing an id, and confirm the job is the intended one with
+`clio-slurm:slurm_describe` first.
+
+## Reporting
+
+Report the state and the source. "Queued in partition X, position unknown"
+is a useful answer. "Running" without saying which identifier it came from is
+not, because the two can disagree: a Slurm job can be running while the pipeline
+step it hosts has already failed.
+
+## What not to do
+
+- Do not report a run as finished because `clio-jarvis:jarvis_run` returned.
+- Do not pass a Slurm job ID where a pipeline handle is expected, or the
+  reverse.
+- Do not poll in a tight loop; these are cluster-scale operations.
+- Do not cancel without confirming the job is the intended one.

--- a/src/clio_kit/__init__.py
+++ b/src/clio_kit/__init__.py
@@ -22,11 +22,7 @@ from clio_kit.env_cache import (
     maintain_after_build,
     measure_cache_budget,
 )
-from clio_kit.skills import (
-    discover_skills,
-    find_skills_root,
-    format_skill_listing,
-)
+from clio_kit.skills import SKILL_COMMANDS
 from clio_kit.mcp_contracts import (
     load_mcp_user_contract,
     load_mcp_user_contract_index,
@@ -120,11 +116,6 @@ def _distribution_shared_data_roots(shared_name: str) -> list[Path]:
 def _is_servers_root(path: Path) -> bool:
     """Return whether a directory contains at least one embedded server project."""
     return path.is_dir() and any(path.glob("*/pyproject.toml"))
-
-
-def get_skills_path() -> Path:
-    """Return the shipped skill collection (source checkout or installed wheel)."""
-    return find_skills_root(MODULE_DIR)
 
 
 def get_search_path():
@@ -726,26 +717,6 @@ def search(args):
         sys.exit(1)
 
 
-@main.command("skills")
-def list_skills() -> None:
-    """List the shipped cross-server skills."""
-    for line in format_skill_listing(get_skills_path()):
-        click.echo(line)
-
-
-@main.command("skill")
-@click.argument("skill_name")
-def show_skill(skill_name: str) -> None:
-    """Print one skill's SKILL.md to stdout."""
-    skills = discover_skills(get_skills_path())
-    manifest = skills.get(skill_name.lower())
-    if manifest is None:
-        click.echo(f"Error: Unknown skill '{skill_name}'")
-        click.echo(f"Available skills: {', '.join(skills) or 'none'}")
-        sys.exit(1)
-    click.echo(manifest.read_text(encoding="utf-8"))
-
-
 @main.group("cache")
 def cache_group() -> None:
     """Inspect and reclaim the private MCP runtime cache."""
@@ -846,6 +817,10 @@ def cache_status() -> None:
             sort_keys=True,
         )
     )
+
+
+for _skill_command in SKILL_COMMANDS:
+    main.add_command(_skill_command)
 
 
 def cli():

--- a/src/clio_kit/__init__.py
+++ b/src/clio_kit/__init__.py
@@ -22,6 +22,11 @@ from clio_kit.env_cache import (
     maintain_after_build,
     measure_cache_budget,
 )
+from clio_kit.skills import (
+    discover_skills,
+    find_skills_root,
+    format_skill_listing,
+)
 from clio_kit.mcp_contracts import (
     load_mcp_user_contract,
     load_mcp_user_contract_index,
@@ -117,46 +122,9 @@ def _is_servers_root(path: Path) -> bool:
     return path.is_dir() and any(path.glob("*/pyproject.toml"))
 
 
-def get_prompts_path():
-    """Get the path to prompts directory (dev or installed)"""
-    # First try development path (../../prompts from module)
-    dev_path = MODULE_DIR.parent.parent / "prompts"
-    if dev_path.exists():
-        return dev_path
-
-    # Try to find shared data in the installed package
-    possible_paths = [
-        # Standard site-packages installation
-        MODULE_DIR.parent / "prompts",  # ../prompts from module
-        # Alternative installation paths
-        MODULE_DIR / "prompts",  # ./prompts from module
-        # System-wide data directory
-        Path(sys.prefix) / "share" / "clio-kit" / "prompts",
-        # Local data directory
-        Path.home() / ".local" / "share" / "clio-kit" / "prompts",
-    ]
-
-    # Try each possible path
-    for path in possible_paths:
-        if path.exists() and path.is_dir():
-            return path
-
-    # If none found, check if we're in an isolated environment (like uvx)
-    python_path = Path(sys.executable)
-    isolated_paths = [
-        # uvx style isolated environment
-        python_path.parent.parent / "prompts",
-        python_path.parent.parent / "share" / "prompts",
-        python_path.parent.parent / "purelib" / "prompts",
-        python_path.parent.parent / "data" / "prompts",
-    ]
-
-    for path in isolated_paths:
-        if path.exists() and path.is_dir():
-            return path
-
-    # Last resort: return the dev path
-    return dev_path
+def get_skills_path() -> Path:
+    """Return the shipped skill collection (source checkout or installed wheel)."""
+    return find_skills_root(MODULE_DIR)
 
 
 def get_search_path():
@@ -238,47 +206,10 @@ def auto_discover_mcps():
     return server_command_map, dir_name_map
 
 
-def auto_discover_prompts():
-    """Auto-discover prompts from the prompts directory (recursively)"""
-    prompts_path = get_prompts_path()
-    if not prompts_path.exists():
-        return {}
-
-    prompt_map = {}
-
-    # Recursively scan for .md files
-    for md_file in prompts_path.rglob("*.md"):
-        # Get relative path from prompts directory
-        relative_path = md_file.relative_to(prompts_path)
-
-        # Create prompt name from relative path without extension
-        # e.g., "code-coverage-prompt.md" -> "code-coverage-prompt"
-        # e.g., "testing/foo.md" -> "testing/foo"
-        prompt_name = str(relative_path.with_suffix(""))
-
-        # Also support underscore version
-        # "code-coverage-prompt" -> also accessible as "code_coverage_prompt"
-        prompt_map[prompt_name] = md_file
-        prompt_map[prompt_name.replace("-", "_")] = md_file
-
-    return prompt_map
-
-
 def list_available_servers():
     """List all available servers"""
     server_command_map, _ = auto_discover_mcps()
     return sorted(server_command_map.keys())
-
-
-def list_available_prompts():
-    """List all available prompts"""
-    prompt_map = auto_discover_prompts()
-    # Remove duplicates (dash vs underscore versions)
-    unique_prompts = set()
-    for name in prompt_map.keys():
-        # Normalize to dash version for display
-        unique_prompts.add(name.replace("_", "-"))
-    return sorted(unique_prompts)
 
 
 def subprocess_env_with_github_https_rewrite() -> dict[str, str]:
@@ -519,23 +450,21 @@ def _locked_server_environment_path(
 @click.group(invoke_without_command=True)
 @click.pass_context
 def main(ctx):
-    """clio-kit: Unified launcher for MCP servers and AI prompts"""
+    """clio-kit: Unified launcher for MCP servers, skills, and services"""
     if ctx.invoked_subcommand is None:
-        click.echo(
-            "clio-kit: Unified launcher for MCP servers, AI prompts, and services"
-        )
+        click.echo("clio-kit: Unified launcher for MCP servers, skills, and services")
         click.echo("\nAvailable commands:")
         click.echo("  mcp-server   Run an MCP server")
         click.echo("  mcp-servers  List all available MCP servers")
         click.echo(
             "  search       Run agentic search (query, index, serve, list, seed)"
         )
-        click.echo("  prompt       Print a prompt to stdout")
-        click.echo("  prompts      List all available prompts")
+        click.echo("  skill        Print a skill to stdout")
+        click.echo("  skills       List all available skills")
         click.echo("\nUsage:")
         click.echo("  clio-kit mcp-server <server-name>")
         click.echo("  clio-kit search <subcommand>")
-        click.echo("  clio-kit prompt <prompt-name>")
+        click.echo("  clio-kit skill <skill-name>")
         click.echo("\nFor more help: clio-kit <command> --help")
 
 
@@ -749,56 +678,6 @@ def show_mcp_contract(contract_id: str) -> None:
     click.echo(json.dumps(artifact, separators=(",", ":"), sort_keys=True))
 
 
-@main.command("prompt")
-@click.argument("prompt_name", required=False)
-def prompt(prompt_name):
-    """Print a prompt to stdout. List all if no name specified."""
-
-    prompt_map = auto_discover_prompts()
-
-    if not prompt_name:
-        # List all prompts
-        prompts = list_available_prompts()
-        if prompts:
-            click.echo("Available prompts:")
-            for p in prompts:
-                click.echo(f"  - {p}")
-        else:
-            click.echo("No prompts found.")
-        click.echo("\nUsage: clio-kit prompt <prompt-name>")
-        return
-
-    # Normalize prompt name (support both dash and underscore)
-    prompt_lower = prompt_name.lower()
-
-    if prompt_lower not in prompt_map:
-        click.echo(f"Error: Unknown prompt '{prompt_name}'")
-        click.echo(f"Available prompts: {', '.join(list_available_prompts())}")
-        sys.exit(1)
-
-    # Read and print the prompt file
-    prompt_file = prompt_map[prompt_lower]
-    try:
-        with open(prompt_file, "r") as f:
-            content = f.read()
-        click.echo(content)
-    except Exception as e:
-        click.echo(f"Error reading prompt file: {e}")
-        sys.exit(1)
-
-
-@main.command("prompts")
-def list_prompts_cmd():
-    """List all available prompts"""
-    prompts = list_available_prompts()
-    if prompts:
-        click.echo("Available prompts:")
-        for p in prompts:
-            click.echo(f"  - {p}")
-    else:
-        click.echo("No prompts found.")
-
-
 @main.command(
     "search",
     context_settings=dict(
@@ -845,6 +724,26 @@ def search(args):
             "Error: uvx not found. Please install uv: https://github.com/astral-sh/uv"
         )
         sys.exit(1)
+
+
+@main.command("skills")
+def list_skills() -> None:
+    """List the shipped cross-server skills."""
+    for line in format_skill_listing(get_skills_path()):
+        click.echo(line)
+
+
+@main.command("skill")
+@click.argument("skill_name")
+def show_skill(skill_name: str) -> None:
+    """Print one skill's SKILL.md to stdout."""
+    skills = discover_skills(get_skills_path())
+    manifest = skills.get(skill_name.lower())
+    if manifest is None:
+        click.echo(f"Error: Unknown skill '{skill_name}'")
+        click.echo(f"Available skills: {', '.join(skills) or 'none'}")
+        sys.exit(1)
+    click.echo(manifest.read_text(encoding="utf-8"))
 
 
 @main.group("cache")

--- a/src/clio_kit/skills.py
+++ b/src/clio_kit/skills.py
@@ -17,6 +17,8 @@ Each SKILL.md opens with YAML-style frontmatter carrying at least ``name`` and
 import sys
 from pathlib import Path
 
+import click
+
 SKILL_FILENAME = "SKILL.md"
 REQUIRED_FRONTMATTER = ("name", "description", "category", "servers", "tools")
 
@@ -118,3 +120,83 @@ def format_skill_listing(skills_root: Path) -> list[str]:
     lines.append("")
     lines.append("Usage: clio-kit skill <skill-name>")
     return lines
+
+
+SKILL_INSTALL_SCOPES = {
+    "user": Path.home() / ".claude" / "skills",
+    "project": Path(".claude") / "skills",
+}
+
+
+def format_install_result(skills_root: Path, scope: str) -> list[str]:
+    """Install for one scope and render the outcome as output lines."""
+    destination = SKILL_INSTALL_SCOPES[scope].expanduser().resolve()
+    installed = install_skills(skills_root, destination)
+    if not installed:
+        return ["No skills found to install."]
+    return [f"Installed {len(installed)} skills to {destination}:"] + [
+        f"  - {name}" for name in installed
+    ]
+
+
+def install_skills(skills_root: Path, destination: Path) -> list[str]:
+    """Copy the shipped skills to where an agent discovers them.
+
+    Claude Code reads skills from ~/.claude/skills or ./.claude/skills; the kit
+    ships them inside its wheel, so they are invisible there until copied. Each
+    skill is replaced wholesale rather than merged, so a stale file from an
+    older release cannot survive an upgrade.
+    """
+    import shutil
+
+    skills = discover_skills(skills_root)
+    if not skills:
+        return []
+    destination.mkdir(parents=True, exist_ok=True)
+    installed: list[str] = []
+    for name, manifest in skills.items():
+        target = destination / name
+        if target.exists():
+            shutil.rmtree(target)
+        shutil.copytree(manifest.parent, target)
+        installed.append(name)
+    return installed
+
+
+def _shipped_root() -> Path:
+    """Resolve the collection relative to this module's own install location."""
+    return find_skills_root(Path(__file__).resolve().parent)
+
+
+@click.command("skills")
+def list_skills_command() -> None:
+    """List the shipped cross-server skills, grouped by category."""
+    click.echo("\n".join(format_skill_listing(_shipped_root())))
+
+
+@click.command("skill")
+@click.argument("skill_name")
+def show_skill_command(skill_name: str) -> None:
+    """Print one skill's SKILL.md to stdout."""
+    skills = discover_skills(_shipped_root())
+    manifest = skills.get(skill_name.lower())
+    if manifest is None:
+        click.echo(f"Error: Unknown skill '{skill_name}'")
+        click.echo(f"Available skills: {', '.join(skills) or 'none'}")
+        sys.exit(1)
+    click.echo(manifest.read_text(encoding="utf-8"))
+
+
+@click.command("skills-install")
+@click.option(
+    "--scope",
+    type=click.Choice(sorted(SKILL_INSTALL_SCOPES)),
+    default="user",
+    help="Install for this user (~/.claude/skills) or this project (.claude/skills).",
+)
+def install_skills_command(scope: str) -> None:
+    """Copy the shipped skills to where an agent discovers them."""
+    click.echo("\n".join(format_install_result(_shipped_root(), scope)))
+
+
+SKILL_COMMANDS = (list_skills_command, show_skill_command, install_skills_command)

--- a/src/clio_kit/skills.py
+++ b/src/clio_kit/skills.py
@@ -18,7 +18,7 @@ import sys
 from pathlib import Path
 
 SKILL_FILENAME = "SKILL.md"
-REQUIRED_FRONTMATTER = ("name", "description")
+REQUIRED_FRONTMATTER = ("name", "description", "category", "servers", "tools")
 
 
 def find_skills_root(module_dir: Path) -> Path:
@@ -86,16 +86,35 @@ def describe_skill(manifest: Path) -> str:
     return parse_frontmatter(text).get("description", "")
 
 
+def skill_field(manifest: Path, field: str) -> str:
+    """Return one frontmatter field, or an empty string."""
+    try:
+        text = manifest.read_text(encoding="utf-8")
+    except OSError:
+        return ""
+    return parse_frontmatter(text).get(field, "")
+
+
 def format_skill_listing(skills_root: Path) -> list[str]:
-    """Render `clio-kit skills` as output lines."""
+    """Render `clio-kit skills` grouped by category."""
     skills = discover_skills(skills_root)
     if not skills:
         return ["No skills found."]
-    width = max(len(name) for name in skills)
-    lines = ["Available skills:"]
+    by_category: dict[str, list[tuple[str, Path]]] = {}
     for name, manifest in skills.items():
-        description = describe_skill(manifest)
-        lines.append(f"  {name.ljust(width)}  {description}".rstrip())
+        category = skill_field(manifest, "category") or "Uncategorized"
+        by_category.setdefault(category, []).append((name, manifest))
+
+    lines: list[str] = []
+    for category in sorted(by_category):
+        if lines:
+            lines.append("")
+        lines.append(f"{category}:")
+        for name, manifest in sorted(by_category[category]):
+            lines.append(f"  {name}")
+            summary = describe_skill(manifest).split(". Use when")[0].rstrip(".")
+            if summary:
+                lines.append(f"      {summary}.")
     lines.append("")
     lines.append("Usage: clio-kit skill <skill-name>")
     return lines

--- a/src/clio_kit/skills.py
+++ b/src/clio_kit/skills.py
@@ -199,4 +199,121 @@ def install_skills_command(scope: str) -> None:
     click.echo("\n".join(format_install_result(_shipped_root(), scope)))
 
 
-SKILL_COMMANDS = (list_skills_command, show_skill_command, install_skills_command)
+def read_server_inventory(servers_root: Path) -> dict[str, set[str]]:
+    """Map each client-facing server name to the tools it exposes.
+
+    Clients register these servers as ``clio-<name>``, which is what the
+    generated Claude Desktop, Claude Code and Gemini configs all use, so skills
+    are validated against the names an agent actually sees.
+    """
+    import json
+
+    inventory: dict[str, set[str]] = {}
+    for manifest in sorted(servers_root.glob("*/server.json")):
+        try:
+            document = json.loads(manifest.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            continue
+        inventory[f"clio-{manifest.parent.name}"] = {
+            tool["name"] for tool in document.get("tools", []) if "name" in tool
+        }
+    return inventory
+
+
+def validate_skill(manifest: Path, tools_by_server: dict[str, set[str]]) -> list[str]:
+    """Return every problem with one skill, empty when it is sound.
+
+    Shared by the repository's own test suite and the `skills validate` command,
+    so a skill written outside this repository is held to exactly the same rules
+    as the shipped collection. Reports all problems at once rather than the
+    first, because fixing them one build at a time is the slow way.
+    """
+    problems: list[str] = []
+    text = manifest.read_text(encoding="utf-8")
+    fields = parse_frontmatter(text)
+    body = text.split("---", 2)[-1]
+
+    for key in REQUIRED_FRONTMATTER:
+        if not fields.get(key):
+            problems.append(f"missing frontmatter '{key}'")
+    if not problems and fields["name"] != manifest.parent.name:
+        problems.append(
+            f"frontmatter name {fields['name']!r} does not match "
+            f"directory {manifest.parent.name!r}"
+        )
+    if "Use when" not in fields.get("description", ""):
+        problems.append("description does not say when to use the skill")
+    if len(fields.get("description", "")) > 1024:
+        problems.append("description exceeds 1024 characters")
+
+    servers = {s.strip() for s in fields.get("servers", "").split(",") if s.strip()}
+    if len(servers) < 2:
+        problems.append(
+            "a skill must span more than one server; single-server sequencing "
+            "belongs in that server's MCP prompt"
+        )
+
+    declared = {t.strip() for t in fields.get("tools", "").split(",") if t.strip()}
+    for reference in sorted(declared):
+        server, delimiter, tool = reference.partition(":")
+        if not delimiter:
+            problems.append(f"'{reference}' is unqualified; use server:tool")
+            continue
+        if server not in tools_by_server:
+            problems.append(f"'{reference}' names unknown server '{server}'")
+        elif tool not in tools_by_server[server]:
+            problems.append(f"'{server}' does not expose '{tool}'")
+        elif f"`{reference}`" not in body:
+            problems.append(f"'{reference}' is declared but never used in the steps")
+
+    for server, tools in tools_by_server.items():
+        for tool in tools:
+            if f"`{server}:{tool}`" in body and f"{server}:{tool}" not in declared:
+                problems.append(f"'{server}:{tool}' is used but never declared")
+            elif f"`{tool}`" in body and f":{tool}`" not in body:
+                problems.append(f"'{tool}' is cited without a server prefix")
+    return problems
+
+
+@click.command("skills-validate")
+@click.argument(
+    "path",
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+    required=False,
+)
+def validate_skills_command(path: Path | None) -> None:
+    """Check a skill collection against the servers this kit ships.
+
+    Defaults to the shipped collection. Point it at your own directory to hold
+    an external skill to the same rules.
+    """
+    from clio_kit import get_servers_path
+
+    root = path or _shipped_root()
+    skills = discover_skills(root)
+    if not skills:
+        click.echo(f"No skills found in {root}")
+        sys.exit(1)
+    inventory = read_server_inventory(get_servers_path())
+    failures = 0
+    for name, manifest in skills.items():
+        problems = validate_skill(manifest, inventory)
+        if problems:
+            failures += 1
+            click.echo(f"FAIL: {name}")
+            for problem in problems:
+                click.echo(f"  - {problem}")
+        else:
+            click.echo(f"OK:   {name}")
+    if failures:
+        click.echo(f"\n{failures} of {len(skills)} skills have problems.")
+        sys.exit(1)
+    click.echo(f"\nAll {len(skills)} skills validate against this kit's servers.")
+
+
+SKILL_COMMANDS: tuple[click.Command, ...] = (
+    list_skills_command,
+    show_skill_command,
+    install_skills_command,
+    validate_skills_command,
+)

--- a/src/clio_kit/skills.py
+++ b/src/clio_kit/skills.py
@@ -1,0 +1,101 @@
+"""Discovery for the shipped skill collection.
+
+A skill is a markdown file describing a workflow that spans more than one MCP
+server. Anything one server can express on its own belongs in that server's MCP
+prompt, which ships and versions with its contract; a skill exists for the
+sequences no single server owns -- resolve a Spack install, then hand its exact
+spec to JARVIS to run, for instance.
+
+Layout, one directory per skill so a skill can carry supporting files later::
+
+    skills/<name>/SKILL.md
+
+Each SKILL.md opens with YAML-style frontmatter carrying at least ``name`` and
+``description``, matching the convention agents already read.
+"""
+
+import sys
+from pathlib import Path
+
+SKILL_FILENAME = "SKILL.md"
+REQUIRED_FRONTMATTER = ("name", "description")
+
+
+def find_skills_root(module_dir: Path) -> Path:
+    """Locate the shipped skills directory in a checkout or an installed wheel.
+
+    Mirrors how the launcher already resolves its other shared data: the
+    repository copy wins in a source checkout, then the locations a wheel's
+    shared data can land in.
+    """
+    candidates = [
+        module_dir.parent.parent / "skills",
+        module_dir.parent / "skills",
+        module_dir / "skills",
+        Path(sys.prefix) / "share" / "clio-kit" / "skills",
+        Path(sys.executable).parent.parent / "skills",
+        Path(sys.executable).parent.parent / "share" / "skills",
+    ]
+    for candidate in candidates:
+        if candidate.is_dir():
+            return candidate
+    return candidates[0]
+
+
+def parse_frontmatter(text: str) -> dict[str, str]:
+    """Return the leading ``---`` delimited key/value block, empty if absent.
+
+    Deliberately not a YAML parser: the frontmatter this project ships is flat
+    ``key: value`` lines, and depending on a YAML library to read a shipped
+    asset would put a parser in the launcher's runtime for no gain.
+    """
+    if not text.startswith("---"):
+        return {}
+    _, _, rest = text.partition("\n")
+    block, sep, _ = rest.partition("\n---")
+    if not sep:
+        return {}
+    fields: dict[str, str] = {}
+    for line in block.splitlines():
+        key, delimiter, value = line.partition(":")
+        if delimiter and key.strip() and not key.startswith((" ", "\t", "#")):
+            fields[key.strip()] = value.strip().strip("\"'")
+    return fields
+
+
+def discover_skills(skills_root: Path) -> dict[str, Path]:
+    """Map skill name to its SKILL.md, keyed by directory name."""
+    if not skills_root.is_dir():
+        return {}
+    found: dict[str, Path] = {}
+    for child in sorted(skills_root.iterdir()):
+        if child.name.startswith(".") or not child.is_dir():
+            continue
+        manifest = child / SKILL_FILENAME
+        if manifest.is_file():
+            found[child.name] = manifest
+    return found
+
+
+def describe_skill(manifest: Path) -> str:
+    """Return one skill's one-line description, or an empty string."""
+    try:
+        text = manifest.read_text(encoding="utf-8")
+    except OSError:
+        return ""
+    return parse_frontmatter(text).get("description", "")
+
+
+def format_skill_listing(skills_root: Path) -> list[str]:
+    """Render `clio-kit skills` as output lines."""
+    skills = discover_skills(skills_root)
+    if not skills:
+        return ["No skills found."]
+    width = max(len(name) for name in skills)
+    lines = ["Available skills:"]
+    for name, manifest in skills.items():
+        description = describe_skill(manifest)
+        lines.append(f"  {name.ljust(width)}  {description}".rstrip())
+    lines.append("")
+    lines.append("Usage: clio-kit skill <skill-name>")
+    return lines

--- a/tests/test_generate_server_json_contract.py
+++ b/tests/test_generate_server_json_contract.py
@@ -86,9 +86,12 @@ def test_every_committed_server_has_an_agent_runnable_package_coordinate() -> No
             encoding="utf-8"
         )
     )
+    # clio-skills is a kit-level plugin carrying cross-server workflows, not a
+    # server, so it is excluded from the per-server coordinate comparison below.
     marketplace_plugins = {
         plugin["name"].removeprefix("clio-"): plugin
         for plugin in marketplace["plugins"]
+        if plugin["name"] != "clio-skills"
     }
     gemini_extension = json.loads(
         (repository_root / "gemini-extension.json").read_text(encoding="utf-8")

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -16,7 +16,6 @@ from click.testing import CliRunner
 from clio_kit import get_skills_path, main
 from clio_kit.skills import (
     REQUIRED_FRONTMATTER,
-    describe_skill,
     discover_skills,
     find_skills_root,
     format_skill_listing,
@@ -27,18 +26,28 @@ REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
 TOOL_REFERENCE = re.compile(r"`([a-z][a-z0-9_]*)`")
 
 
-def _shipped_tool_names() -> set[str]:
+def _shipped_tools_by_server() -> dict[str, set[str]]:
+    """Map the client-facing server name to the tools it exposes.
+
+    Clients register these servers as ``clio-<name>`` -- that is what the
+    generated Claude Desktop, Claude Code and Gemini configs all use -- so a
+    skill's fully qualified references are checked against the same names an
+    agent would actually see.
+    """
     servers = REPOSITORY_ROOT / "clio-kit-mcp-servers"
     return {
-        tool["name"]
+        f"clio-{manifest.parent.name}": {
+            tool["name"]
+            for tool in json.loads(manifest.read_text(encoding="utf-8")).get(
+                "tools", []
+            )
+        }
         for manifest in servers.glob("*/server.json")
-        for tool in json.loads(manifest.read_text(encoding="utf-8")).get("tools", [])
     }
 
 
 def _shipped_server_names() -> set[str]:
-    servers = REPOSITORY_ROOT / "clio-kit-mcp-servers"
-    return {path.parent.name for path in servers.glob("*/pyproject.toml")}
+    return set(_shipped_tools_by_server())
 
 
 SKILLS = sorted(discover_skills(REPOSITORY_ROOT / "skills").items())
@@ -84,8 +93,17 @@ def test_every_tool_a_skill_declares_still_exists(name: str, manifest: Path) -> 
     declared = {t.strip() for t in fields.get("tools", "").split(",") if t.strip()}
 
     assert declared, f"{name} declares no tools; it is not describing a workflow"
-    missing = sorted(declared - _shipped_tool_names())
-    assert not missing, f"{name} declares tools that no longer exist: {missing}"
+    shipped = _shipped_tools_by_server()
+    for reference in sorted(declared):
+        server, delimiter, tool = reference.partition(":")
+        assert delimiter, (
+            f"{name} cites '{reference}' unqualified; MCP references must be "
+            "server:tool or an agent with several servers mounted cannot resolve them"
+        )
+        assert server in shipped, f"{name} cites unknown server '{server}'"
+        assert tool in shipped[server], (
+            f"{name} cites '{tool}' which {server} does not expose"
+        )
 
 
 @pytest.mark.parametrize("name,manifest", SKILLS, ids=[n for n, _ in SKILLS])
@@ -118,12 +136,78 @@ def test_a_skill_spans_more_than_one_server() -> None:
         )
 
 
+@pytest.mark.parametrize("name,manifest", SKILLS, ids=[n for n, _ in SKILLS])
+def test_body_cites_nothing_the_frontmatter_did_not_declare(
+    name: str, manifest: Path
+) -> None:
+    """The declared list is what the drift guard checks, so it must be complete.
+
+    A tool used in the steps but missing from `tools:` is invisible to the
+    existence check above, which is exactly how a skill would survive a rename
+    it should have failed.
+    """
+    body = manifest.read_text(encoding="utf-8")
+    declared = {t.strip() for t in parse_frontmatter(body).get("tools", "").split(",")}
+    steps = body.split("---", 2)[-1]
+    cited = {
+        f"{server}:{tool}"
+        for server, tools in _shipped_tools_by_server().items()
+        for tool in tools
+        if f"`{server}:{tool}`" in steps
+    }
+
+    undeclared = sorted(cited - declared)
+    assert not undeclared, f"{name} uses tools it never declared: {undeclared}"
+
+
+@pytest.mark.parametrize("name,manifest", SKILLS, ids=[n for n, _ in SKILLS])
+def test_body_never_cites_a_tool_unqualified(name: str, manifest: Path) -> None:
+    """`identify_io_bottlenecks` exists on two servers; bare names are ambiguous."""
+    shipped = _shipped_tools_by_server()
+    every_tool = {tool for tools in shipped.values() for tool in tools}
+    body = manifest.read_text(encoding="utf-8").split("---", 2)[-1]
+
+    bare = sorted(
+        tool for tool in every_tool if f"`{tool}`" in body and f":{tool}`" not in body
+    )
+    assert not bare, f"{name} cites tools without a server prefix: {bare}"
+
+
+@pytest.mark.parametrize("name,manifest", SKILLS, ids=[n for n, _ in SKILLS])
+def test_description_says_when_to_use_the_skill(name: str, manifest: Path) -> None:
+    """The description is the only thing loaded until a skill triggers.
+
+    Anthropic's authoring guidance is explicit: it must carry both what the
+    skill does and when to reach for it, in third person, within 1024
+    characters. Without the trigger half an agent cannot select it.
+    """
+    description = parse_frontmatter(manifest.read_text(encoding="utf-8"))["description"]
+
+    assert "Use when" in description, f"{name} never says when to use it"
+    assert len(description) <= 1024, f"{name} description exceeds 1024 characters"
+    assert not description.startswith(("I ", "You ")), "write in third person"
+
+
+def test_skill_names_follow_one_convention() -> None:
+    """A mixed collection is harder to search and reference."""
+    for name, _ in SKILLS:
+        assert name.islower() and " " not in name and "_" not in name, name
+        assert len(name) <= 64, name
+        assert name.split("-")[0].endswith("ing"), (
+            f"{name} should use the gerund form the collection settled on"
+        )
+
+
 def test_listing_reports_each_skill_with_its_description() -> None:
     lines = format_skill_listing(REPOSITORY_ROOT / "skills")
 
-    assert lines[0] == "Available skills:"
-    for name, manifest in SKILLS:
-        assert any(name in line and describe_skill(manifest) in line for line in lines)
+    categories = {
+        parse_frontmatter(m.read_text(encoding="utf-8"))["category"] for _, m in SKILLS
+    }
+    for category in categories:
+        assert f"{category}:" in lines
+    for name, _ in SKILLS:
+        assert any(name in line for line in lines)
 
 
 def test_missing_skills_directory_reports_rather_than_raises(tmp_path: Path) -> None:

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -13,12 +13,14 @@ from pathlib import Path
 import pytest
 from click.testing import CliRunner
 
-from clio_kit import get_skills_path, main
+from clio_kit import main
 from clio_kit.skills import (
+    _shipped_root,
     REQUIRED_FRONTMATTER,
     discover_skills,
     find_skills_root,
     format_skill_listing,
+    install_skills,
     parse_frontmatter,
 )
 
@@ -226,7 +228,7 @@ def test_skills_root_resolves_inside_the_source_checkout() -> None:
     assert find_skills_root(REPOSITORY_ROOT / "src" / "clio_kit") == (
         REPOSITORY_ROOT / "skills"
     )
-    assert get_skills_path().is_dir()
+    assert _shipped_root().is_dir()
 
 
 def test_cli_prints_a_skill_and_rejects_an_unknown_one() -> None:
@@ -241,3 +243,48 @@ def test_cli_prints_a_skill_and_rejects_an_unknown_one() -> None:
     assert missing.exit_code == 1
     assert "Unknown skill" in missing.output
     assert name in missing.output
+
+
+def test_the_skills_plugin_manifest_matches_what_ships() -> None:
+    """The plugin is generated, so it cannot drift from the collection."""
+    manifest = json.loads(
+        (REPOSITORY_ROOT / ".claude-plugin" / "plugin.json").read_text(encoding="utf-8")
+    )
+
+    assert manifest["name"] == "clio-skills"
+    assert manifest["skills"] == "./skills/", (
+        "must point at the repository's skills directory, the documented layout"
+    )
+    for name, _ in SKILLS:
+        assert name in manifest["description"]
+
+
+def test_the_marketplace_offers_the_skills_plugin() -> None:
+    """`/plugin install` has to be able to reach the workflows, not just servers."""
+    marketplace = json.loads(
+        (REPOSITORY_ROOT / ".claude-plugin" / "marketplace.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    entry = next(p for p in marketplace["plugins"] if p["name"] == "clio-skills")
+
+    assert entry["source"] == "./"
+    assert entry["category"] == "workflows"
+
+
+def test_installing_replaces_a_stale_copy_rather_than_merging(tmp_path: Path) -> None:
+    """An upgrade must not leave a file from the previous release behind."""
+    destination = tmp_path / "skills"
+    first = install_skills(REPOSITORY_ROOT / "skills", destination)
+    stale = destination / first[0] / "LEFTOVER.md"
+    stale.write_text("from an older release", encoding="utf-8")
+
+    second = install_skills(REPOSITORY_ROOT / "skills", destination)
+
+    assert sorted(second) == sorted(first)
+    assert not stale.exists()
+    assert (destination / first[0] / "SKILL.md").is_file()
+
+
+def test_installing_into_an_empty_collection_reports_nothing(tmp_path: Path) -> None:
+    assert install_skills(tmp_path / "absent", tmp_path / "dest") == []

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -16,12 +16,12 @@ from click.testing import CliRunner
 from clio_kit import main
 from clio_kit.skills import (
     _shipped_root,
-    REQUIRED_FRONTMATTER,
     discover_skills,
     find_skills_root,
     format_skill_listing,
     install_skills,
     parse_frontmatter,
+    validate_skill,
 )
 
 REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
@@ -62,132 +62,63 @@ def test_the_repository_ships_at_least_one_skill() -> None:
 
 
 @pytest.mark.parametrize("name,manifest", SKILLS, ids=[n for n, _ in SKILLS])
-def test_skill_declares_the_required_frontmatter(name: str, manifest: Path) -> None:
-    fields = parse_frontmatter(manifest.read_text(encoding="utf-8"))
+def test_shipped_skill_satisfies_every_rule(name: str, manifest: Path) -> None:
+    """The suite and `clio-kit skills-validate` enforce one implementation.
 
-    for key in REQUIRED_FRONTMATTER:
-        assert fields.get(key), f"{name} is missing frontmatter '{key}'"
-    assert fields["name"] == name, "frontmatter name must match the directory"
+    validate_skill covers the frontmatter, the more-than-one-server rule, and
+    the tool declarations in both directions -- declared tools must exist on the
+    server named and be used in the steps, and tools used in the steps must be
+    declared. Sharing it means an externally authored skill is held to exactly
+    the rules the shipped collection is.
+    """
+    problems = validate_skill(manifest, _shipped_tools_by_server())
+
+    assert not problems, f"{name}: " + "; ".join(problems)
 
 
-@pytest.mark.parametrize("name,manifest", SKILLS, ids=[n for n, _ in SKILLS])
-def test_skill_names_only_servers_that_ship(name: str, manifest: Path) -> None:
-    """A skill pointing at a removed or renamed server sends an agent nowhere."""
-    fields = parse_frontmatter(manifest.read_text(encoding="utf-8"))
-    declared = {s.strip() for s in fields.get("servers", "").split(",") if s.strip()}
-
-    assert declared, f"{name} must declare which servers it spans"
-    assert declared <= _shipped_server_names(), (
-        f"{name} names servers that do not ship: {sorted(declared - _shipped_server_names())}"
+def test_validation_reports_every_problem_at_once(tmp_path: Path) -> None:
+    """Fixing one problem per build is the slow way to write a skill."""
+    skill = tmp_path / "broken-skill"
+    skill.mkdir()
+    (skill / "SKILL.md").write_text(
+        "---\n"
+        "name: wrong-name\n"
+        "description: Does a thing.\n"
+        "category: Custom\n"
+        "servers: clio-hdf5\n"
+        "tools: clio-hdf5:get_shape, clio-hdf5:no_such_tool\n"
+        "---\n"
+        "Call `get_shape`.\n",
+        encoding="utf-8",
     )
 
+    problems = validate_skill(skill / "SKILL.md", _shipped_tools_by_server())
 
-@pytest.mark.parametrize("name,manifest", SKILLS, ids=[n for n, _ in SKILLS])
-def test_every_tool_a_skill_declares_still_exists(name: str, manifest: Path) -> None:
-    """The check that makes skills survive #357's merges and renames.
-
-    A skill declares its tools in frontmatter rather than having them inferred
-    from prose: a body legitimately mentions parameter names, and this one
-    deliberately names a tool that does not exist ("do not look for spack_load")
-    to stop an agent hunting for it.
-    """
-    fields = parse_frontmatter(manifest.read_text(encoding="utf-8"))
-    declared = {t.strip() for t in fields.get("tools", "").split(",") if t.strip()}
-
-    assert declared, f"{name} declares no tools; it is not describing a workflow"
-    shipped = _shipped_tools_by_server()
-    for reference in sorted(declared):
-        server, delimiter, tool = reference.partition(":")
-        assert delimiter, (
-            f"{name} cites '{reference}' unqualified; MCP references must be "
-            "server:tool or an agent with several servers mounted cannot resolve them"
-        )
-        assert server in shipped, f"{name} cites unknown server '{server}'"
-        assert tool in shipped[server], (
-            f"{name} cites '{tool}' which {server} does not expose"
-        )
+    assert any("does not match" in p for p in problems)
+    assert any("when to use" in p for p in problems)
+    assert any("more than one server" in p for p in problems)
+    assert any("does not expose 'no_such_tool'" in p for p in problems)
+    assert any("without a server prefix" in p for p in problems)
 
 
-@pytest.mark.parametrize("name,manifest", SKILLS, ids=[n for n, _ in SKILLS])
-def test_declared_tools_are_actually_used_in_the_body(
-    name: str, manifest: Path
-) -> None:
-    """The declaration and the prose must not drift apart."""
-    body = manifest.read_text(encoding="utf-8")
-    fields = parse_frontmatter(body)
-    declared = {t.strip() for t in fields.get("tools", "").split(",") if t.strip()}
-    steps = body.split("---", 2)[-1]
-
-    unused = sorted(tool for tool in declared if f"`{tool}`" not in steps)
-    assert not unused, f"{name} declares tools its steps never mention: {unused}"
-
-
-def test_a_skill_spans_more_than_one_server() -> None:
-    """Single-server sequencing belongs in that server's MCP prompt instead.
-
-    Prompts ship and version with the server's contract; a skill that duplicates
-    one just gives the agent two sources that can disagree.
-    """
-    for name, manifest in SKILLS:
-        fields = parse_frontmatter(manifest.read_text(encoding="utf-8"))
-        declared = {
-            s.strip() for s in fields.get("servers", "").split(",") if s.strip()
-        }
-        assert len(declared) > 1, (
-            f"{name} spans one server; make it an MCP prompt on that server"
-        )
-
-
-@pytest.mark.parametrize("name,manifest", SKILLS, ids=[n for n, _ in SKILLS])
-def test_body_cites_nothing_the_frontmatter_did_not_declare(
-    name: str, manifest: Path
-) -> None:
-    """The declared list is what the drift guard checks, so it must be complete.
-
-    A tool used in the steps but missing from `tools:` is invisible to the
-    existence check above, which is exactly how a skill would survive a rename
-    it should have failed.
-    """
-    body = manifest.read_text(encoding="utf-8")
-    declared = {t.strip() for t in parse_frontmatter(body).get("tools", "").split(",")}
-    steps = body.split("---", 2)[-1]
-    cited = {
-        f"{server}:{tool}"
-        for server, tools in _shipped_tools_by_server().items()
-        for tool in tools
-        if f"`{server}:{tool}`" in steps
-    }
-
-    undeclared = sorted(cited - declared)
-    assert not undeclared, f"{name} uses tools it never declared: {undeclared}"
-
-
-@pytest.mark.parametrize("name,manifest", SKILLS, ids=[n for n, _ in SKILLS])
-def test_body_never_cites_a_tool_unqualified(name: str, manifest: Path) -> None:
-    """`identify_io_bottlenecks` exists on two servers; bare names are ambiguous."""
-    shipped = _shipped_tools_by_server()
-    every_tool = {tool for tools in shipped.values() for tool in tools}
-    body = manifest.read_text(encoding="utf-8").split("---", 2)[-1]
-
-    bare = sorted(
-        tool for tool in every_tool if f"`{tool}`" in body and f":{tool}`" not in body
+def test_an_external_skill_can_be_validated_against_this_kit(tmp_path: Path) -> None:
+    """Third parties writing skills for these servers get the same guard."""
+    skill = tmp_path / "checking-node-health-before-a-run"
+    skill.mkdir()
+    (skill / "SKILL.md").write_text(
+        "---\n"
+        "name: checking-node-health-before-a-run\n"
+        "description: Checks a node before submitting. Use when a job must not "
+        "land on an unhealthy node.\n"
+        "category: Custom\n"
+        "servers: clio-node-hardware, clio-slurm\n"
+        "tools: clio-node-hardware:health_check, clio-slurm:slurm_cluster\n"
+        "---\n"
+        "Run `clio-node-hardware:health_check`, then `clio-slurm:slurm_cluster`.\n",
+        encoding="utf-8",
     )
-    assert not bare, f"{name} cites tools without a server prefix: {bare}"
 
-
-@pytest.mark.parametrize("name,manifest", SKILLS, ids=[n for n, _ in SKILLS])
-def test_description_says_when_to_use_the_skill(name: str, manifest: Path) -> None:
-    """The description is the only thing loaded until a skill triggers.
-
-    Anthropic's authoring guidance is explicit: it must carry both what the
-    skill does and when to reach for it, in third person, within 1024
-    characters. Without the trigger half an agent cannot select it.
-    """
-    description = parse_frontmatter(manifest.read_text(encoding="utf-8"))["description"]
-
-    assert "Use when" in description, f"{name} never says when to use it"
-    assert len(description) <= 1024, f"{name} description exceeds 1024 characters"
-    assert not description.startswith(("I ", "You ")), "write in third person"
+    assert validate_skill(skill / "SKILL.md", _shipped_tools_by_server()) == []
 
 
 def test_skill_names_follow_one_convention() -> None:
@@ -288,3 +219,21 @@ def test_installing_replaces_a_stale_copy_rather_than_merging(tmp_path: Path) ->
 
 def test_installing_into_an_empty_collection_reports_nothing(tmp_path: Path) -> None:
     assert install_skills(tmp_path / "absent", tmp_path / "dest") == []
+
+
+def test_installing_leaves_skills_from_other_sources_alone(tmp_path: Path) -> None:
+    """An install must not own the directory, only the skills it ships.
+
+    Claude Code merges skills from the user directory, the project directory and
+    every installed plugin, so a user's own skill lives beside these. Clearing
+    the destination would delete it.
+    """
+    destination = tmp_path / "skills"
+    foreign = destination / "someone-elses-skill"
+    foreign.mkdir(parents=True)
+    (foreign / "SKILL.md").write_text("---\nname: x\n---\n", encoding="utf-8")
+
+    install_skills(REPOSITORY_ROOT / "skills", destination)
+
+    assert (foreign / "SKILL.md").is_file(), "installing clobbered a foreign skill"
+    assert len(list(destination.iterdir())) == len(SKILLS) + 1

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -1,0 +1,159 @@
+"""The shipped skills must stay true to the contracts they describe.
+
+A skill hard-codes tool names and the servers they live on. Nothing else in the
+build notices when a tool is renamed, merged into another server, or removed, so
+a skill is the one asset here that can quietly become wrong while every other
+check stays green. These tests are that notice.
+"""
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from clio_kit import get_skills_path, main
+from clio_kit.skills import (
+    REQUIRED_FRONTMATTER,
+    describe_skill,
+    discover_skills,
+    find_skills_root,
+    format_skill_listing,
+    parse_frontmatter,
+)
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+TOOL_REFERENCE = re.compile(r"`([a-z][a-z0-9_]*)`")
+
+
+def _shipped_tool_names() -> set[str]:
+    servers = REPOSITORY_ROOT / "clio-kit-mcp-servers"
+    return {
+        tool["name"]
+        for manifest in servers.glob("*/server.json")
+        for tool in json.loads(manifest.read_text(encoding="utf-8")).get("tools", [])
+    }
+
+
+def _shipped_server_names() -> set[str]:
+    servers = REPOSITORY_ROOT / "clio-kit-mcp-servers"
+    return {path.parent.name for path in servers.glob("*/pyproject.toml")}
+
+
+SKILLS = sorted(discover_skills(REPOSITORY_ROOT / "skills").items())
+
+
+def test_the_repository_ships_at_least_one_skill() -> None:
+    assert SKILLS, (
+        "skills/ is empty; the launcher's skill commands have nothing to serve"
+    )
+
+
+@pytest.mark.parametrize("name,manifest", SKILLS, ids=[n for n, _ in SKILLS])
+def test_skill_declares_the_required_frontmatter(name: str, manifest: Path) -> None:
+    fields = parse_frontmatter(manifest.read_text(encoding="utf-8"))
+
+    for key in REQUIRED_FRONTMATTER:
+        assert fields.get(key), f"{name} is missing frontmatter '{key}'"
+    assert fields["name"] == name, "frontmatter name must match the directory"
+
+
+@pytest.mark.parametrize("name,manifest", SKILLS, ids=[n for n, _ in SKILLS])
+def test_skill_names_only_servers_that_ship(name: str, manifest: Path) -> None:
+    """A skill pointing at a removed or renamed server sends an agent nowhere."""
+    fields = parse_frontmatter(manifest.read_text(encoding="utf-8"))
+    declared = {s.strip() for s in fields.get("servers", "").split(",") if s.strip()}
+
+    assert declared, f"{name} must declare which servers it spans"
+    assert declared <= _shipped_server_names(), (
+        f"{name} names servers that do not ship: {sorted(declared - _shipped_server_names())}"
+    )
+
+
+@pytest.mark.parametrize("name,manifest", SKILLS, ids=[n for n, _ in SKILLS])
+def test_every_tool_a_skill_declares_still_exists(name: str, manifest: Path) -> None:
+    """The check that makes skills survive #357's merges and renames.
+
+    A skill declares its tools in frontmatter rather than having them inferred
+    from prose: a body legitimately mentions parameter names, and this one
+    deliberately names a tool that does not exist ("do not look for spack_load")
+    to stop an agent hunting for it.
+    """
+    fields = parse_frontmatter(manifest.read_text(encoding="utf-8"))
+    declared = {t.strip() for t in fields.get("tools", "").split(",") if t.strip()}
+
+    assert declared, f"{name} declares no tools; it is not describing a workflow"
+    missing = sorted(declared - _shipped_tool_names())
+    assert not missing, f"{name} declares tools that no longer exist: {missing}"
+
+
+@pytest.mark.parametrize("name,manifest", SKILLS, ids=[n for n, _ in SKILLS])
+def test_declared_tools_are_actually_used_in_the_body(
+    name: str, manifest: Path
+) -> None:
+    """The declaration and the prose must not drift apart."""
+    body = manifest.read_text(encoding="utf-8")
+    fields = parse_frontmatter(body)
+    declared = {t.strip() for t in fields.get("tools", "").split(",") if t.strip()}
+    steps = body.split("---", 2)[-1]
+
+    unused = sorted(tool for tool in declared if f"`{tool}`" not in steps)
+    assert not unused, f"{name} declares tools its steps never mention: {unused}"
+
+
+def test_a_skill_spans_more_than_one_server() -> None:
+    """Single-server sequencing belongs in that server's MCP prompt instead.
+
+    Prompts ship and version with the server's contract; a skill that duplicates
+    one just gives the agent two sources that can disagree.
+    """
+    for name, manifest in SKILLS:
+        fields = parse_frontmatter(manifest.read_text(encoding="utf-8"))
+        declared = {
+            s.strip() for s in fields.get("servers", "").split(",") if s.strip()
+        }
+        assert len(declared) > 1, (
+            f"{name} spans one server; make it an MCP prompt on that server"
+        )
+
+
+def test_listing_reports_each_skill_with_its_description() -> None:
+    lines = format_skill_listing(REPOSITORY_ROOT / "skills")
+
+    assert lines[0] == "Available skills:"
+    for name, manifest in SKILLS:
+        assert any(name in line and describe_skill(manifest) in line for line in lines)
+
+
+def test_missing_skills_directory_reports_rather_than_raises(tmp_path: Path) -> None:
+    assert discover_skills(tmp_path / "absent") == {}
+    assert format_skill_listing(tmp_path / "absent") == ["No skills found."]
+
+
+def test_frontmatter_parsing_ignores_a_body_without_one() -> None:
+    assert parse_frontmatter("# Just a heading\n") == {}
+    assert parse_frontmatter("---\nname: x\n") == {}, (
+        "unterminated block is not frontmatter"
+    )
+
+
+def test_skills_root_resolves_inside_the_source_checkout() -> None:
+    assert find_skills_root(REPOSITORY_ROOT / "src" / "clio_kit") == (
+        REPOSITORY_ROOT / "skills"
+    )
+    assert get_skills_path().is_dir()
+
+
+def test_cli_prints_a_skill_and_rejects_an_unknown_one() -> None:
+    runner = CliRunner()
+    name = SKILLS[0][0]
+
+    shown = runner.invoke(main, ["skill", name])
+    assert shown.exit_code == 0
+    assert f"name: {name}" in shown.output
+
+    missing = runner.invoke(main, ["skill", "no-such-skill"])
+    assert missing.exit_code == 1
+    assert "Unknown skill" in missing.output
+    assert name in missing.output


### PR DESCRIPTION
Adds the skill collection #359 asked for, plus the two things that make it usable: it ships as a Claude Code plugin, and any skill — including one written outside this repository — can be validated against the servers this kit exposes.

## What a skill is here, and what it is not

A skill is a markdown workflow that **spans more than one MCP server**. Anything a single server can sequence belongs in that server's MCP prompt instead, where it ships and versions with the contract rather than sitting beside it and disagreeing. That rule is enforced, not just written down.

Five skills, one per category:

| Category | Skill | Spans |
|---|---|---|
| Data Analysis | `analyzing-scientific-datasets` | hdf5 / parquet / adios → pandas → plot |
| HPC | `running-spack-packages-with-jarvis` | spack → jarvis |
| HPC | `tracking-cluster-runs` | jarvis ↔ slurm, node-hardware |
| Performance | `diagnosing-io-performance` | darshan → hdf5 / adios → node-hardware |
| Research | `surveying-research-literature` | arxiv → ndp |

Each encodes a failure the kit's own design implies: reading a whole dataset to compute one aggregate; treating `jarvis_run`'s return as completion; blaming a chunk layout for what was a full disk; stopping a literature survey at titles.

`running-spack-packages-with-jarvis` is the kit's own documented flow, not an invention — `spack://capabilities` already declares `stateful_load_exposed: false` and `runtime_owner: jarvis_run`, and `spack_locate` already tells the agent to copy `load_spec` unchanged into `jarvis_run`.

## It replaces a surface that had been dead since February

`prompts/` held exactly one file, `code-coverage-prompt.md`, deleted on 2026-02-19 in a commit titled *"cleanup old docs and planning markdown files"* — swept up as a stray planning doc, not retired as a feature. Since then `clio-kit prompts` answered "No prompts found", `clio-kit prompt <name>` could not succeed, `pyproject.toml` shipped a `prompts` shared-data entry pointing at nothing, and five launcher functions served all of it.

Carrying two near-identical markdown-asset mechanisms was not worth it, so skills take the shared-data slot. **Net effect: adding a whole CLI surface still left the launcher smaller than it started — 990 → 832 lines**, ratchet baseline following each time.

## Written to Anthropic's published guidance

Researched the Agent Skills format before writing, which changed the work:

- **Fully qualified MCP tool references** (`clio-spack:spack_locate`). Not cosmetic here — `identify_io_bottlenecks` exists on **both** darshan and hdf5 and means different things, which the I/O skill calls out. Clients register these servers as `clio-<name>`, which is what the generated Desktop/Code/Gemini configs use.
- **Descriptions carry what the skill does *and* when to reach for it**, third person — metadata is all that loads until a skill triggers.
- **Gerund naming**, bodies at 77–92 lines against the 500-line guidance, checklists for multi-step work, and an explicit "what not to do" per skill.

## Automated distribution

`scripts/generate_server_json.py` reads each `SKILL.md`'s frontmatter and generates `.claude-plugin/plugin.json` plus the marketplace entry, failing generation on a missing field or a name that disagrees with its directory — the same discipline the server manifests follow. A new skill needs no manual registration.

```
/plugin marketplace add iowarp/clio-kit
/plugin install clio-skills@iowarp-clio-kit
```

For anyone not using the marketplace, `clio-kit skills-install --scope user|project` copies them where Claude Code reads. It replaces only the skills it ships — a test plants a foreign skill and asserts it survives, since clearing the directory would have been the obvious implementation and the wrong one.

Note `clio-skills` is a **kit-level** plugin with `source: "./"`, because skills are cross-server by construction and cannot belong to any one server's plugin. The per-server coordinate test excludes it explicitly for that reason.

## Skills cannot rot silently

A skill hard-codes tool names, so it is the one asset here that can go wrong while every other check stays green — particularly with #357's merges and renames in flight.

`validate_skill()` is shared by the test suite and `clio-kit skills-validate`, so the rules apply to skills written anywhere, not only in this repo:

```
$ clio-kit skills-validate /path/to/external/skills
FAIL: my-skill
  - description does not say when to use the skill
  - a skill must span more than one server
  - 'clio-hdf5' does not expose 'no_such_tool'
  - 'get_shape' is cited without a server prefix
```

Both directions are checked — every declared tool must exist on the server named and be used in the steps, and every tool used in the steps must be declared. **That second direction immediately found six real omissions across three of my own skills**, each invisible to the existence check. Sabotage-tested by renaming `spack_locate`.

## Documentation

`CONTRIBUTING.md` explained adding an MCP server in seven steps and said nothing about skills, so the rules were discoverable only by failing CI. Adds "Adding a Skill" with the layout, every frontmatter field and why it exists, the enforced rules with reasons, both install routes, and external validation. `CLAUDE.md` gains the directory and the four commands.

## Relationship to other issues

Skills become a **fifth generated channel** alongside the registry, marketplace, Claude Desktop and Gemini manifests — same generator, same CI verification. That is partly an answer by demonstration to #360's "which channels does v2 ship through".

Independent of #357: this branch is off `develop` and no skill references geo, geojson, sac or seismic, so the merges in #368 cannot invalidate one. If they later do, `skills-validate` fails rather than misleading an agent.

## Verification

172 root tests · ruff · format · mypy · size ratchet green · manifests regenerated by their generator, never hand-edited.

Known stale, left alone deliberately: `CLAUDE.md`'s "Running Servers" block still documents `uvx clio-kit hdf5`, which stopped being the interface when the launcher moved to subcommands. That is a docs fix, not a skills change.