### PR TITLE
feat(web): add provider-fixed search and document fetching

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "CLIO Kit - MCP Servers for Scientific Computing and HPC",
-    "version": "2.8.0",
+    "version": "2.9.0",
     "pluginRoot": "./clio-kit-mcp-servers"
   },
   "plugins": [
@@ -326,8 +326,8 @@
     {
       "name": "clio-web",
       "source": "./clio-kit-mcp-servers/web",
-      "description": "Web MCP server providing curated fetch + search tools for agentic web access",
-      "version": "1.1.0",
+      "description": "Provider-fixed web search plus transparent URL, DOI, and document fetching",
+      "version": "2.0.0",
       "category": "development",
       "keywords": [],
       "license": "BSD-3-Clause",

--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ distinct `not_installed` semantic, while real Spack failures remain errors.
 | **`slurm`** | 3.0.0 | HPC | Job submission and management | `clio-kit mcp-server slurm` |
 | **`spack`** | 2.1.0 | Package Management | Structured package discovery, installation, and location | `clio-kit mcp-server spack` |
 | **`terrain`** | 2.2.3 | Geospatial | Analyze DEMs and terrain point clouds | `clio-kit mcp-server terrain` |
-| **`web`** | 1.1.0 | Web | Fetch a URL to Markdown and search the web | `clio-kit mcp-server web` |
+| **`web`** | 2.0.0 | Web | Provider-fixed web search plus unified URL, DOI, and document fetching | `clio-kit mcp-server web` |
 
 </div>
 

--- a/clio-kit-mcp-servers/adios/server.json
+++ b/clio-kit-mcp-servers/adios/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.8.0",
+      "version": "2.9.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/arxiv/server.json
+++ b/clio-kit-mcp-servers/arxiv/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.8.0",
+      "version": "2.9.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/chronolog/server.json
+++ b/clio-kit-mcp-servers/chronolog/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.8.0",
+      "version": "2.9.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/compression/server.json
+++ b/clio-kit-mcp-servers/compression/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.8.0",
+      "version": "2.9.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/darshan/server.json
+++ b/clio-kit-mcp-servers/darshan/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.8.0",
+      "version": "2.9.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/geo/server.json
+++ b/clio-kit-mcp-servers/geo/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.8.0",
+      "version": "2.9.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/geojson/server.json
+++ b/clio-kit-mcp-servers/geojson/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.8.0",
+      "version": "2.9.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/hdf5/server.json
+++ b/clio-kit-mcp-servers/hdf5/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.8.0",
+      "version": "2.9.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/jarvis/server.json
+++ b/clio-kit-mcp-servers/jarvis/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.8.0",
+      "version": "2.9.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/lmod/server.json
+++ b/clio-kit-mcp-servers/lmod/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.8.0",
+      "version": "2.9.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/ndp/server.json
+++ b/clio-kit-mcp-servers/ndp/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.8.0",
+      "version": "2.9.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/node-hardware/server.json
+++ b/clio-kit-mcp-servers/node-hardware/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.8.0",
+      "version": "2.9.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/pandas/server.json
+++ b/clio-kit-mcp-servers/pandas/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.8.0",
+      "version": "2.9.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/parallel-sort/server.json
+++ b/clio-kit-mcp-servers/parallel-sort/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.8.0",
+      "version": "2.9.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/paraview/server.json
+++ b/clio-kit-mcp-servers/paraview/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.8.0",
+      "version": "2.9.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/parquet/server.json
+++ b/clio-kit-mcp-servers/parquet/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.8.0",
+      "version": "2.9.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/plot/server.json
+++ b/clio-kit-mcp-servers/plot/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.8.0",
+      "version": "2.9.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/sac/server.json
+++ b/clio-kit-mcp-servers/sac/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.8.0",
+      "version": "2.9.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/scientific-catalog/server.json
+++ b/clio-kit-mcp-servers/scientific-catalog/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.8.0",
+      "version": "2.9.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/seismic/server.json
+++ b/clio-kit-mcp-servers/seismic/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.8.0",
+      "version": "2.9.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/slurm/server.json
+++ b/clio-kit-mcp-servers/slurm/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.8.0",
+      "version": "2.9.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/spack/server.json
+++ b/clio-kit-mcp-servers/spack/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.8.0",
+      "version": "2.9.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/terrain/server.json
+++ b/clio-kit-mcp-servers/terrain/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.8.0",
+      "version": "2.9.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/web/.claude-plugin/plugin.json
+++ b/clio-kit-mcp-servers/web/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "clio-web",
-  "description": "Web MCP server providing curated fetch + search tools for agentic web access",
-  "version": "1.1.0"
+  "description": "Provider-fixed web search plus transparent URL, DOI, and document fetching",
+  "version": "2.0.0"
 }

--- a/clio-kit-mcp-servers/web/README.md
+++ b/clio-kit-mcp-servers/web/README.md
@@ -1,105 +1,94 @@
 # Web MCP Server
 
-[![Python](https://img.shields.io/badge/Python-3.10%2B-blue)](https://www.python.org/)
+The Web MCP exposes two stable agent tools—`search` and `fetch`—while fixing the
+search provider when each MCP installation starts. The agent cannot switch providers per
+call, and it never sees parameters that the selected provider cannot use.
 
-**Part of [CLIO Kit](https://docs.iowarp.ai/) - Gnosis Research Center**
+## Installations
 
-The Web MCP server provides two curated, high-level tools for agentic web
-access. It is the seed of CLIO's web tooling and the test instrument for the
-sandbox campaign's egress recording.
+DuckDuckGo remains the keyless default:
 
-## Tools
+```bash
+claude mcp add web -- uvx clio-kit mcp-server web --provider ddg
+```
 
-### `fetch`
+Use a private SearXNG deployment (or the optional `clio-search` image) with:
 
-Retrieve an HTTP(S) URL, convert HTML to Markdown, and return it inline or save
-it to a local file.
+```bash
+claude mcp add web -- uvx clio-kit mcp-server web \
+  -- \
+  --provider searxng \
+  --address http://10.0.0.102:8089
+```
 
-- **Agent story:** "I found a promising URL and need its actual content." The
-  agent calls `fetch` to pull the page, get clean Markdown (links preserved),
-  and read the title. For large or binary resources it passes `to_file=True` so
-  the raw page is written to disk and only a `local_path` comes back — raw pages
-  never bloat the context window. The agent can then pipe that file through its
-  own model for `(url, prompt)`-style extraction.
-- **Behavior:** streamed download with a hard size cap (default 5 MiB, enforced
-  on `Content-Length` and mid-stream) and configurable timeouts;
-  `follow_redirects=True`; HTML → Markdown via trafilatura, falling back to
-  readability-lxml then a plain-text strip; non-HTML text returned as-is; binary
-  content only materialized when `to_file=True`.
-- **Returns:** `{ok, url, content | local_path, size_bytes, content_type,
-  status, title, method: "http"}`. The `url` key always carries the fetched
-  source URL verbatim — CLIO's provenance layer keys the web source off it.
+For `searxng`, `--address` is required. When that address is a `clio-search`
+installation, it also enables DOI resolution and structured-document conversion. A standalone
+SearXNG instance still supports search; document enrichment will fail explicitly if requested.
+For a non-SearXNG search provider, document enrichment can be configured separately with
+`--document-address`.
 
-### `search`
+Brave and Tavily remain optional bring-your-own-key providers. Their keys are read from
+`WEB_BRAVE_API_KEY` and `WEB_TAVILY_API_KEY`; selecting either provider without its key is a
+startup error. No paid provider is required by the default or SearXNG installations.
 
-Query a configurable web-search provider and return ranked results.
+## `search`
 
-- **Agent story:** "I need candidate URLs for a question." The agent calls
-  `search` and gets back a small list of `{title, url, snippet}` rows to triage
-  and then `fetch`.
-- **Providers:** keyless **DuckDuckGo** (`ddg`, default, via the `ddgs`
-  package); self-hosted **SearXNG** (`searxng`); optional BYO-key **Brave** and
-  **Tavily**. Selecting an unconfigured provider raises a typed error naming
-  the missing config — it never silently falls back to `ddg`.
-- **SearXNG selectors:** `category` (`general` / `science` / `it`), exact
-  `engines`, `language`, `time_range`, `pageno`, and `safesearch`. These are
-  rejected for other providers instead of being silently discarded. An exact
-  `engines` list takes precedence over `category`, because SearXNG otherwise
-  treats the two selectors as a broader union.
-- **Returns:** `{ok, provider, query, results: [{title, url, snippet}], count}`.
+Every installation accepts `query` and `count`. A SearXNG installation additionally exposes:
+
+- `category` (`general`, `science`, or `it`)
+- `engines`
+- `language`
+- `time_range`
+- `pageno` (1 through 3)
+- `safesearch`
+
+Those fields are absent from the MCP schema for DDG, Brave, and Tavily. Results always preserve
+`title`, `url`, `snippet`, and provider provenance. SearXNG results also preserve available
+scholarly metadata such as authors, DOI, publication date, journal, publisher, document type,
+PDF/HTML URLs, tags, citation count, engines, and score. `unresponsive_engines` is diagnostic
+secondary-engine information; a successful result set is still a successful search.
+
+## `fetch`
+
+`fetch(target)` accepts an HTTP(S) URL or DOI. HTML is converted to Markdown locally. Text and
+structured text pass through. Supported PDFs, Office documents, XML, and images are detected from
+headers, URL, and content signatures and sent to the optional document service automatically.
+The returned document includes Markdown, normalized structure, metadata, and—where GROBID detects
+a scholarly paper—bibliographic references and in-text citation contexts.
+
+Long conversions return `reason="document_conversion_pending"`, a durable `conversion_id`, and a
+retry interval. Repeating the same fetch is content-deduplicated by `clio-search`. With
+`to_file=True`, converted documents write a Markdown artifact and a JSON metadata companion.
+Without a document service, existing HTML/text behavior remains available and unsupported binary
+content can still be saved raw.
+
+DOI resolution queries Crossref, falls back to DataCite metadata, and optionally uses Unpaywall
+when the private `clio-search` installation has its own contact email configured. It never bypasses
+access controls or fabricates an open copy.
 
 ## Configuration
 
-Configuration is a single `pydantic-settings` `Settings` model. All fields are
-overridable via `WEB_`-prefixed environment variables or a `.env` file, but the
-recommended path is a single source of config with clear defaults.
+CLI arguments define the installed search contract:
 
-| Field | Env var | Default | Meaning |
-| --- | --- | --- | --- |
-| `search_provider` | `WEB_SEARCH_PROVIDER` | `"ddg"` | Active search provider (`ddg` / `searxng` / `brave` / `tavily`). |
-| `searxng_base_url` | `WEB_SEARXNG_BASE_URL` | `None` | Root URL of the self-hosted SearXNG instance (required for `searxng`). |
-| `brave_api_key` | `WEB_BRAVE_API_KEY` | `None` | Brave Search API key (required for `brave`). |
-| `tavily_api_key` | `WEB_TAVILY_API_KEY` | `None` | Tavily API key (required for `tavily`). |
-| `max_bytes` | `WEB_MAX_BYTES` | `5242880` | Fetch size cap in bytes (5 MiB). |
-| `connect_timeout_s` | `WEB_CONNECT_TIMEOUT_S` | `5.0` | HTTP connect timeout. |
-| `read_timeout_s` | `WEB_READ_TIMEOUT_S` | `30.0` | HTTP read timeout. |
-| `artifacts_root` | `WEB_ARTIFACTS_ROOT` | `None` (→ CWD) | Default directory for `to_file` output. |
+| Argument | Meaning |
+| --- | --- |
+| `--provider {ddg,searxng,brave,tavily}` | Fixed provider for this installation. |
+| `--address URL` | Required SearXNG root; also used for document enrichment by default. |
+| `--document-address URL` | Optional separate `clio-search` root. |
 
-## Documented extension points (not yet available in v1)
+Runtime limits use `WEB_` environment variables, including `WEB_MAX_BYTES` (5 MiB HTML/text),
+`WEB_MAX_DOCUMENT_BYTES` (50 MiB), `WEB_CONNECT_TIMEOUT_S`, `WEB_READ_TIMEOUT_S`,
+`WEB_CONVERSION_WAIT_S`, `WEB_ARTIFACTS_ROOT`, and `WEB_ALLOW_PRIVATE_HOSTS`.
 
-These are honest, typed gaps — the follow-on campaign's remainder — not silent
-failures:
-
-- **Headless-browser escalation (Playwright)** for JS-rendered / Anubis-walled
-  pages. When HTML extraction yields nothing, `fetch` returns a typed note
-  `reason="js_render_required_browser_unavailable"` instead of returning junk.
-- **`(url, prompt)` small-model extraction.** An MCP server has no model access,
-  so page-specific extraction stays the agent's job: `fetch` with
-  `to_file=True`, then let the agent pipe the saved file through its own model.
+Discovery is available at `web://capabilities` and describes only this installation's active
+provider and tool parameters; it does not advertise alternative providers to the agent.
 
 ## Development
 
 ```bash
 uv sync
-uv run pytest -q            # network-mocked suite (default)
-uv run ruff check src/ tests/
-uv run mypy src/
+uv run ruff check --fix src tests
+uv run ruff format src tests
+uv run mypy src
+WEB_MCP_LIVE=1 WEB_SEARXNG_BASE_URL=http://10.0.0.102:8089 uv run pytest
 ```
-
-Real-network checks are opt-in and skipped by default:
-
-```bash
-WEB_MCP_LIVE=1 uv run pytest -m integration
-```
-
-To make the self-hosted instance the active backend:
-
-```bash
-WEB_SEARCH_PROVIDER=searxng \
-WEB_SEARXNG_BASE_URL=http://10.0.0.102:8088 \
-uv run web-mcp
-```
-
-No paid-provider credential is needed for SearXNG. The server forwards native
-selectors to the deployment and returns `engines_answered` plus normalized
-`unresponsive_engines` alongside the stable `{title, url, snippet}` rows.

--- a/clio-kit-mcp-servers/web/pyproject.toml
+++ b/clio-kit-mcp-servers/web/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "web-mcp"
-version = "1.1.0"
-description = "Web MCP server providing curated fetch + search tools for agentic web access"
+version = "2.0.0"
+description = "Provider-fixed web search plus transparent URL, DOI, and document fetching"
 readme = "README.md"
 requires-python = ">=3.10"
 license = "BSD-3-Clause"

--- a/clio-kit-mcp-servers/web/server.json
+++ b/clio-kit-mcp-servers/web/server.json
@@ -2,8 +2,8 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.iowarp/web-mcp",
   "title": "CLIO Web",
-  "description": "Web MCP server providing curated fetch + search tools for agentic web access",
-  "version": "1.1.0",
+  "description": "Provider-fixed web search plus transparent URL, DOI, and document fetching",
+  "version": "2.0.0",
   "repository": {
     "url": "https://github.com/iowarp/clio-kit",
     "source": "github"
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.8.0",
+      "version": "2.9.0",
       "transport": {
         "type": "stdio"
       },
@@ -31,18 +31,18 @@
   "tools": [
     {
       "name": "fetch",
-      "description": "Fetch an HTTP(S) URL with a streamed size cap and timeout, convert HTML to Markdown, and return the content inline or (to_file=True) write it to a local file and return its path."
+      "description": "Fetch an HTTP(S) URL or DOI. HTML and text are read locally; supported PDFs and structured documents use the optional CLIO Search document service."
     },
     {
       "name": "search",
-      "description": "Search the web via a configurable provider (keyless DuckDuckGo by default; self-hosted SearXNG; optional BYO-key Brave or Tavily) and return ranked results. SearXNG supports category, engine, language, time-range, page, and safe-search selectors."
+      "description": "Search the web using this installation's fixed ddg provider."
     }
   ],
   "resources": [
     {
-      "uri": "web://providers",
-      "name": "search_providers",
-      "description": "The active + available web-search providers and current fetch limits."
+      "uri": "web://capabilities",
+      "name": "capabilities",
+      "description": "Return only the active installation's search and fetch capabilities."
     }
   ],
   "prompts": [

--- a/clio-kit-mcp-servers/web/src/web_mcp/__init__.py
+++ b/clio-kit-mcp-servers/web/src/web_mcp/__init__.py
@@ -9,4 +9,4 @@ It is the seed of CLIO's web tooling and the test instrument for the sandbox
 campaign's egress recording.
 """
 
-__version__ = "1.1.0"
+__version__ = "2.0.0"

--- a/clio-kit-mcp-servers/web/src/web_mcp/document_service.py
+++ b/clio-kit-mcp-servers/web/src/web_mcp/document_service.py
@@ -1,0 +1,136 @@
+"""Client for an optional CLIO Search document-enrichment service."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from pathlib import Path
+from typing import Any, cast
+from urllib.parse import urlparse
+
+import httpx
+from fastmcp.exceptions import ToolError
+
+_CONVERTIBLE_SUFFIXES = {
+    ".pdf",
+    ".docx",
+    ".pptx",
+    ".xlsx",
+    ".xml",
+    ".png",
+    ".jpg",
+    ".jpeg",
+    ".tif",
+    ".tiff",
+    ".bmp",
+    ".webp",
+}
+_CONVERTIBLE_MIMES = {
+    "application/pdf",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    "application/xml",
+    "text/xml",
+}
+
+
+def service_endpoint(value: str | None, path: str) -> str:
+    """Build a validated CLIO Search endpoint URL."""
+
+    base = (value or "").strip()
+    parsed = urlparse(base)
+    if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+        raise ToolError(
+            "Document enrichment requires an absolute CLIO Search address. "
+            "Set --document-address or WEB_DOCUMENT_SERVICE_URL."
+        )
+    if parsed.query or parsed.fragment:
+        raise ToolError("The CLIO Search address must not contain a query or fragment.")
+    return f"{base.rstrip('/')}{path}"
+
+
+def is_convertible_document(body: bytes, content_type: str | None, url: str) -> bool:
+    """Return whether CLIO Search can structure the fetched content."""
+
+    mime = (content_type or "").split(";", 1)[0].strip().lower()
+    suffix = Path(urlparse(url).path).suffix.lower()
+    return (
+        body.startswith(b"%PDF-")
+        or mime in _CONVERTIBLE_MIMES
+        or mime.startswith("image/")
+        or suffix in _CONVERTIBLE_SUFFIXES
+    )
+
+
+def likely_convertible_url(content_type: str | None, url: str) -> bool:
+    """Classify a response before its body has been downloaded."""
+
+    return is_convertible_document(b"", content_type, url)
+
+
+async def resolve_doi(
+    doi: str,
+    *,
+    service_url: str | None,
+    timeout: httpx.Timeout,
+) -> dict[str, Any]:
+    """Resolve a DOI through the configured CLIO Search installation."""
+
+    endpoint = service_endpoint(service_url, "/v1/doi/resolve")
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            response = await client.post(endpoint, json={"doi": doi})
+            response.raise_for_status()
+            payload = response.json()
+    except (httpx.HTTPError, ValueError) as exc:
+        raise ToolError(f"Could not resolve DOI through CLIO Search at {endpoint}: {exc}") from exc
+    if not isinstance(payload, dict) or not isinstance(payload.get("candidates"), list):
+        raise ToolError("CLIO Search returned a malformed DOI-resolution response.")
+    return cast(dict[str, Any], payload)
+
+
+async def convert_document(
+    body: bytes,
+    *,
+    filename: str,
+    content_type: str | None,
+    source_url: str,
+    doi: str | None,
+    service_url: str | None,
+    timeout: httpx.Timeout,
+    wait_s: float,
+    poll_s: float,
+) -> dict[str, Any]:
+    """Submit a document and return completion or a durable pending handle."""
+
+    submit_url = service_endpoint(service_url, "/v1/documents")
+    fields = {"source_url": source_url}
+    if doi:
+        fields["doi"] = doi
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            response = await client.post(
+                submit_url,
+                data=fields,
+                files={"file": (filename, body, content_type or "application/octet-stream")},
+            )
+            response.raise_for_status()
+            payload = response.json()
+            if not isinstance(payload, dict) or not payload.get("id"):
+                raise ToolError("CLIO Search returned a malformed document submission.")
+            deadline = time.monotonic() + max(wait_s, 0)
+            while payload.get("status") in {"queued", "running"} and time.monotonic() < deadline:
+                await asyncio.sleep(max(poll_s, 0.1))
+                response = await client.get(f"{submit_url}/{payload['id']}")
+                response.raise_for_status()
+                payload = response.json()
+    except ToolError:
+        raise
+    except (httpx.HTTPError, ValueError) as exc:
+        raise ToolError(f"Could not convert document through CLIO Search: {exc}") from exc
+    if payload.get("status") == "failed":
+        error = payload.get("error")
+        message = error.get("message") if isinstance(error, dict) else error
+        raise ToolError(f"CLIO Search document conversion failed: {message or 'unknown error'}")
+    return cast(dict[str, Any], payload)

--- a/clio-kit-mcp-servers/web/src/web_mcp/fetch_utils.py
+++ b/clio-kit-mcp-servers/web/src/web_mcp/fetch_utils.py
@@ -1,0 +1,267 @@
+"""Low-level download, content detection, and artifact helpers for Web MCP."""
+
+from __future__ import annotations
+
+import ipaddress
+import re
+from pathlib import Path
+from urllib.parse import urlparse
+
+import httpx
+import trafilatura
+from fastmcp.exceptions import ToolError
+from readability import Document as ReadabilityDocument
+
+from web_mcp.document_service import likely_convertible_url
+
+REASON_BLOCKED_HOST = "blocked_private_host"
+
+_MAX_REDIRECTS = 5
+_LOCAL_HOSTNAMES = {"localhost", "localhost.localdomain", "ip6-localhost", "ip6-loopback"}
+_TEXT_SUBTYPES = {
+    "json",
+    "xml",
+    "xhtml+xml",
+    "javascript",
+    "ecmascript",
+    "x-yaml",
+    "yaml",
+    "csv",
+    "tab-separated-values",
+    "markdown",
+    "plain",
+}
+_TAG_RE = re.compile(r"<[^>]+>")
+_TITLE_RE = re.compile(r"<title[^>]*>(.*?)</title>", re.IGNORECASE | re.DOTALL)
+_WS_RE = re.compile(r"[ \t\r\f\v]+")
+_BLANKLINES_RE = re.compile(r"\n{3,}")
+
+
+def artifacts_root(
+    output_dir: str | Path | None = None, *, configured_root: str | None = None
+) -> Path:
+    """Return and create the configured writable artifact root."""
+    explicit = str(output_dir).strip() if output_dir not in (None, "") else ""
+    configured = (configured_root or "").strip()
+    root = Path(explicit or configured or Path.cwd()).expanduser()
+    root.mkdir(parents=True, exist_ok=True)
+    return root.resolve()
+
+
+def validate_output_path(
+    candidate: str | Path,
+    *,
+    default_name: str,
+    output_dir: str | Path | None = None,
+    configured_root: str | None = None,
+) -> Path:
+    """Resolve a write path while confining it to the artifact root."""
+    root = artifacts_root(output_dir, configured_root=configured_root)
+    raw = Path(str(candidate)).expanduser() if candidate else Path(default_name)
+    name = raw.name or default_name
+    if raw.is_absolute():
+        try:
+            resolved = raw.resolve()
+            resolved.relative_to(root)
+            resolved.parent.mkdir(parents=True, exist_ok=True)
+            return resolved
+        except (ValueError, OSError):
+            pass
+    target = (root / name).resolve()
+    target.parent.mkdir(parents=True, exist_ok=True)
+    return target
+
+
+def _safe_filename(value: str, *, default: str) -> str:
+    """Return a conservative filesystem name for saved content."""
+    cleaned = "".join(ch if ch.isalnum() or ch in "._-" else "_" for ch in value.strip())
+    cleaned = cleaned.strip("._-")
+    return cleaned[:120] or default
+
+
+def derive_filename(url: str, *, is_html: bool, is_binary: bool) -> str:
+    """Derive a safe output filename from a URL and detected content kind."""
+    parsed = urlparse(url)
+    base = Path(parsed.path).name or parsed.netloc or "page"
+    safe = _safe_filename(base, default="page")
+    if is_html:
+        return f"{Path(safe).stem or 'page'}.md"
+    if is_binary:
+        return safe
+    return safe if "." in safe else f"{safe}.txt"
+
+
+def split_content_type(content_type: str | None) -> tuple[str, str | None]:
+    """Return the lowercased MIME type without params and its charset."""
+    if not content_type:
+        return "", None
+    parts = [part.strip() for part in content_type.split(";")]
+    charset: str | None = None
+    for param in parts[1:]:
+        if param.lower().startswith("charset="):
+            charset = param.split("=", 1)[1].strip().strip('"') or None
+    return parts[0].lower(), charset
+
+
+def is_html(mime: str) -> bool:
+    """Return whether the MIME type denotes HTML."""
+    return mime in {"text/html", "application/xhtml+xml"} or mime.endswith("+html")
+
+
+def is_text(mime: str) -> bool:
+    """Return whether the MIME type denotes inline-able text."""
+    if not mime:
+        return False
+    main, _, subtype = mime.partition("/")
+    return main == "text" or subtype in _TEXT_SUBTYPES
+
+
+def _strip_tags(html: str) -> str:
+    """Collapse an HTML fragment to visible plain text."""
+    without_head = re.sub(r"<head[^>]*>.*?</head>", " ", html, flags=re.IGNORECASE | re.DOTALL)
+    without_script = re.sub(
+        r"<(script|style)[^>]*>.*?</\1>",
+        " ",
+        without_head,
+        flags=re.IGNORECASE | re.DOTALL,
+    )
+    text = _WS_RE.sub(" ", _TAG_RE.sub(" ", without_script))
+    text = "\n".join(line.strip() for line in text.splitlines())
+    return _BLANKLINES_RE.sub("\n\n", text).strip()
+
+
+def extract_title(html: str) -> str | None:
+    """Extract the document title when present."""
+    match = _TITLE_RE.search(html)
+    if not match:
+        return None
+    return _strip_tags(match.group(1)).strip() or None
+
+
+def html_to_markdown(html: str) -> tuple[str | None, str | None]:
+    """Convert HTML through named, quality-visible extraction fallbacks."""
+    try:
+        markdown = trafilatura.extract(
+            html,
+            output_format="markdown",
+            include_links=True,
+            favor_recall=True,
+        )
+    except Exception:  # noqa: BLE001 - parser failure advances to the explicit fallback
+        markdown = None
+    if markdown and markdown.strip():
+        return markdown.strip(), "trafilatura"
+    try:
+        readable = _strip_tags(ReadabilityDocument(html).summary(html_partial=True))
+    except Exception:  # noqa: BLE001 - parser failure advances to the explicit fallback
+        readable = ""
+    if readable.strip():
+        return readable.strip(), "readability"
+    stripped = _strip_tags(html)
+    return (stripped, "plaintext") if stripped else (None, None)
+
+
+def decode(body: bytes, charset: str | None) -> str:
+    """Decode bytes using the advertised charset when valid, then UTF-8."""
+    if charset:
+        try:
+            return body.decode(charset, errors="replace")
+        except LookupError:
+            pass
+    return body.decode("utf-8", errors="replace")
+
+
+def looks_like_text(body: bytes) -> bool:
+    """Sniff content without a MIME type for likely UTF-8 text."""
+    if not body:
+        return True
+    sample = body[:8192]
+    if b"\x00" in sample:
+        return False
+    decoded = sample.decode("utf-8", errors="replace")
+    return bool(decoded) and decoded.count("\ufffd") / len(decoded) < 0.05
+
+
+def assert_allowed_url(url: str, *, allow_private_hosts: bool) -> None:
+    """Reject local and non-routable literal targets unless explicitly allowed."""
+    if allow_private_hosts:
+        return
+    host = (urlparse(url).hostname or "").strip().strip("[]").lower()
+    blocked = not host or host in _LOCAL_HOSTNAMES or host.endswith(".localhost")
+    if not blocked:
+        try:
+            ip = ipaddress.ip_address(host)
+        except ValueError:
+            ip = None
+        blocked = bool(
+            ip
+            and (
+                ip.is_loopback
+                or ip.is_private
+                or ip.is_link_local
+                or ip.is_reserved
+                or ip.is_multicast
+                or ip.is_unspecified
+            )
+        )
+    if blocked:
+        raise ToolError(
+            f"fetch blocked host {host!r}: refusing a loopback/private/link-local address "
+            f"(reason={REASON_BLOCKED_HOST}). Set WEB_ALLOW_PRIVATE_HOSTS=true to permit "
+            "internal fetches."
+        )
+
+
+async def download(
+    url: str,
+    *,
+    max_bytes: int,
+    max_document_bytes: int,
+    timeout: httpx.Timeout,
+    allow_private_hosts: bool,
+) -> tuple[bytes, str | None, int, str]:
+    """Stream a URL within size limits while validating every redirect hop."""
+    async with httpx.AsyncClient(timeout=timeout, follow_redirects=False) as client:
+        current = httpx.URL(url)
+        for _hop in range(_MAX_REDIRECTS + 1):
+            assert_allowed_url(str(current), allow_private_hosts=allow_private_hosts)
+            async with client.stream("GET", current) as response:
+                if response.is_redirect and "location" in response.headers:
+                    current = current.join(response.headers["location"])
+                    continue
+                response.raise_for_status()
+                content_type = response.headers.get("content-type")
+                mime, _ = split_content_type(content_type)
+                effective_cap = (
+                    max_document_bytes
+                    if likely_convertible_url(content_type, str(response.url))
+                    or (mime and not is_html(mime) and not is_text(mime))
+                    else max_bytes
+                )
+                content_length = response.headers.get("content-length")
+                if content_length:
+                    try:
+                        advertised = int(content_length)
+                    except ValueError:
+                        advertised = 0
+                    if advertised > effective_cap:
+                        raise ToolError(
+                            f"Resource is {advertised} bytes, which exceeds the fetch size "
+                            f"limit of {effective_cap} bytes. Increase max_bytes intentionally "
+                            "or select a smaller resource."
+                        )
+                chunks: list[bytes] = []
+                total = 0
+                async for chunk in response.aiter_bytes(chunk_size=64 * 1024):
+                    if not chunk:
+                        continue
+                    total += len(chunk)
+                    if total > effective_cap:
+                        raise ToolError(
+                            f"Resource exceeded the fetch size limit of {effective_cap} bytes "
+                            "while downloading. Increase max_bytes intentionally or select "
+                            "a smaller resource."
+                        )
+                    chunks.append(chunk)
+                return b"".join(chunks), content_type, response.status_code, str(response.url)
+    raise ToolError(f"fetch exceeded {_MAX_REDIRECTS} redirects for {url!r}.")

--- a/clio-kit-mcp-servers/web/src/web_mcp/searxng.py
+++ b/clio-kit-mcp-servers/web/src/web_mcp/searxng.py
@@ -2,11 +2,73 @@
 
 from __future__ import annotations
 
+import re
 from typing import Any
 from urllib.parse import urlparse
 
 import httpx
 from fastmcp.exceptions import ToolError
+
+_CITATION_COUNT_RE = re.compile(r"^(\d+)\s+citations?$", re.IGNORECASE)
+
+
+def _string_list(value: Any) -> list[str]:
+    """Normalize a SearXNG scalar/list metadata field to non-empty strings."""
+
+    if isinstance(value, list):
+        return [str(item).strip() for item in value if str(item).strip()]
+    if isinstance(value, str) and value.strip():
+        return [value.strip()]
+    return []
+
+
+def _citation_count(item: dict[str, Any]) -> int | None:
+    """Parse only explicit SearXNG citation-count labels."""
+
+    direct = item.get("citation_count")
+    if isinstance(direct, int) and not isinstance(direct, bool) and direct >= 0:
+        return direct
+    for candidate in _string_list(item.get("comments")):
+        match = _CITATION_COUNT_RE.fullmatch(candidate)
+        if match:
+            return int(match.group(1))
+    return None
+
+
+def _normalize_result(item: dict[str, Any]) -> dict[str, Any]:
+    """Preserve useful standard and scholarly fields from one SearXNG result."""
+
+    engines = _string_list(item.get("engines"))
+    if not engines and item.get("engine"):
+        engines = [str(item["engine"])]
+    result: dict[str, Any] = {
+        "title": str(item.get("title") or ""),
+        "url": str(item.get("url") or ""),
+        "snippet": str(item.get("content") or item.get("snippet") or ""),
+        "engines": engines,
+    }
+    aliases: dict[str, tuple[str, ...]] = {
+        "authors": ("authors", "author"),
+        "doi": ("doi",),
+        "published_at": ("published_at", "publishedDate", "published_date"),
+        "journal": ("journal",),
+        "publisher": ("publisher",),
+        "document_type": ("document_type", "type"),
+        "pdf_url": ("pdf_url",),
+        "html_url": ("html_url",),
+        "tags": ("tags",),
+        "score": ("score",),
+    }
+    for output_name, source_names in aliases.items():
+        value = next((item[name] for name in source_names if item.get(name) is not None), None)
+        if value not in (None, "", []):
+            result[output_name] = (
+                _string_list(value) if output_name in {"authors", "tags"} else value
+            )
+    citation_count = _citation_count(item)
+    if citation_count is not None:
+        result["citation_count"] = citation_count
+    return result
 
 
 def _search_endpoint(base_url: str | None) -> str:
@@ -56,7 +118,7 @@ async def search_searxng(
     time_range: str | None,
     pageno: int,
     safesearch: int | None,
-) -> tuple[list[dict[str, str]], list[str], list[dict[str, str]]]:
+) -> tuple[list[dict[str, Any]], list[str], list[dict[str, str]]]:
     """Search a configured self-hosted SearXNG instance via its JSON API."""
     endpoint = _search_endpoint(base_url)
     params: dict[str, str | int] = {"q": query, "format": "json"}
@@ -101,7 +163,7 @@ async def search_searxng(
     if not isinstance(payload, dict) or not isinstance(payload.get("results"), list):
         raise ToolError("SearXNG returned malformed JSON: expected a results list.")
 
-    results: list[dict[str, str]] = []
+    results: list[dict[str, Any]] = []
     engines_answered: set[str] = set()
     for item in payload["results"]:
         if not isinstance(item, dict):
@@ -111,13 +173,7 @@ async def search_searxng(
             engines_answered.update(str(name) for name in item_engines if name)
         elif item.get("engine"):
             engines_answered.add(str(item["engine"]))
-        results.append(
-            {
-                "title": str(item.get("title") or ""),
-                "url": str(item.get("url") or ""),
-                "snippet": str(item.get("content") or item.get("snippet") or ""),
-            }
-        )
+        results.append(_normalize_result(item))
         if len(results) >= count:
             break
 

--- a/clio-kit-mcp-servers/web/src/web_mcp/server.py
+++ b/clio-kit-mcp-servers/web/src/web_mcp/server.py
@@ -539,13 +539,13 @@ async def _search_searxng_tool(
         Field(description="SearXNG recency: day, month, or year."),
     ] = None,
     pageno: Annotated[
-        int | None,
+        int,
         Field(
             description="SearXNG result page, bounded by this deployment to 1 through 3.",
             ge=1,
             le=3,
         ),
-    ] = None,
+    ] = 1,
     safesearch: Annotated[
         int | None,
         Field(description="SearXNG safe-search level, 0 through 2.", ge=0, le=2),
@@ -567,7 +567,7 @@ async def _search_searxng_tool(
         engines=engines,
         language=language,
         time_range=time_range,
-        pageno=pageno or 1,
+        pageno=pageno,
         safesearch=safesearch,
     )
     return {

--- a/clio-kit-mcp-servers/web/src/web_mcp/server.py
+++ b/clio-kit-mcp-servers/web/src/web_mcp/server.py
@@ -23,23 +23,39 @@ a silent fallback):
 from __future__ import annotations
 
 import asyncio
-import ipaddress
+import json
 import os
-import re
 from pathlib import Path
 from typing import Annotated, Any, Literal
 from urllib.parse import urlparse
 
 import httpx
-import trafilatura
 from dotenv import load_dotenv
 from fastmcp import FastMCP
 from fastmcp.exceptions import ToolError
 from fastmcp.prompts import Message
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
-from readability import Document as ReadabilityDocument
 
+from web_mcp.document_service import (
+    convert_document,
+    is_convertible_document,
+    resolve_doi,
+)
+from web_mcp.fetch_utils import REASON_BLOCKED_HOST as REASON_BLOCKED_HOST
+from web_mcp.fetch_utils import (
+    assert_allowed_url,
+    decode,
+    derive_filename,
+    download,
+    extract_title,
+    html_to_markdown,
+    is_html,
+    is_text,
+    looks_like_text,
+    split_content_type,
+    validate_output_path,
+)
 from web_mcp.searxng import search_searxng
 
 # Environment setup
@@ -65,15 +81,19 @@ class Settings(BaseSettings):
     # Search provider selection. Keyless "ddg" is the default so search works
     # out of the box; self-hosted "searxng" requires its deployment URL, while
     # "brave"/"tavily" are opt-in and require their own key.
-    search_provider: str = "ddg"
+    search_provider: Literal["ddg", "searxng", "brave", "tavily"] = "ddg"
     searxng_base_url: str | None = None
+    document_service_url: str | None = None
     brave_api_key: str | None = None
     tavily_api_key: str | None = None
 
     # Fetch limits.
     max_bytes: int = 5 * 1024 * 1024
+    max_document_bytes: int = 50 * 1024 * 1024
     connect_timeout_s: float = 5.0
     read_timeout_s: float = 30.0
+    conversion_wait_s: float = 25.0
+    conversion_poll_s: float = 1.0
 
     # Default writable root for ``to_file`` output. ``None`` -> current working
     # directory, so a caller that launches the server from a chosen directory
@@ -104,241 +124,25 @@ _TAVILY_ENDPOINT = "https://api.tavily.com/search"
 # Typed extension-point signals (honest gaps, never silent fallbacks).
 REASON_JS_RENDER_REQUIRED = "js_render_required_browser_unavailable"
 REASON_BINARY_NOT_INLINED = "binary_content_not_inlined"
-REASON_BLOCKED_HOST = "blocked_private_host"
+REASON_CONVERSION_PENDING = "document_conversion_pending"
 
 # Bounds. Redirects are followed manually so each hop is SSRF-checked before the
 # connection; search results are capped so a caller can't request an unbounded page.
-_MAX_REDIRECTS = 5
 _MAX_SEARCH_COUNT = 25
 
-# Host names that always denote the local machine (checked before literal-IP parse).
-_LOCAL_HOSTNAMES = {"localhost", "localhost.localdomain", "ip6-localhost", "ip6-loopback"}
 
+def _new_mcp() -> FastMCP:
+    """Create an unregistered Web MCP instance."""
 
-# Initialize FastMCP server instance.
-mcp: FastMCP = FastMCP(
-    "web",
-    instructions=(
-        "Provides agentic web access. Use fetch to retrieve a URL and convert "
-        "HTML to Markdown (optionally saving it to a local file with "
-        "to_file=True so raw pages never bloat context), and search to query a "
-        "configurable web-search provider for candidate URLs."
-    ),
-    list_page_size=10,
-)
-
-
-# ---------------------------------------------------------------------------
-# Output-path helpers (self-contained allowed-root confinement)
-# ---------------------------------------------------------------------------
-
-
-def artifacts_root(output_dir: str | Path | None = None) -> Path:
-    """Return the writable root for fetched-to-file content.
-
-    Precedence: an explicit ``output_dir`` wins; otherwise ``settings.
-    artifacts_root``; otherwise the current working directory. No destination
-    is hardcoded and nothing is rerouted.
-    """
-    explicit = str(output_dir).strip() if output_dir not in (None, "") else ""
-    configured = (settings.artifacts_root or "").strip()
-    if explicit:
-        root = Path(explicit).expanduser()
-    elif configured:
-        root = Path(configured).expanduser()
-    else:
-        root = Path.cwd()
-    root.mkdir(parents=True, exist_ok=True)
-    return root.resolve()
-
-
-def _validate_output_path(
-    candidate: str | Path, *, default_name: str, output_dir: str | Path | None = None
-) -> Path:
-    """Resolve an output path, confining writes to the resolved artifacts root.
-
-    A relative path, bare filename, or any path outside that root is relocated
-    under it using only its filename -- a self-contained allowed-root check.
-    """
-    root = artifacts_root(output_dir)
-    raw = Path(str(candidate)).expanduser() if candidate else Path(default_name)
-    name = raw.name or default_name
-    if raw.is_absolute():
-        try:
-            resolved = raw.resolve()
-            resolved.relative_to(root)
-            resolved.parent.mkdir(parents=True, exist_ok=True)
-            return resolved
-        except (ValueError, OSError):
-            pass
-    target = (root / name).resolve()
-    target.parent.mkdir(parents=True, exist_ok=True)
-    return target
-
-
-def _safe_filename(value: str, *, default: str) -> str:
-    """Return a conservative filesystem name for saved content."""
-    cleaned = "".join(ch if ch.isalnum() or ch in "._-" else "_" for ch in value.strip())
-    cleaned = cleaned.strip("._-")
-    return cleaned[:120] or default
-
-
-def _derive_filename(url: str, *, is_html: bool, is_binary: bool) -> str:
-    """Derive a safe output filename from a URL and the detected content kind."""
-    parsed = urlparse(url)
-    base = Path(parsed.path).name or parsed.netloc or "page"
-    safe = _safe_filename(base, default="page")
-    if is_html:
-        # HTML is converted to Markdown; give it a .md extension.
-        stem = Path(safe).stem or "page"
-        return f"{stem}.md"
-    if is_binary:
-        return safe
-    if "." not in safe:
-        return f"{safe}.txt"
-    return safe
-
-
-# ---------------------------------------------------------------------------
-# Content-type detection and HTML -> Markdown conversion
-# ---------------------------------------------------------------------------
-
-_TEXT_SUBTYPES = {
-    "json",
-    "xml",
-    "xhtml+xml",
-    "javascript",
-    "ecmascript",
-    "x-yaml",
-    "yaml",
-    "csv",
-    "tab-separated-values",
-    "markdown",
-    "plain",
-}
-
-
-def _split_content_type(content_type: str | None) -> tuple[str, str | None]:
-    """Return the lowercased mime type (without params) and its charset."""
-    if not content_type:
-        return "", None
-    parts = [p.strip() for p in content_type.split(";")]
-    mime = parts[0].lower()
-    charset: str | None = None
-    for param in parts[1:]:
-        if param.lower().startswith("charset="):
-            charset = param.split("=", 1)[1].strip().strip('"') or None
-    return mime, charset
-
-
-def _is_html(mime: str) -> bool:
-    """True when the mime type denotes HTML."""
-    return mime in {"text/html", "application/xhtml+xml"} or mime.endswith("+html")
-
-
-def _is_text(mime: str) -> bool:
-    """True when the mime type denotes inline-able text."""
-    if not mime:
-        return False
-    main, _, sub = mime.partition("/")
-    if main == "text":
-        return True
-    return sub in _TEXT_SUBTYPES
-
-
-_TAG_RE = re.compile(r"<[^>]+>")
-_TITLE_RE = re.compile(r"<title[^>]*>(.*?)</title>", re.IGNORECASE | re.DOTALL)
-_WS_RE = re.compile(r"[ \t\r\f\v]+")
-_BLANKLINES_RE = re.compile(r"\n{3,}")
-
-
-def _strip_tags(html: str) -> str:
-    """Collapse an HTML fragment to readable plain text.
-
-    ``<head>`` (with its ``<title>``/meta) and ``<script>``/``<style>`` blocks
-    are dropped first so only body-visible text remains -- a page whose body is
-    an empty SPA shell then strips to nothing, which is the signal used to raise
-    the headless-browser extension point.
-    """
-    without_head = re.sub(r"<head[^>]*>.*?</head>", " ", html, flags=re.IGNORECASE | re.DOTALL)
-    without_script = re.sub(
-        r"<(script|style)[^>]*>.*?</\1>", " ", without_head, flags=re.IGNORECASE | re.DOTALL
+    return FastMCP(
+        "web",
+        instructions=(
+            "Provides agentic web access. Use search to discover candidate sources and fetch "
+            "to read HTTP(S), DOI, HTML, text, PDF, and structured-document targets. The search "
+            "provider is fixed when this MCP installation starts."
+        ),
+        list_page_size=10,
     )
-    text = _TAG_RE.sub(" ", without_script)
-    text = _WS_RE.sub(" ", text)
-    text = "\n".join(line.strip() for line in text.splitlines())
-    return _BLANKLINES_RE.sub("\n\n", text).strip()
-
-
-def _extract_title(html: str) -> str | None:
-    """Extract the document ``<title>`` when present."""
-    match = _TITLE_RE.search(html)
-    if not match:
-        return None
-    title = _strip_tags(match.group(1)).strip()
-    return title or None
-
-
-def _html_to_markdown(html: str) -> tuple[str | None, str | None]:
-    """Convert HTML to Markdown; return ``(content, extractor)``.
-
-    Falls back trafilatura -> readability-lxml -> plain-text strip, and NAMES which extractor
-    produced the content (``"trafilatura"``/``"readability"``/``"plaintext"``) so a quality
-    DOWNGRADE is visible to the caller rather than silent (clio's no-silent-fallback rule).
-    ``(None, None)`` when nothing meaningful can be extracted -- the signal used to raise the
-    headless-browser extension point rather than return junk.
-    """
-    try:
-        markdown = trafilatura.extract(
-            html,
-            output_format="markdown",
-            include_links=True,
-            favor_recall=True,
-        )
-    except Exception:  # noqa: BLE001 - any parse failure falls through to readability
-        markdown = None
-    if markdown and markdown.strip():
-        return markdown.strip(), "trafilatura"
-
-    try:
-        document = ReadabilityDocument(html)
-        summary_html = document.summary(html_partial=True)
-        readable = _strip_tags(summary_html)
-    except Exception:  # noqa: BLE001 - readability failure falls through to strip
-        readable = ""
-    if readable.strip():
-        return readable.strip(), "readability"
-
-    stripped = _strip_tags(html)
-    return (stripped, "plaintext") if stripped else (None, None)
-
-
-def _decode(body: bytes, charset: str | None) -> str:
-    """Decode fetched bytes to text using the advertised charset when valid."""
-    if charset:
-        try:
-            return body.decode(charset, errors="replace")
-        except LookupError:
-            pass
-    return body.decode("utf-8", errors="replace")
-
-
-def _looks_like_text(body: bytes) -> bool:
-    """Heuristic content-sniff for a body served with NO content-type header.
-
-    A NUL byte or a high share of UTF-8 replacement chars in the leading sample denotes binary;
-    otherwise it is treated as text (returned) rather than withheld. Boundary-cut multibyte
-    chars are tolerated (decode with ``replace``), so valid text is never misread as binary.
-    """
-    if not body:
-        return True
-    sample = body[:8192]
-    if b"\x00" in sample:
-        return False
-    decoded = sample.decode("utf-8", errors="replace")
-    if not decoded:
-        return False
-    return decoded.count("�") / len(decoded) < 0.05
 
 
 # ---------------------------------------------------------------------------
@@ -346,108 +150,41 @@ def _looks_like_text(body: bytes) -> bool:
 # ---------------------------------------------------------------------------
 
 
-def _host_is_blocked(host: str) -> bool:
-    """True when ``host`` is a local/private/reserved LITERAL address or a localhost name.
-
-    A hostname that is not a literal IP returns False here (not blocked by the tool) --
-    resolving it would require client-side DNS the confined proxy tier does not provide, so
-    DNS-rebinding to a private IP is caught at the sandbox egress layer, not here.
-    """
-    h = host.strip().strip("[]").lower()
-    if not h:
-        return True
-    if h in _LOCAL_HOSTNAMES or h.endswith(".localhost"):
-        return True
-    try:
-        ip = ipaddress.ip_address(h)
-    except ValueError:
-        return False  # a hostname, not a literal IP -- allowed at the tool layer
-    return (
-        ip.is_loopback
-        or ip.is_private
-        or ip.is_link_local  # covers 169.254.0.0/16 incl. the 169.254.169.254 metadata addr
-        or ip.is_reserved
-        or ip.is_multicast
-        or ip.is_unspecified
+def _validate_output_path(
+    candidate: str | Path, *, default_name: str, output_dir: str | Path | None = None
+) -> Path:
+    """Confine a requested output path to this installation's artifact root."""
+    return validate_output_path(
+        candidate,
+        default_name=default_name,
+        output_dir=output_dir,
+        configured_root=settings.artifacts_root,
     )
 
 
 def _assert_allowed_url(url: str) -> None:
-    """Raise ToolError if ``url``'s host is a blocked literal address (unless configured open)."""
-    if settings.allow_private_hosts:
-        return
-    host = urlparse(url).hostname or ""
-    if _host_is_blocked(host):
-        raise ToolError(
-            f"fetch blocked host {host!r}: refusing a loopback/private/link-local address "
-            f"(reason={REASON_BLOCKED_HOST}). Set WEB_ALLOW_PRIVATE_HOSTS=true to permit "
-            "internal fetches."
-        )
+    """Apply this installation's private-host policy to a target URL."""
+    assert_allowed_url(url, allow_private_hosts=settings.allow_private_hosts)
 
 
 async def _download(
-    url: str, *, max_bytes: int, timeout: httpx.Timeout
+    url: str, *, max_bytes: int, max_document_bytes: int, timeout: httpx.Timeout
 ) -> tuple[bytes, str | None, int, str]:
-    """Stream a URL with a hard size cap; return (body, content_type, status, final_url).
-
-    Redirects are followed MANUALLY (up to :data:`_MAX_REDIRECTS`) so each hop's host is
-    SSRF-checked with :func:`_assert_allowed_url` BEFORE the connection -- a public page can
-    otherwise 30x-redirect into an internal service. The size cap is enforced both against an
-    advertised ``content-length`` and while streaming, so an oversized body raises before it is
-    fully buffered. ``final_url`` is the last (non-redirect) URL actually fetched.
-    """
-    async with httpx.AsyncClient(timeout=timeout, follow_redirects=False) as client:
-        current = httpx.URL(url)
-        for _hop in range(_MAX_REDIRECTS + 1):
-            _assert_allowed_url(str(current))
-            async with client.stream("GET", current) as response:
-                if response.is_redirect and "location" in response.headers:
-                    current = current.join(response.headers["location"])
-                    continue
-                response.raise_for_status()
-                content_type = response.headers.get("content-type")
-                content_length = response.headers.get("content-length")
-                if content_length:
-                    try:
-                        advertised = int(content_length)
-                    except ValueError:
-                        advertised = 0
-                    if advertised > max_bytes:
-                        raise ToolError(
-                            f"Resource is {advertised} bytes, which exceeds the fetch size "
-                            f"limit of {max_bytes} bytes. Increase max_bytes intentionally "
-                            "or select a smaller resource."
-                        )
-                chunks: list[bytes] = []
-                total = 0
-                async for chunk in response.aiter_bytes(chunk_size=64 * 1024):
-                    if not chunk:
-                        continue
-                    total += len(chunk)
-                    if total > max_bytes:
-                        raise ToolError(
-                            f"Resource exceeded the fetch size limit of {max_bytes} bytes "
-                            "while downloading. Increase max_bytes intentionally or select "
-                            "a smaller resource."
-                        )
-                    chunks.append(chunk)
-                return b"".join(chunks), content_type, response.status_code, str(response.url)
-    raise ToolError(f"fetch exceeded {_MAX_REDIRECTS} redirects for {url!r}.")
+    """Download through the shared redirect, SSRF, and size-limit implementation."""
+    return await download(
+        url,
+        max_bytes=max_bytes,
+        max_document_bytes=max_document_bytes,
+        timeout=timeout,
+        allow_private_hosts=settings.allow_private_hosts,
+    )
 
 
-@mcp.tool(
-    name="fetch",
-    title="Fetch URL",
-    description=(
-        "Fetch an HTTP(S) URL with a streamed size cap and timeout, convert "
-        "HTML to Markdown, and return the content inline or (to_file=True) "
-        "write it to a local file and return its path."
-    ),
-    annotations={"readOnlyHint": True, "destructiveHint": False, "idempotentHint": True},
-    tags={"web", "fetch", "http"},
-)
 async def fetch(
-    url: Annotated[str, Field(description="The http(s) URL to fetch.")],
+    target: Annotated[
+        str,
+        Field(description="An http(s) URL or DOI (bare, doi: prefix, or doi.org URL) to fetch."),
+    ],
     to_file: Annotated[
         bool,
         Field(
@@ -478,56 +215,99 @@ async def fetch(
         Field(description="Override the read timeout in seconds (default from config)."),
     ] = None,
 ) -> dict[str, Any]:
-    """Fetch a URL and return Markdown/text content or a saved file path.
+    """Fetch a URL or DOI and return Markdown, structure, or a saved artifact.
 
     An MCP server has no model access, so page-specific ``(url, prompt)``
     extraction is intentionally left to the agent: fetch to a file and pipe it
     through the agent's own model.
     """
-    target = (url or "").strip()
-    if not target.lower().startswith(("http://", "https://")):
-        raise ToolError(f"fetch only supports http(s) URLs; got: {target!r}")
+    requested_target = (target or "").strip()
+    if not requested_target:
+        raise ToolError("fetch requires a non-empty URL or DOI target.")
 
     cap = max_bytes if max_bytes and max_bytes > 0 else settings.max_bytes
     read_timeout = timeout if timeout and timeout > 0 else settings.read_timeout_s
     timeout_cfg = httpx.Timeout(read_timeout, connect=settings.connect_timeout_s)
 
-    # Guard the initial URL up front (each redirect hop is re-checked inside _download).
-    _assert_allowed_url(target)
-    try:
-        body, raw_content_type, status, final_url = await _download(
-            target, max_bytes=cap, timeout=timeout_cfg
+    doi: str | None = None
+    doi_resolution: dict[str, Any] | None = None
+    download_targets: list[str]
+    parsed_target = urlparse(requested_target)
+    is_doi_url = (
+        parsed_target.scheme in {"http", "https"}
+        and (parsed_target.hostname or "").lower() in {"doi.org", "dx.doi.org"}
+        and bool(parsed_target.path.strip("/"))
+    )
+    if is_doi_url or not requested_target.lower().startswith(("http://", "https://")):
+        if "://" in requested_target and not is_doi_url:
+            raise ToolError(
+                f"fetch only supports http(s) URLs or DOI targets; got: {requested_target!r}"
+            )
+        doi = parsed_target.path.strip("/") if is_doi_url else requested_target
+        doi_resolution = await resolve_doi(
+            doi,
+            service_url=settings.document_service_url,
+            timeout=timeout_cfg,
         )
-    except ToolError:
-        raise
-    except httpx.HTTPError as exc:
-        raise ToolError(f"Could not fetch {target}: {exc}") from exc
+        doi = str(doi_resolution["doi"])
+        download_targets = [
+            str(candidate["url"])
+            for candidate in doi_resolution["candidates"]
+            if isinstance(candidate, dict) and candidate.get("url")
+        ]
+        if not download_targets:
+            raise ToolError(f"CLIO Search found no lawful retrieval candidate for DOI {doi}.")
+    else:
+        download_targets = [requested_target]
+
+    download_target = ""
+    failures: list[str] = []
+    for candidate in download_targets:
+        _assert_allowed_url(candidate)
+        try:
+            body, raw_content_type, status, final_url = await _download(
+                candidate,
+                max_bytes=cap,
+                max_document_bytes=settings.max_document_bytes,
+                timeout=timeout_cfg,
+            )
+            download_target = candidate
+            break
+        except (ToolError, httpx.HTTPError) as exc:
+            failures.append(f"{candidate}: {exc}")
+    else:
+        summary = "; ".join(failures)
+        raise ToolError(f"Could not fetch {requested_target}: {summary}")
 
     size_bytes = len(body)
-    mime, charset = _split_content_type(raw_content_type)
-    is_html = _is_html(mime)
+    mime, charset = split_content_type(raw_content_type)
+    is_html_content = is_html(mime)
     # A response with NO content-type is content-sniffed: decodable-as-UTF-8 text is treated as
     # text (returned), not withheld as binary. Only genuinely undecodable bytes stay binary.
-    is_text = _is_text(mime) or is_html or (mime == "" and _looks_like_text(body))
-    is_binary = not is_text
+    is_text_content = is_text(mime) or is_html_content or (mime == "" and looks_like_text(body))
+    is_binary = not is_text_content
 
     result: dict[str, Any] = {
         "ok": True,
-        "url": target,
+        "target": requested_target,
+        "url": download_target,
         "size_bytes": size_bytes,
         "content_type": raw_content_type,
         "status": status,
         "title": None,
         "method": "http",
     }
-    if final_url and final_url != target:
+    if doi_resolution is not None:
+        result["doi"] = doi
+        result["doi_resolution"] = doi_resolution
+    if final_url and final_url != download_target:
         result["final_url"] = final_url  # the resolved URL after redirects (url stays verbatim)
 
     content: str | None
-    if is_html:
-        html = _decode(body, charset)
-        result["title"] = _extract_title(html)
-        content, extractor = _html_to_markdown(html)
+    if is_html_content:
+        html = decode(body, charset)
+        result["title"] = extract_title(html)
+        content, extractor = html_to_markdown(html)
         result["extractor"] = extractor  # which extractor ran (downgrade is visible)
         if content is None:
             # Extraction produced nothing usable: almost always a JS-rendered
@@ -540,6 +320,72 @@ async def fetch(
                 "JavaScript-capable headless browser, which is not available in v1."
             )
             return result
+    elif (
+        is_binary
+        and settings.document_service_url
+        and is_convertible_document(body, raw_content_type, final_url)
+    ):
+        filename = derive_filename(final_url, is_html=False, is_binary=True)
+        conversion = await convert_document(
+            body,
+            filename=filename,
+            content_type=raw_content_type,
+            source_url=final_url,
+            doi=doi,
+            service_url=settings.document_service_url,
+            timeout=timeout_cfg,
+            wait_s=settings.conversion_wait_s,
+            poll_s=settings.conversion_poll_s,
+        )
+        if conversion.get("status") != "complete":
+            result.update(
+                {
+                    "content": None,
+                    "reason": REASON_CONVERSION_PENDING,
+                    "conversion_id": conversion.get("id"),
+                    "retry_after_s": conversion.get("retry_after_s", 2),
+                }
+            )
+            return result
+        converted = conversion.get("result")
+        if not isinstance(converted, dict):
+            raise ToolError("CLIO Search completed conversion without a result payload.")
+        content = str(converted.get("markdown") or "")
+        result["method"] = "clio-search"
+        result["extractor"] = "document-service"
+        document = converted.get("document")
+        if isinstance(document, dict):
+            inline_document = dict(document)
+            structure = inline_document.pop("structure", None)
+            if structure is not None:
+                inline_document["structure_available"] = True
+                if isinstance(structure, dict):
+                    inline_document["structure_summary"] = {
+                        key: len(value)
+                        for key, value in structure.items()
+                        if isinstance(value, (dict, list))
+                    }
+            result["document"] = inline_document
+        else:
+            result["document"] = document
+        result["conversion_id"] = conversion.get("id")
+        if to_file:
+            output_path = _validate_output_path(
+                f"{Path(filename).stem}.md", default_name="document.md", output_dir=output_dir
+            )
+            output_path.write_text(content, encoding="utf-8")
+            metadata_path = output_path.with_suffix(".json")
+            metadata_path.write_text(
+                json.dumps(document, ensure_ascii=False, indent=2),
+                encoding="utf-8",
+            )
+            result["local_path"] = str(output_path)
+            result["metadata_path"] = str(metadata_path)
+            if isinstance(document, dict) and "structure" in document:
+                result["structure_saved_to"] = str(metadata_path)
+            return result
+        result["content"] = content
+        return result
     elif is_binary:
         if not to_file:
             # Never inline a giant binary blob; hand back a typed note.
@@ -552,10 +398,10 @@ async def fetch(
             return result
         content = None  # binary is written raw below
     else:
-        content = _decode(body, charset)
+        content = decode(body, charset)
 
     if to_file:
-        filename = _derive_filename(target, is_html=is_html, is_binary=is_binary)
+        filename = derive_filename(final_url, is_html=is_html_content, is_binary=is_binary)
         output_path = _validate_output_path(filename, default_name="page", output_dir=output_dir)
         if is_binary:
             output_path.write_bytes(body)
@@ -649,21 +495,35 @@ async def _search_tavily(query: str, count: int) -> list[dict[str, str]]:
     return results
 
 
-@mcp.tool(
-    name="search",
-    title="Search Web",
-    description=(
-        "Search the web via a configurable provider (keyless DuckDuckGo by "
-        "default; self-hosted SearXNG; optional BYO-key Brave or Tavily) and "
-        "return ranked results. SearXNG supports category, engine, language, "
-        "time-range, page, and safe-search selectors."
-    ),
-    annotations={"readOnlyHint": True, "destructiveHint": False, "idempotentHint": False},
-    tags={"web", "search"},
-)
-async def search(
+async def _search_common(
     query: Annotated[str, Field(description="The search query.")],
-    provider: Annotated[str | None, Field(description="Search provider override.")] = None,
+    count: Annotated[int, Field(description="Maximum number of results to return.")] = 5,
+) -> dict[str, Any]:
+    """Search the fixed DDG, Brave, or Tavily provider."""
+
+    text = (query or "").strip()
+    if not text:
+        raise ToolError("A non-empty query is required.")
+    effective_count = min(count if count and count > 0 else 5, _MAX_SEARCH_COUNT)
+    if settings.search_provider == "ddg":
+        results = await _search_ddg(text, effective_count)
+    elif settings.search_provider == "brave":
+        results = await _search_brave(text, effective_count)
+    elif settings.search_provider == "tavily":
+        results = await _search_tavily(text, effective_count)
+    else:
+        raise ToolError("The active search provider requires the SearXNG search schema.")
+    return {
+        "ok": True,
+        "provider": settings.search_provider,
+        "query": text,
+        "results": results,
+        "count": len(results),
+    }
+
+
+async def _search_searxng_tool(
+    query: Annotated[str, Field(description="The search query.")],
     count: Annotated[int, Field(description="Maximum number of results to return.")] = 5,
     category: Annotated[
         Literal["general", "science", "it"] | None,
@@ -680,94 +540,65 @@ async def search(
     ] = None,
     pageno: Annotated[
         int | None,
-        Field(description="SearXNG-only result page, 1 through 3.", ge=1, le=3),
+        Field(
+            description="SearXNG result page, bounded by this deployment to 1 through 3.",
+            ge=1,
+            le=3,
+        ),
     ] = None,
     safesearch: Annotated[
         int | None,
         Field(description="SearXNG safe-search level, 0 through 2.", ge=0, le=2),
     ] = None,
 ) -> dict[str, Any]:
-    """Search the web and return ``{title, url, snippet}`` results.
+    """Search the fixed SearXNG provider with its native selectors."""
 
-    The provider is selected by config (``Settings.search_provider``, keyless
-    ``ddg`` by default). Selecting a keyed provider without its key raises a
-    typed error naming the missing configuration -- never a silent fallback.
-    """
     text = (query or "").strip()
     if not text:
         raise ToolError("A non-empty query is required.")
     effective_count = min(count if count and count > 0 else 5, _MAX_SEARCH_COUNT)
-    selected = (provider or settings.search_provider or "ddg").lower()
-    has_searxng_selectors = any(
-        (
-            category is not None,
-            bool(engines),
-            bool(language and language.strip()),
-            time_range is not None,
-            pageno is not None,
-            safesearch is not None,
-        )
+    results, engines_answered, unresponsive_engines = await search_searxng(
+        text,
+        effective_count,
+        base_url=settings.searxng_base_url,
+        connect_timeout_s=settings.connect_timeout_s,
+        read_timeout_s=settings.read_timeout_s,
+        category=category,
+        engines=engines,
+        language=language,
+        time_range=time_range,
+        pageno=pageno or 1,
+        safesearch=safesearch,
     )
-    if selected != "searxng" and has_searxng_selectors:
-        raise ToolError(
-            "category, engines, language, time_range, pageno, and safesearch are "
-            "only supported by provider 'searxng'."
-        )
-
-    engines_answered: list[str] = []
-    unresponsive_engines: list[dict[str, str]] = []
-    if selected == "ddg":
-        results = await _search_ddg(text, effective_count)
-    elif selected == "brave":
-        results = await _search_brave(text, effective_count)
-    elif selected == "tavily":
-        results = await _search_tavily(text, effective_count)
-    elif selected == "searxng":
-        results, engines_answered, unresponsive_engines = await search_searxng(
-            text,
-            effective_count,
-            base_url=settings.searxng_base_url,
-            connect_timeout_s=settings.connect_timeout_s,
-            read_timeout_s=settings.read_timeout_s,
-            category=category,
-            engines=engines,
-            language=language,
-            time_range=time_range,
-            pageno=pageno or 1,
-            safesearch=safesearch,
-        )
-    else:
-        raise ToolError(
-            f"Unknown search provider {selected!r}. Supported: 'ddg', 'searxng', 'brave', 'tavily'."
-        )
-
-    response: dict[str, Any] = {
+    return {
         "ok": True,
-        "provider": selected,
+        "provider": "searxng",
         "query": text,
         "results": results,
         "count": len(results),
+        "engines_answered": engines_answered,
+        "unresponsive_engines": unresponsive_engines,
     }
-    if selected == "searxng":
-        response["engines_answered"] = engines_answered
-        response["unresponsive_engines"] = unresponsive_engines
-    return response
 
 
-@mcp.resource("web://providers")
-def search_providers() -> dict[str, Any]:
-    """The active + available web-search providers and current fetch limits."""
+def capabilities() -> dict[str, Any]:
+    """Return only the active installation's search and fetch capabilities."""
+
+    search_parameters = ["query", "count"]
+    if settings.search_provider == "searxng":
+        search_parameters.extend(
+            ["category", "engines", "language", "time_range", "pageno", "safesearch"]
+        )
     return {
         "active_provider": settings.search_provider,
-        "available_providers": ["ddg", "searxng", "brave", "tavily"],
-        "keyless_default": "ddg",
-        "searxng_configured": bool((settings.searxng_base_url or "").strip()),
+        "search_parameters": search_parameters,
+        "document_enrichment": bool((settings.document_service_url or "").strip()),
         "max_bytes": settings.max_bytes,
+        "max_document_bytes": settings.max_document_bytes,
         "allow_private_hosts": settings.allow_private_hosts,
     }
 
 
-@mcp.prompt()
 def research_web(topic: str) -> list[Message]:
     """Guided search then fetch workflow for researching a topic on the web."""
     return [
@@ -779,20 +610,115 @@ def research_web(topic: str) -> list[Message]:
     ]
 
 
+def _validate_startup(configured: Settings) -> None:
+    """Reject invalid selected-provider configuration before serving tools."""
+
+    if configured.search_provider == "searxng":
+        value = (configured.searxng_base_url or "").strip()
+        parsed = urlparse(value)
+        if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+            raise ValueError("provider 'searxng' requires --address with an absolute HTTP(S) URL")
+    if configured.search_provider == "brave" and not configured.brave_api_key:
+        raise ValueError("provider 'brave' requires WEB_BRAVE_API_KEY")
+    if configured.search_provider == "tavily" and not configured.tavily_api_key:
+        raise ValueError("provider 'tavily' requires WEB_TAVILY_API_KEY")
+
+
+def create_mcp(configured: Settings | None = None) -> FastMCP:
+    """Create the provider-specific MCP schema for one installation."""
+
+    global settings
+    if configured is not None:
+        settings = configured
+    _validate_startup(settings)
+    instance = _new_mcp()
+    instance.tool(
+        name="fetch",
+        title="Fetch Target",
+        description=(
+            "Fetch an HTTP(S) URL or DOI. HTML and text are read locally; supported PDFs and "
+            "structured documents use the optional CLIO Search document service."
+        ),
+        annotations={"readOnlyHint": True, "destructiveHint": False, "idempotentHint": True},
+        tags={"web", "fetch", "http", "documents"},
+    )(fetch)
+    search_function = (
+        _search_searxng_tool if settings.search_provider == "searxng" else _search_common
+    )
+    search_description = (
+        "Search the configured self-hosted SearXNG deployment with native category, engine, "
+        "language, time-range, page, and safe-search selectors."
+        if settings.search_provider == "searxng"
+        else f"Search the web using this installation's fixed {settings.search_provider} provider."
+    )
+    instance.tool(
+        name="search",
+        title="Search Web",
+        description=search_description,
+        annotations={"readOnlyHint": True, "destructiveHint": False, "idempotentHint": False},
+        tags={"web", "search"},
+    )(search_function)
+    instance.resource("web://capabilities")(capabilities)
+    instance.prompt()(research_web)
+    return instance
+
+
+mcp = create_mcp()
+
+
 def main() -> None:
     """Main entry point for the web MCP server."""
     import argparse
 
     parser = argparse.ArgumentParser(description="Web MCP Server")
+    parser.add_argument(
+        "--provider",
+        type=str.lower,
+        choices=["ddg", "searxng", "brave", "tavily"],
+        default=None,
+        help="Search provider fixed for this MCP installation.",
+    )
+    parser.add_argument(
+        "--address",
+        help="SearXNG or CLIO Search root URL; required when --provider searxng.",
+    )
+    parser.add_argument(
+        "--document-address",
+        help="Optional CLIO Search root URL for DOI and document enrichment.",
+    )
     parser.add_argument("--transport", choices=["stdio", "http"], default=None)
     parser.add_argument("--host", default="0.0.0.0")
     parser.add_argument("--port", type=int, default=8000)
     args = parser.parse_args()
+    selected = args.provider or settings.search_provider
+    configured = Settings(
+        search_provider=selected,
+        searxng_base_url=args.address or settings.searxng_base_url,
+        document_service_url=(
+            args.document_address
+            or settings.document_service_url
+            or (args.address if selected == "searxng" else None)
+        ),
+        brave_api_key=settings.brave_api_key,
+        tavily_api_key=settings.tavily_api_key,
+        max_bytes=settings.max_bytes,
+        max_document_bytes=settings.max_document_bytes,
+        connect_timeout_s=settings.connect_timeout_s,
+        read_timeout_s=settings.read_timeout_s,
+        conversion_wait_s=settings.conversion_wait_s,
+        conversion_poll_s=settings.conversion_poll_s,
+        artifacts_root=settings.artifacts_root,
+        allow_private_hosts=settings.allow_private_hosts,
+    )
+    try:
+        server = create_mcp(configured)
+    except ValueError as exc:
+        parser.error(str(exc))
     transport = args.transport or os.getenv("MCP_TRANSPORT", "stdio")
     if transport == "http":
-        mcp.run(transport="http", host=args.host, port=args.port)
+        server.run(transport="http", host=args.host, port=args.port)
     else:
-        mcp.run(transport="stdio")
+        server.run(transport="stdio")
 
 
 if __name__ == "__main__":

--- a/clio-kit-mcp-servers/web/tests/conftest.py
+++ b/clio-kit-mcp-servers/web/tests/conftest.py
@@ -24,6 +24,7 @@ def clean_settings(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Settings:
     """
     for key in [k for k in os.environ if k.startswith("WEB_")]:
         monkeypatch.delenv(key, raising=False)
-    cfg = Settings(_env_file=None, artifacts_root=str(tmp_path / "artifacts"))
+    # ``_env_file`` is a pydantic-settings constructor option generated at runtime.
+    cfg = Settings(_env_file=None, artifacts_root=str(tmp_path / "artifacts"))  # type: ignore[call-arg]
     monkeypatch.setattr(server, "settings", cfg)
     return cfg

--- a/clio-kit-mcp-servers/web/tests/helpers.py
+++ b/clio-kit-mcp-servers/web/tests/helpers.py
@@ -12,5 +12,7 @@ def parse_result(result: Any) -> dict[str, Any]:
     if isinstance(data, dict):
         return data
     if isinstance(data, str):
-        return json.loads(data)
+        parsed = json.loads(data)
+        if isinstance(parsed, dict):
+            return parsed
     return {"raw": str(data)}

--- a/clio-kit-mcp-servers/web/tests/test_document_service.py
+++ b/clio-kit-mcp-servers/web/tests/test_document_service.py
@@ -1,0 +1,193 @@
+"""Document-service and DOI behavior through the real MCP tool contract."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from fastmcp import Client, FastMCP
+from pytest_httpx import HTTPXMock
+
+from web_mcp.server import Settings, create_mcp
+
+from .helpers import parse_result
+
+_SERVICE = "http://clio-search.test:8080"
+_PDF = b"%PDF-1.7\nstructured test"
+
+
+def _document_mcp(tmp_path: Path, *, wait_s: float = 0) -> FastMCP:
+    return create_mcp(
+        Settings(
+            search_provider="ddg",
+            document_service_url=_SERVICE,
+            artifacts_root=str(tmp_path),
+            conversion_wait_s=wait_s,
+            conversion_poll_s=0.1,
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_fetch_pdf_returns_structured_conversion(
+    httpx_mock: HTTPXMock, tmp_path: Path
+) -> None:
+    """A detected PDF is automatically routed through CLIO Search."""
+
+    source = "https://papers.test/work.pdf"
+    httpx_mock.add_response(url=source, content=_PDF, headers={"content-type": "application/pdf"})
+    httpx_mock.add_response(
+        method="POST",
+        url=f"{_SERVICE}/v1/documents",
+        json={
+            "id": "job-1",
+            "status": "complete",
+            "result": {
+                "markdown": "# Parsed paper",
+                "document": {
+                    "profile": "scholarly",
+                    "metadata": {"title": "Parsed paper"},
+                    "references": [{"title": "Prior work"}],
+                    "citation_contexts": [],
+                    "structure": {"texts": [{"text": "Parsed paper"}], "tables": []},
+                },
+            },
+        },
+    )
+
+    async with Client(_document_mcp(tmp_path)) as client:
+        result = await client.call_tool("fetch", {"target": source})
+    data = parse_result(result)
+
+    assert data["method"] == "clio-search"
+    assert data["content"] == "# Parsed paper"
+    assert data["document"]["profile"] == "scholarly"
+    assert "structure" not in data["document"]
+    assert data["document"]["structure_available"] is True
+    assert data["document"]["structure_summary"] == {"tables": 0, "texts": 1}
+    assert data["conversion_id"] == "job-1"
+
+
+@pytest.mark.asyncio
+async def test_fetch_pdf_to_file_writes_markdown_and_metadata(
+    httpx_mock: HTTPXMock, tmp_path: Path
+) -> None:
+    """Structured output writes Markdown plus a JSON metadata companion."""
+
+    source = "https://papers.test/work.pdf"
+    document = {
+        "profile": "general",
+        "metadata": {},
+        "references": [],
+        "structure": {"texts": [{"text": "converted"}]},
+    }
+    httpx_mock.add_response(url=source, content=_PDF, headers={"content-type": "application/pdf"})
+    httpx_mock.add_response(
+        method="POST",
+        url=f"{_SERVICE}/v1/documents",
+        json={
+            "id": "job-2",
+            "status": "complete",
+            "result": {"markdown": "converted", "document": document},
+        },
+    )
+
+    async with Client(_document_mcp(tmp_path)) as client:
+        result = await client.call_tool("fetch", {"target": source, "to_file": True})
+    data = parse_result(result)
+
+    assert Path(data["local_path"]).read_text(encoding="utf-8") == "converted"
+    assert json.loads(Path(data["metadata_path"]).read_text(encoding="utf-8")) == document
+    assert data["structure_saved_to"] == data["metadata_path"]
+    assert "structure" not in data["document"]
+
+
+@pytest.mark.asyncio
+async def test_fetch_doi_resolves_then_downloads_candidate(
+    httpx_mock: HTTPXMock, tmp_path: Path
+) -> None:
+    """Bare DOI fetch uses CLIO Search metadata and lawful candidate ordering."""
+
+    doi = "10.1234/example"
+    landing = "https://repository.test/article"
+    httpx_mock.add_response(
+        method="POST",
+        url=f"{_SERVICE}/v1/doi/resolve",
+        json={
+            "doi": doi,
+            "metadata": {"title": "Example"},
+            "candidates": [{"url": landing, "source": "unpaywall"}],
+            "sources_queried": ["crossref", "unpaywall"],
+            "warnings": [],
+        },
+    )
+    httpx_mock.add_response(
+        url=landing,
+        content=b"open copy",
+        headers={"content-type": "text/plain"},
+    )
+
+    async with Client(_document_mcp(tmp_path)) as client:
+        result = await client.call_tool("fetch", {"target": doi})
+    data = parse_result(result)
+
+    assert data["doi"] == doi
+    assert data["url"] == landing
+    assert data["content"] == "open copy"
+    assert data["doi_resolution"]["sources_queried"] == ["crossref", "unpaywall"]
+
+
+@pytest.mark.asyncio
+async def test_fetch_doi_url_uses_same_resolution_contract(
+    httpx_mock: HTTPXMock, tmp_path: Path
+) -> None:
+    """A doi.org URL is semantic DOI input rather than an ordinary landing-page URL."""
+
+    doi = "10.1234/example"
+    landing = "https://repository.test/article"
+    httpx_mock.add_response(
+        method="POST",
+        url=f"{_SERVICE}/v1/doi/resolve",
+        json={
+            "doi": doi,
+            "metadata": {},
+            "candidates": [{"url": landing, "source": "datacite"}],
+            "sources_queried": ["crossref", "datacite"],
+            "warnings": [],
+        },
+    )
+    httpx_mock.add_response(
+        url=landing,
+        content=b"resolved",
+        headers={"content-type": "text/plain"},
+    )
+
+    async with Client(_document_mcp(tmp_path)) as client:
+        result = await client.call_tool("fetch", {"target": f"https://doi.org/{doi}"})
+
+    assert parse_result(result)["doi"] == doi
+
+
+@pytest.mark.asyncio
+async def test_fetch_document_returns_durable_pending_handle(
+    httpx_mock: HTTPXMock, tmp_path: Path
+) -> None:
+    """A long conversion returns an honest retry handle rather than hiding work."""
+
+    source = "https://papers.test/work.pdf"
+    httpx_mock.add_response(url=source, content=_PDF, headers={"content-type": "application/pdf"})
+    httpx_mock.add_response(
+        method="POST",
+        url=f"{_SERVICE}/v1/documents",
+        status_code=202,
+        json={"id": "job-pending", "status": "queued", "retry_after_s": 2},
+    )
+
+    async with Client(_document_mcp(tmp_path)) as client:
+        result = await client.call_tool("fetch", {"target": source})
+    data = parse_result(result)
+
+    assert data["reason"] == "document_conversion_pending"
+    assert data["conversion_id"] == "job-pending"
+    assert data["retry_after_s"] == 2

--- a/clio-kit-mcp-servers/web/tests/test_document_service.py
+++ b/clio-kit-mcp-servers/web/tests/test_document_service.py
@@ -5,10 +5,13 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import httpx
 import pytest
 from fastmcp import Client, FastMCP
+from fastmcp.exceptions import ToolError
 from pytest_httpx import HTTPXMock
 
+from web_mcp.document_service import convert_document, resolve_doi, service_endpoint
 from web_mcp.server import Settings, create_mcp
 
 from .helpers import parse_result
@@ -191,3 +194,135 @@ async def test_fetch_document_returns_durable_pending_handle(
     assert data["reason"] == "document_conversion_pending"
     assert data["conversion_id"] == "job-pending"
     assert data["retry_after_s"] == 2
+
+
+@pytest.mark.parametrize(
+    ("address", "message"),
+    [
+        ("not-a-url", "absolute CLIO Search address"),
+        ("https://search.test/?tenant=x", "query or fragment"),
+    ],
+)
+def test_service_endpoint_rejects_ambiguous_addresses(address: str, message: str) -> None:
+    """Document-service configuration is validated before any request is sent."""
+
+    with pytest.raises(ToolError, match=message):
+        service_endpoint(address, "/v1/documents")
+
+
+@pytest.mark.asyncio
+async def test_resolve_doi_rejects_malformed_service_payload(httpx_mock: HTTPXMock) -> None:
+    """A successful HTTP response still must satisfy the DOI response contract."""
+
+    httpx_mock.add_response(
+        method="POST",
+        url=f"{_SERVICE}/v1/doi/resolve",
+        json={"doi": "10.1234/example", "candidates": "not-a-list"},
+    )
+    with pytest.raises(ToolError, match="malformed DOI-resolution response"):
+        await resolve_doi(
+            "10.1234/example",
+            service_url=_SERVICE,
+            timeout=httpx.Timeout(2),
+        )
+
+
+@pytest.mark.asyncio
+async def test_resolve_doi_wraps_service_failure(httpx_mock: HTTPXMock) -> None:
+    """DOI service transport failures identify the failing endpoint."""
+
+    httpx_mock.add_exception(
+        httpx.ConnectError("offline"),
+        method="POST",
+        url=f"{_SERVICE}/v1/doi/resolve",
+    )
+    with pytest.raises(ToolError, match="Could not resolve DOI through CLIO Search"):
+        await resolve_doi(
+            "10.1234/example",
+            service_url=_SERVICE,
+            timeout=httpx.Timeout(2),
+        )
+
+
+@pytest.mark.asyncio
+async def test_convert_document_polls_and_sends_doi(httpx_mock: HTTPXMock) -> None:
+    """Queued conversion is polled to completion and preserves DOI provenance."""
+
+    httpx_mock.add_response(
+        method="POST",
+        url=f"{_SERVICE}/v1/documents",
+        status_code=202,
+        json={"id": "poll-1", "status": "queued"},
+    )
+    httpx_mock.add_response(
+        method="GET",
+        url=f"{_SERVICE}/v1/documents/poll-1",
+        json={"id": "poll-1", "status": "complete", "result": {"markdown": "done"}},
+    )
+    payload = await convert_document(
+        _PDF,
+        filename="paper.pdf",
+        content_type="application/pdf",
+        source_url="https://papers.test/paper.pdf",
+        doi="10.1234/example",
+        service_url=_SERVICE,
+        timeout=httpx.Timeout(2),
+        wait_s=1,
+        poll_s=0,
+    )
+
+    assert payload["status"] == "complete"
+    request_body = httpx_mock.get_requests()[0].content
+    assert b"10.1234/example" in request_body
+
+
+@pytest.mark.asyncio
+async def test_convert_document_rejects_malformed_submission(httpx_mock: HTTPXMock) -> None:
+    """A document submission without a durable id is rejected."""
+
+    httpx_mock.add_response(
+        method="POST",
+        url=f"{_SERVICE}/v1/documents",
+        json={"status": "queued"},
+    )
+    with pytest.raises(ToolError, match="malformed document submission"):
+        await convert_document(
+            _PDF,
+            filename="paper.pdf",
+            content_type="application/pdf",
+            source_url="https://papers.test/paper.pdf",
+            doi=None,
+            service_url=_SERVICE,
+            timeout=httpx.Timeout(2),
+            wait_s=0,
+            poll_s=0,
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("error", "message"),
+    [({"message": "parser unavailable"}, "parser unavailable"), (None, "unknown error")],
+)
+async def test_convert_document_surfaces_typed_failure(
+    httpx_mock: HTTPXMock, error: object, message: str
+) -> None:
+    """Failed conversion returns the service's reason without hiding it."""
+
+    httpx_mock.add_response(
+        method="POST",
+        url=f"{_SERVICE}/v1/documents",
+        json={"id": "failed-1", "status": "failed", "error": error},
+    )
+    with pytest.raises(ToolError, match=message):
+        await convert_document(
+            _PDF,
+            filename="paper.pdf",
+            content_type="application/pdf",
+            source_url="https://papers.test/paper.pdf",
+            doi=None,
+            service_url=_SERVICE,
+            timeout=httpx.Timeout(2),
+            wait_s=0,
+            poll_s=0,
+        )

--- a/clio-kit-mcp-servers/web/tests/test_fetch.py
+++ b/clio-kit-mcp-servers/web/tests/test_fetch.py
@@ -38,7 +38,7 @@ async def test_fetch_html_to_markdown(httpx_mock: HTTPXMock) -> None:
         headers={"content-type": "text/html; charset=utf-8"},
     )
     async with Client(mcp) as client:
-        result = await client.call_tool("fetch", {"url": "https://example.test/report"})
+        result = await client.call_tool("fetch", {"target": "https://example.test/report"})
     data = parse_result(result)
 
     assert data["ok"] is True
@@ -59,7 +59,7 @@ async def test_fetch_url_round_trips_verbatim(httpx_mock: HTTPXMock) -> None:
         headers={"content-type": "text/plain"},
     )
     async with Client(mcp) as client:
-        result = await client.call_tool("fetch", {"url": url})
+        result = await client.call_tool("fetch", {"target": url})
     data = parse_result(result)
     assert data["url"] == url
 
@@ -73,7 +73,7 @@ async def test_fetch_text_passthrough(httpx_mock: HTTPXMock) -> None:
         headers={"content-type": "text/plain"},
     )
     async with Client(mcp) as client:
-        result = await client.call_tool("fetch", {"url": "https://example.test/data.txt"})
+        result = await client.call_tool("fetch", {"target": "https://example.test/data.txt"})
     data = parse_result(result)
     assert data["content"] == "plain body text"
     assert data["content_type"] == "text/plain"
@@ -85,7 +85,7 @@ async def test_fetch_rejects_non_http_scheme() -> None:
     """A non-http(s) URL raises a ToolError before any network call."""
     async with Client(mcp) as client:
         with pytest.raises(Exception) as excinfo:
-            await client.call_tool("fetch", {"url": "ftp://example.test/x"})
+            await client.call_tool("fetch", {"target": "ftp://example.test/x"})
     assert "http(s)" in str(excinfo.value)
 
 
@@ -100,7 +100,7 @@ async def test_fetch_size_cap_content_length(httpx_mock: HTTPXMock) -> None:
     async with Client(mcp) as client:
         with pytest.raises(Exception) as excinfo:
             await client.call_tool(
-                "fetch", {"url": "https://example.test/big.bin", "max_bytes": 10}
+                "fetch", {"target": "https://example.test/big.bin", "max_bytes": 10}
             )
     assert "exceeds the fetch size limit" in str(excinfo.value)
 
@@ -115,7 +115,9 @@ async def test_fetch_size_cap_mid_stream(httpx_mock: HTTPXMock) -> None:
     )
     async with Client(mcp) as client:
         with pytest.raises(Exception) as excinfo:
-            await client.call_tool("fetch", {"url": "https://example.test/stream", "max_bytes": 10})
+            await client.call_tool(
+                "fetch", {"target": "https://example.test/stream", "max_bytes": 10}
+            )
     assert "while downloading" in str(excinfo.value)
 
 
@@ -132,7 +134,7 @@ async def test_fetch_to_file_writes_and_returns_path(httpx_mock: HTTPXMock, tmp_
         result = await client.call_tool(
             "fetch",
             {
-                "url": "https://example.test/notes.txt",
+                "target": "https://example.test/notes.txt",
                 "to_file": True,
                 "output_dir": str(out),
             },
@@ -154,7 +156,7 @@ async def test_fetch_binary_without_to_file_is_typed_note(httpx_mock: HTTPXMock)
         headers={"content-type": "image/png"},
     )
     async with Client(mcp) as client:
-        result = await client.call_tool("fetch", {"url": "https://example.test/image.png"})
+        result = await client.call_tool("fetch", {"target": "https://example.test/image.png"})
     data = parse_result(result)
     assert data["content"] is None
     assert data["reason"] == REASON_BINARY_NOT_INLINED
@@ -173,7 +175,11 @@ async def test_fetch_binary_to_file_writes_raw_bytes(httpx_mock: HTTPXMock, tmp_
     async with Client(mcp) as client:
         result = await client.call_tool(
             "fetch",
-            {"url": "https://example.test/image.png", "to_file": True, "output_dir": str(out)},
+            {
+                "target": "https://example.test/image.png",
+                "to_file": True,
+                "output_dir": str(out),
+            },
         )
     data = parse_result(result)
     local_path = Path(data["local_path"])
@@ -194,7 +200,7 @@ async def test_fetch_empty_html_signals_js_render(httpx_mock: HTTPXMock) -> None
         headers={"content-type": "text/html"},
     )
     async with Client(mcp) as client:
-        result = await client.call_tool("fetch", {"url": "https://example.test/spa"})
+        result = await client.call_tool("fetch", {"target": "https://example.test/spa"})
     data = parse_result(result)
     assert data["content"] is None
     assert data["reason"] == REASON_JS_RENDER_REQUIRED
@@ -213,5 +219,5 @@ async def test_fetch_max_bytes_default_from_settings(
     )
     async with Client(mcp) as client:
         with pytest.raises(Exception) as excinfo:
-            await client.call_tool("fetch", {"url": "https://example.test/toobig"})
+            await client.call_tool("fetch", {"target": "https://example.test/toobig"})
     assert "exceeds the fetch size limit" in str(excinfo.value)

--- a/clio-kit-mcp-servers/web/tests/test_fetch_security.py
+++ b/clio-kit-mcp-servers/web/tests/test_fetch_security.py
@@ -6,6 +6,8 @@ and content-sniff for a missing content-type. All network is mocked via pytest-h
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 from fastmcp import Client
 from pytest_httpx import HTTPXMock
@@ -154,3 +156,76 @@ async def test_fetch_no_content_type_binary_stays_a_typed_note(httpx_mock: HTTPX
         data = parse_result(await client.call_tool("fetch", {"target": "https://x.test/bin"}))
     assert data.get("content") is None
     assert data["reason"] == REASON_BINARY_NOT_INLINED
+
+
+def test_validate_output_path_accepts_inside_and_confines_outside(tmp_path: Path) -> None:
+    """Absolute artifact paths are accepted only when they stay under the configured root."""
+
+    inside = tmp_path / "nested" / "inside.md"
+    assert (
+        fetch_utils.validate_output_path(
+            inside,
+            default_name="default.md",
+            configured_root=str(tmp_path),
+        )
+        == inside.resolve()
+    )
+    outside = tmp_path.parent / "outside.md"
+    assert (
+        fetch_utils.validate_output_path(
+            outside,
+            default_name="default.md",
+            configured_root=str(tmp_path),
+        )
+        == (tmp_path / "outside.md").resolve()
+    )
+
+
+def test_content_helpers_cover_empty_invalid_and_html_inputs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Low-level content helpers keep their edge cases deterministic and typed."""
+
+    assert fetch_utils.derive_filename("https://example.test/", is_html=True, is_binary=False) == (
+        "example.md"
+    )
+    assert fetch_utils.extract_title("<html><body>untitled</body></html>") is None
+    assert fetch_utils.decode(b"plain", "not-a-real-codec") == "plain"
+    assert fetch_utils.looks_like_text(b"") is True
+
+    def _boom(*_args: object, **_kwargs: object) -> str:
+        raise RuntimeError("extractor down")
+
+    monkeypatch.setattr(fetch_utils.trafilatura, "extract", _boom)
+    content, extractor = fetch_utils.html_to_markdown(_HTML)
+    assert content and "body content" in content.lower()
+    assert extractor == "readability"
+
+
+@pytest.mark.asyncio
+async def test_fetch_ignores_invalid_content_length(httpx_mock: HTTPXMock) -> None:
+    """A malformed advisory content-length cannot hide an otherwise bounded response."""
+
+    httpx_mock.add_response(
+        url="https://x.test/length",
+        content=b"bounded",
+        headers={"content-type": "text/plain", "content-length": "unknown"},
+    )
+    async with Client(mcp) as client:
+        data = parse_result(await client.call_tool("fetch", {"target": "https://x.test/length"}))
+    assert data["content"] == "bounded"
+
+
+@pytest.mark.asyncio
+async def test_fetch_rejects_redirect_loop(httpx_mock: HTTPXMock) -> None:
+    """The explicit redirect cap terminates cyclic public redirects."""
+
+    for _ in range(6):
+        httpx_mock.add_response(
+            url="https://x.test/loop",
+            status_code=302,
+            headers={"location": "https://x.test/loop"},
+        )
+    async with Client(mcp) as client:
+        with pytest.raises(Exception, match="exceeded 5 redirects"):
+            await client.call_tool("fetch", {"target": "https://x.test/loop"})

--- a/clio-kit-mcp-servers/web/tests/test_fetch_security.py
+++ b/clio-kit-mcp-servers/web/tests/test_fetch_security.py
@@ -10,7 +10,7 @@ import pytest
 from fastmcp import Client
 from pytest_httpx import HTTPXMock
 
-from web_mcp import server
+from web_mcp import fetch_utils, server
 from web_mcp.server import REASON_BINARY_NOT_INLINED, REASON_BLOCKED_HOST, mcp
 
 from .helpers import parse_result
@@ -38,7 +38,7 @@ async def test_fetch_blocks_private_and_metadata_hosts(url: str) -> None:
     """A literal loopback/private/link-local host (or localhost) is refused before any request."""
     async with Client(mcp) as client:
         with pytest.raises(Exception) as excinfo:
-            await client.call_tool("fetch", {"url": url})
+            await client.call_tool("fetch", {"target": url})
     assert REASON_BLOCKED_HOST in str(excinfo.value)
 
 
@@ -52,7 +52,7 @@ async def test_fetch_blocks_redirect_into_metadata(httpx_mock: HTTPXMock) -> Non
     )
     async with Client(mcp) as client:
         with pytest.raises(Exception) as excinfo:
-            await client.call_tool("fetch", {"url": "https://public.test/go"})
+            await client.call_tool("fetch", {"target": "https://public.test/go"})
     assert REASON_BLOCKED_HOST in str(excinfo.value)
 
 
@@ -68,7 +68,7 @@ async def test_fetch_allow_private_hosts_config_opens_the_guard(
         headers={"content-type": "text/plain"},
     )
     async with Client(mcp) as client:
-        result = await client.call_tool("fetch", {"url": "http://127.0.0.1:9000/health"})
+        result = await client.call_tool("fetch", {"target": "http://127.0.0.1:9000/health"})
     assert parse_result(result)["content"] == "OK"
 
 
@@ -84,7 +84,7 @@ async def test_fetch_follows_redirect_and_reports_final_url(httpx_mock: HTTPXMoc
         url="https://b.test/end", content=b"done", headers={"content-type": "text/plain"}
     )
     async with Client(mcp) as client:
-        result = await client.call_tool("fetch", {"url": "https://a.test/start"})
+        result = await client.call_tool("fetch", {"target": "https://a.test/start"})
     data = parse_result(result)
     assert data["url"] == "https://a.test/start"  # verbatim source
     assert data["final_url"] == "https://b.test/end"  # resolved after redirect
@@ -98,7 +98,7 @@ async def test_fetch_reports_extractor_trafilatura(httpx_mock: HTTPXMock) -> Non
         url="https://x.test/a", content=_HTML.encode(), headers={"content-type": "text/html"}
     )
     async with Client(mcp) as client:
-        data = parse_result(await client.call_tool("fetch", {"url": "https://x.test/a"}))
+        data = parse_result(await client.call_tool("fetch", {"target": "https://x.test/a"}))
     assert data["extractor"] == "trafilatura"
 
 
@@ -107,12 +107,12 @@ async def test_fetch_reports_readability_downgrade(
     httpx_mock: HTTPXMock, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """When trafilatura yields nothing, readability runs AND is named (no silent downgrade)."""
-    monkeypatch.setattr(server.trafilatura, "extract", lambda *a, **k: None)
+    monkeypatch.setattr(fetch_utils.trafilatura, "extract", lambda *a, **k: None)
     httpx_mock.add_response(
         url="https://x.test/b", content=_HTML.encode(), headers={"content-type": "text/html"}
     )
     async with Client(mcp) as client:
-        data = parse_result(await client.call_tool("fetch", {"url": "https://x.test/b"}))
+        data = parse_result(await client.call_tool("fetch", {"target": "https://x.test/b"}))
     assert data["extractor"] == "readability"
     assert data["content"] and "body content" in data["content"].lower()
 
@@ -122,17 +122,17 @@ async def test_fetch_reports_plaintext_downgrade(
     httpx_mock: HTTPXMock, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """When both trafilatura and readability fail, the plaintext rung runs and is named."""
-    monkeypatch.setattr(server.trafilatura, "extract", lambda *a, **k: None)
+    monkeypatch.setattr(fetch_utils.trafilatura, "extract", lambda *a, **k: None)
 
     def _boom(*_a: object, **_k: object) -> object:
         raise RuntimeError("readability down")
 
-    monkeypatch.setattr(server, "ReadabilityDocument", _boom)
+    monkeypatch.setattr(fetch_utils, "ReadabilityDocument", _boom)
     httpx_mock.add_response(
         url="https://x.test/c", content=_HTML.encode(), headers={"content-type": "text/html"}
     )
     async with Client(mcp) as client:
-        data = parse_result(await client.call_tool("fetch", {"url": "https://x.test/c"}))
+        data = parse_result(await client.call_tool("fetch", {"target": "https://x.test/c"}))
     assert data["extractor"] == "plaintext"
     assert data["content"] and "body content" in data["content"].lower()
 
@@ -142,7 +142,7 @@ async def test_fetch_no_content_type_text_is_sniffed_and_returned(httpx_mock: HT
     """A text body served with NO content-type is sniffed as text and returned, not withheld."""
     httpx_mock.add_response(url="https://x.test/raw", content=b"plain api response, no header")
     async with Client(mcp) as client:
-        data = parse_result(await client.call_tool("fetch", {"url": "https://x.test/raw"}))
+        data = parse_result(await client.call_tool("fetch", {"target": "https://x.test/raw"}))
     assert data["content"] == "plain api response, no header"
 
 
@@ -151,6 +151,6 @@ async def test_fetch_no_content_type_binary_stays_a_typed_note(httpx_mock: HTTPX
     """A binary body with NO content-type is still withheld with the typed note (never junk)."""
     httpx_mock.add_response(url="https://x.test/bin", content=b"\x00\x01\x02\x03binary\x00blob")
     async with Client(mcp) as client:
-        data = parse_result(await client.call_tool("fetch", {"url": "https://x.test/bin"}))
+        data = parse_result(await client.call_tool("fetch", {"target": "https://x.test/bin"}))
     assert data.get("content") is None
     assert data["reason"] == REASON_BINARY_NOT_INLINED

--- a/clio-kit-mcp-servers/web/tests/test_init.py
+++ b/clio-kit-mcp-servers/web/tests/test_init.py
@@ -6,21 +6,21 @@ import web_mcp
 class TestPackageMetadata:
     """Test package-level metadata and initialization."""
 
-    def test_version_exists(self):
+    def test_version_exists(self) -> None:
         """Test that package version is defined."""
         assert hasattr(web_mcp, "__version__")
 
-    def test_version_format(self):
+    def test_version_format(self) -> None:
         """Test that version follows semantic versioning format."""
         version = web_mcp.__version__
         assert isinstance(version, str)
         assert len(version.split(".")) == 3
 
-    def test_version_value(self):
+    def test_version_value(self) -> None:
         """Test that version has expected value."""
-        assert web_mcp.__version__ == "1.1.0"
+        assert web_mcp.__version__ == "2.0.0"
 
-    def test_docstring_exists(self):
+    def test_docstring_exists(self) -> None:
         """Test that package has a docstring."""
         assert web_mcp.__doc__ is not None
         assert len(web_mcp.__doc__) > 0

--- a/clio-kit-mcp-servers/web/tests/test_integration.py
+++ b/clio-kit-mcp-servers/web/tests/test_integration.py
@@ -13,8 +13,7 @@ import os
 import pytest
 from fastmcp import Client
 
-from web_mcp import server
-from web_mcp.server import Settings, mcp
+from web_mcp.server import Settings, create_mcp, mcp
 
 from .helpers import parse_result
 
@@ -31,7 +30,7 @@ pytestmark = [
 async def test_live_fetch_example_com() -> None:
     """Fetch a real, stable page and confirm content comes back."""
     async with Client(mcp) as client:
-        result = await client.call_tool("fetch", {"url": "https://example.com/"})
+        result = await client.call_tool("fetch", {"target": "https://example.com/"})
     data = parse_result(result)
     assert data["ok"] is True
     assert data["url"] == "https://example.com/"
@@ -53,14 +52,12 @@ async def test_live_search_ddg() -> None:
     reason="set WEB_SEARXNG_BASE_URL to run the live SearXNG integration test",
 )
 @pytest.mark.asyncio
-async def test_live_search_searxng(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_live_search_searxng() -> None:
     """Exercise category and engine selectors against the deployed instance."""
-    monkeypatch.setattr(
-        server,
-        "settings",
+    searxng_mcp = create_mcp(
         Settings(search_provider="searxng", searxng_base_url=_SEARXNG_URL),
     )
-    async with Client(mcp) as client:
+    async with Client(searxng_mcp) as client:
         result = await client.call_tool(
             "search",
             {

--- a/clio-kit-mcp-servers/web/tests/test_main.py
+++ b/clio-kit-mcp-servers/web/tests/test_main.py
@@ -9,30 +9,34 @@ from web_mcp.server import main
 class TestMainFunction:
     """Test the main() entry point function."""
 
-    def test_main_default_stdio_mode(self):
+    def test_main_default_stdio_mode(self) -> None:
         """Test main function runs in stdio mode by default."""
-        with patch("web_mcp.server.mcp.run") as mock_run:
+        with patch("web_mcp.server.create_mcp") as create:
+            mock_run = create.return_value.run
             with patch("sys.argv", ["web-mcp"]):
                 main()
             mock_run.assert_called_once_with(transport="stdio")
 
-    def test_main_stdio_mode_explicit(self):
+    def test_main_stdio_mode_explicit(self) -> None:
         """Test main function runs in stdio mode with --transport stdio."""
-        with patch("web_mcp.server.mcp.run") as mock_run:
+        with patch("web_mcp.server.create_mcp") as create:
+            mock_run = create.return_value.run
             with patch("sys.argv", ["web-mcp", "--transport", "stdio"]):
                 main()
             mock_run.assert_called_once_with(transport="stdio")
 
-    def test_main_http_mode(self):
+    def test_main_http_mode(self) -> None:
         """Test main function runs in http mode with --transport http."""
-        with patch("web_mcp.server.mcp.run") as mock_run:
+        with patch("web_mcp.server.create_mcp") as create:
+            mock_run = create.return_value.run
             with patch("sys.argv", ["web-mcp", "--transport", "http"]):
                 main()
             mock_run.assert_called_once_with(transport="http", host="0.0.0.0", port=8000)
 
-    def test_main_custom_host_and_port(self):
+    def test_main_custom_host_and_port(self) -> None:
         """Test main function with custom host and port."""
-        with patch("web_mcp.server.mcp.run") as mock_run:
+        with patch("web_mcp.server.create_mcp") as create:
+            mock_run = create.return_value.run
             with patch(
                 "sys.argv",
                 ["web-mcp", "--transport", "http", "--host", "localhost", "--port", "9000"],
@@ -40,9 +44,10 @@ class TestMainFunction:
                 main()
             mock_run.assert_called_once_with(transport="http", host="localhost", port=9000)
 
-    def test_main_env_transport(self):
+    def test_main_env_transport(self) -> None:
         """Test main function uses MCP_TRANSPORT env var when no --transport flag."""
-        with patch("web_mcp.server.mcp.run") as mock_run:
+        with patch("web_mcp.server.create_mcp") as create:
+            mock_run = create.return_value.run
             with patch("sys.argv", ["web-mcp"]):
                 with patch.dict("os.environ", {"MCP_TRANSPORT": "http"}):
                     main()
@@ -52,22 +57,23 @@ class TestMainFunction:
 class TestServerInitialization:
     """Test server initialization and module-level setup."""
 
-    def test_fastmcp_instance_created(self):
+    def test_fastmcp_instance_created(self) -> None:
         """Test that FastMCP instance is properly created."""
         assert server.mcp is not None
         assert server.mcp.name == "web"
 
-    def test_tools_registered(self):
+    def test_tools_registered(self) -> None:
         """Test that MCP tools are registered on the module."""
         assert hasattr(server, "fetch")
-        assert hasattr(server, "search")
+        assert hasattr(server, "_search_common")
+        assert hasattr(server, "_search_searxng_tool")
 
-    def test_settings_available(self):
+    def test_settings_available(self) -> None:
         """Test that the Settings model and instance are available."""
         assert server.settings is not None
         assert hasattr(server.Settings, "model_validate")
 
-    def test_reason_constants(self):
+    def test_reason_constants(self) -> None:
         """Test that the typed extension-point reason strings are exported."""
         assert server.REASON_JS_RENDER_REQUIRED == "js_render_required_browser_unavailable"
         assert server.REASON_BINARY_NOT_INLINED == "binary_content_not_inlined"

--- a/clio-kit-mcp-servers/web/tests/test_registration.py
+++ b/clio-kit-mcp-servers/web/tests/test_registration.py
@@ -7,48 +7,42 @@ import json
 import pytest
 from fastmcp import Client
 
-from web_mcp import server
-from web_mcp.server import Settings, mcp
+from web_mcp.server import Settings, create_mcp, mcp
 
 
 @pytest.mark.asyncio
 async def test_resource_and_prompt_are_registered() -> None:
-    """web://providers resource and the research_web prompt are exposed."""
+    """web://capabilities resource and the research_web prompt are exposed."""
     async with Client(mcp) as client:
         resources = await client.list_resources()
         prompts = await client.list_prompts()
-    assert any(str(r.uri) == "web://providers" for r in resources)
+    assert any(str(r.uri) == "web://capabilities" for r in resources)
     assert any(p.name == "research_web" for p in prompts)
 
 
 @pytest.mark.asyncio
-async def test_providers_resource_reports_active_backend() -> None:
-    """Reading web://providers returns the active + available search providers."""
+async def test_capabilities_resource_reports_only_active_backend() -> None:
+    """Discovery describes this installation rather than alternate providers."""
     async with Client(mcp) as client:
-        result = await client.read_resource("web://providers")
+        result = await client.read_resource("web://capabilities")
     payload = json.loads(result[0].text)  # resource contents expose .text (JSON)
     assert payload["active_provider"] == "ddg"  # keyless default
-    assert "brave" in payload["available_providers"] and "tavily" in payload["available_providers"]
-    assert "searxng" in payload["available_providers"]
-    assert payload["searxng_configured"] is False
+    assert payload["search_parameters"] == ["query", "count"]
+    assert "available_providers" not in payload
 
 
 @pytest.mark.asyncio
-async def test_providers_resource_reports_configured_searxng(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Discovery reports SearXNG readiness without exposing its deployment URL."""
-    monkeypatch.setattr(
-        server,
-        "settings",
+async def test_capabilities_resource_reports_configured_searxng() -> None:
+    """Discovery reports SearXNG selectors without exposing its deployment URL."""
+    searxng_mcp = create_mcp(
         Settings(
             search_provider="searxng",
             searxng_base_url="http://10.0.0.102:8088",
         ),
     )
-    async with Client(mcp) as client:
-        result = await client.read_resource("web://providers")
+    async with Client(searxng_mcp) as client:
+        result = await client.read_resource("web://capabilities")
     payload = json.loads(result[0].text)
     assert payload["active_provider"] == "searxng"
-    assert payload["searxng_configured"] is True
+    assert "pageno" in payload["search_parameters"]
     assert "10.0.0.102" not in result[0].text

--- a/clio-kit-mcp-servers/web/tests/test_search.py
+++ b/clio-kit-mcp-servers/web/tests/test_search.py
@@ -6,14 +6,14 @@ mocking their HTTP endpoints. No real network occurs in this suite.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Literal
 
 import pytest
 from fastmcp import Client
 from pytest_httpx import HTTPXMock
 
 from web_mcp import server
-from web_mcp.server import Settings, mcp
+from web_mcp.server import Settings, create_mcp, mcp
 
 from .helpers import parse_result
 
@@ -24,7 +24,7 @@ class _FakeDDGS:
     def __enter__(self) -> _FakeDDGS:
         return self
 
-    def __exit__(self, *args: Any) -> bool:
+    def __exit__(self, *args: Any) -> Literal[False]:
         return False
 
     def text(self, query: str, max_results: int) -> list[dict[str, str]]:
@@ -136,10 +136,8 @@ async def test_search_searxng_maps_results_and_native_selectors(
     monkeypatch: pytest.MonkeyPatch, httpx_mock: HTTPXMock
 ) -> None:
     """SearXNG receives native selectors and exposes engine provenance."""
-    monkeypatch.setattr(
-        server,
-        "settings",
-        Settings(search_provider="searxng", searxng_base_url="http://10.0.0.102:8088"),
+    searxng_mcp = create_mcp(
+        Settings(search_provider="searxng", searxng_base_url="http://10.0.0.102:8088")
     )
     httpx_mock.add_response(
         url=(
@@ -166,7 +164,7 @@ async def test_search_searxng_maps_results_and_native_selectors(
         },
     )
 
-    async with Client(mcp) as client:
+    async with Client(searxng_mcp) as client:
         result = await client.call_tool(
             "search",
             {
@@ -189,6 +187,7 @@ async def test_search_searxng_maps_results_and_native_selectors(
             "title": "Parallel I/O Paper",
             "url": "https://example.org/paper",
             "snippet": "A scientific result.",
+            "engines": ["arxiv", "crossref"],
         }
     ]
     assert data["engines_answered"] == ["arxiv", "crossref"]
@@ -196,13 +195,10 @@ async def test_search_searxng_maps_results_and_native_selectors(
 
 
 @pytest.mark.asyncio
-async def test_search_searxng_requires_base_url(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Selecting SearXNG without its deployment URL fails explicitly."""
-    monkeypatch.setattr(server, "settings", Settings(search_provider="searxng"))
-    async with Client(mcp) as client:
-        with pytest.raises(Exception) as excinfo:
-            await client.call_tool("search", {"query": "anything"})
-    assert "WEB_SEARXNG_BASE_URL" in str(excinfo.value)
+async def test_search_searxng_requires_base_url() -> None:
+    """Selecting SearXNG without its deployment URL fails at startup."""
+    with pytest.raises(ValueError, match="requires --address"):
+        create_mcp(Settings(search_provider="searxng"))
 
 
 @pytest.mark.asyncio
@@ -210,13 +206,11 @@ async def test_search_searxng_reports_disabled_json(
     monkeypatch: pytest.MonkeyPatch, httpx_mock: HTTPXMock
 ) -> None:
     """A 403 identifies the disabled SearXNG JSON API instead of falling back."""
-    monkeypatch.setattr(
-        server,
-        "settings",
-        Settings(search_provider="searxng", searxng_base_url="http://10.0.0.102:8088"),
+    searxng_mcp = create_mcp(
+        Settings(search_provider="searxng", searxng_base_url="http://10.0.0.102:8088")
     )
     httpx_mock.add_response(status_code=403)
-    async with Client(mcp) as client:
+    async with Client(searxng_mcp) as client:
         with pytest.raises(Exception) as excinfo:
             await client.call_tool("search", {"query": "anything"})
     assert "JSON" in str(excinfo.value)
@@ -224,46 +218,35 @@ async def test_search_searxng_reports_disabled_json(
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("provider", ["ddg", "brave", "tavily"])
-@pytest.mark.parametrize(
-    "selector",
-    [
-        {"category": "science"},
-        {"engines": ["arxiv"]},
-        {"language": "en"},
-        {"time_range": "year"},
-        {"pageno": 1},
-        {"safesearch": 0},
-    ],
-)
-async def test_searxng_selectors_rejected_for_other_providers(
-    monkeypatch: pytest.MonkeyPatch, provider: str, selector: dict[str, Any]
-) -> None:
-    """Provider-specific selectors are never silently discarded."""
-    monkeypatch.setattr(server, "settings", Settings(search_provider=provider))
-    async with Client(mcp) as client:
-        with pytest.raises(Exception) as excinfo:
-            await client.call_tool("search", {"query": "x", **selector})
-    assert "only supported by provider 'searxng'" in str(excinfo.value)
+@pytest.mark.asyncio
+async def test_non_searxng_schema_omits_provider_and_native_selectors() -> None:
+    """Provider choice is installation-time and irrelevant arguments are absent."""
+    ddg_mcp = create_mcp(Settings(search_provider="ddg"))
+    async with Client(ddg_mcp) as client:
+        search_tool = next(tool for tool in await client.list_tools() if tool.name == "search")
+    properties = search_tool.input_schema["properties"]
+    assert set(properties) == {"query", "count"}
 
 
 @pytest.mark.asyncio
-async def test_search_provider_override_beats_config(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """An explicit provider argument overrides the configured default."""
-    monkeypatch.setattr(server, "settings", Settings(search_provider="ddg"))
-    async with Client(mcp) as client:
-        with pytest.raises(Exception) as excinfo:
-            await client.call_tool("search", {"query": "x", "provider": "brave"})
-    assert "WEB_BRAVE_API_KEY" in str(excinfo.value)
-
-
-@pytest.mark.asyncio
-async def test_search_unknown_provider_raises(monkeypatch: pytest.MonkeyPatch) -> None:
-    """An unknown provider is rejected with a typed error."""
-    monkeypatch.setattr(server, "settings", Settings(search_provider="bing"))
-    async with Client(mcp) as client:
-        with pytest.raises(Exception) as excinfo:
-            await client.call_tool("search", {"query": "x"})
-    assert "Unknown search provider" in str(excinfo.value)
+async def test_searxng_schema_contains_native_selectors_and_exact_page_description() -> None:
+    """Only the SearXNG installation exposes its native selector schema."""
+    searxng_mcp = create_mcp(
+        Settings(search_provider="searxng", searxng_base_url="http://10.0.0.102:8088")
+    )
+    async with Client(searxng_mcp) as client:
+        search_tool = next(tool for tool in await client.list_tools() if tool.name == "search")
+    properties = search_tool.input_schema["properties"]
+    assert set(properties) == {
+        "query",
+        "count",
+        "category",
+        "engines",
+        "language",
+        "time_range",
+        "pageno",
+        "safesearch",
+    }
+    assert properties["pageno"]["description"] == (
+        "SearXNG result page, bounded by this deployment to 1 through 3."
+    )

--- a/clio-kit-mcp-servers/web/tests/test_search.py
+++ b/clio-kit-mcp-servers/web/tests/test_search.py
@@ -218,7 +218,6 @@ async def test_search_searxng_reports_disabled_json(
 
 
 @pytest.mark.asyncio
-@pytest.mark.asyncio
 async def test_non_searxng_schema_omits_provider_and_native_selectors() -> None:
     """Provider choice is installation-time and irrelevant arguments are absent."""
     ddg_mcp = create_mcp(Settings(search_provider="ddg"))

--- a/clio-kit-mcp-servers/web/tests/test_searxng.py
+++ b/clio-kit-mcp-servers/web/tests/test_searxng.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import httpx
 import pytest
 from fastmcp.exceptions import ToolError
@@ -16,7 +18,7 @@ from web_mcp.searxng import (
 
 async def _search(
     *, category: str | None = None
-) -> tuple[list[dict[str, str]], list[str], list[dict[str, str]]]:
+) -> tuple[list[dict[str, Any]], list[str], list[dict[str, str]]]:
     """Call the adapter with deterministic defaults."""
     return await search_searxng(
         "query",
@@ -82,6 +84,7 @@ async def test_search_category_maps_single_engine_and_skips_invalid_rows(
             "title": "Repository",
             "url": "https://github.com/iowarp/clio-agent",
             "snippet": "Fallback snippet.",
+            "engines": ["github"],
         }
     ]
     assert engines == ["github"]

--- a/clio-kit-mcp-servers/web/tests/test_settings.py
+++ b/clio-kit-mcp-servers/web/tests/test_settings.py
@@ -10,26 +10,26 @@ from web_mcp.server import Settings
 class TestSettingsDefaults:
     """Default values for a freshly constructed Settings object."""
 
-    def test_default_search_provider_is_keyless_ddg(self):
+    def test_default_search_provider_is_keyless_ddg(self) -> None:
         cfg = Settings()
         assert cfg.search_provider == "ddg"
 
-    def test_default_keys_are_none(self):
+    def test_default_keys_are_none(self) -> None:
         cfg = Settings()
         assert cfg.brave_api_key is None
         assert cfg.tavily_api_key is None
         assert cfg.searxng_base_url is None
 
-    def test_default_max_bytes_is_5_mib(self):
+    def test_default_max_bytes_is_5_mib(self) -> None:
         cfg = Settings()
         assert cfg.max_bytes == 5 * 1024 * 1024
 
-    def test_default_timeouts(self):
+    def test_default_timeouts(self) -> None:
         cfg = Settings()
         assert cfg.connect_timeout_s == 5.0
         assert cfg.read_timeout_s == 30.0
 
-    def test_default_artifacts_root_is_none(self):
+    def test_default_artifacts_root_is_none(self) -> None:
         cfg = Settings()
         assert cfg.artifacts_root is None
 
@@ -37,7 +37,7 @@ class TestSettingsDefaults:
 class TestSettingsOverride:
     """Configuration is driven by explicit values, not ambient env."""
 
-    def test_override_via_constructor(self):
+    def test_override_via_constructor(self) -> None:
         cfg = Settings(
             search_provider="brave",
             brave_api_key="secret",
@@ -55,7 +55,7 @@ class TestSettingsOverride:
         assert cfg.read_timeout_s == 9.0
         assert cfg.artifacts_root == "custom/web/root"
 
-    def test_override_via_env_prefix(self, monkeypatch: pytest.MonkeyPatch):
+    def test_override_via_env_prefix(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("WEB_SEARCH_PROVIDER", "tavily")
         monkeypatch.setenv("WEB_SEARXNG_BASE_URL", "http://10.0.0.102:8088")
         monkeypatch.setenv("WEB_MAX_BYTES", "2048")

--- a/clio-kit-mcp-servers/web/uv.lock
+++ b/clio-kit-mcp-servers/web/uv.lock
@@ -2895,7 +2895,7 @@ wheels = [
 
 [[package]]
 name = "web-mcp"
-version = "1.1.0"
+version = "2.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "ddgs" },

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "clio-kit",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "mcpServers": {
     "clio-adios": {
       "command": "clio-kit",

--- a/mcp-server-versions.toml
+++ b/mcp-server-versions.toml
@@ -13,7 +13,7 @@ publish = ["web"]
 # Generated website metadata must not depend on the wall clock. Advance this
 # date intentionally whenever current contract metadata is regenerated.
 [documentation]
-updated = "2026-08-11"
+updated = "2026-08-13"
 
 # MCP Registry server versions describe each agent-facing contract. They are
 # intentionally independent of the clio-kit PyPI distribution version, which
@@ -42,4 +42,4 @@ seismic = "2.2.3"
 slurm = "3.0.0"
 spack = "2.1.0"
 terrain = "2.2.3"
-web = "1.1.0"
+web = "2.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "clio-kit"
-version = "2.8.0"
+version = "2.9.0"
 description = "CLIO Kit - MCP Servers, Clients, and Tools for AI Agents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -61,7 +61,7 @@ wheels = [
 
 [[package]]
 name = "clio-kit"
-version = "2.8.0"
+version = "2.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- fix Web MCP provider selection at installation time and expose provider-specific tool schemas
- preserve enriched SearXNG result metadata and unify URL, DOI, PDF, and structured-document fetching
- release clio-kit 2.9.0 with Web MCP 2.0.0 and deterministic registry metadata

## Verification
- Codex SDK review: 17 clio-search tests, 76 live Web tests, all zero-skip
- Codex SDK root release review: 153 tests, zero skips; Ruff, MyPy, file-size, locks, and wheel builds clean
- live homelab search, DOI resolution, HTML fetch, and fresh BERT PDF conversion through Docling + GROBID

The optional document/search service is published separately at iowarp/clio-search. No clio-agent code was inspected or changed.