### PR TITLE
feat(web): add durable fetch tasks

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "CLIO Kit - MCP Servers for Scientific Computing and HPC",
-    "version": "2.9.0",
+    "version": "2.10.0",
     "pluginRoot": "./clio-kit-mcp-servers"
   },
   "plugins": [
@@ -327,7 +327,7 @@
       "name": "clio-web",
       "source": "./clio-kit-mcp-servers/web",
       "description": "Provider-fixed web search plus transparent URL, DOI, and document fetching",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "category": "development",
       "keywords": [],
       "license": "BSD-3-Clause",

--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ distinct `not_installed` semantic, while real Spack failures remain errors.
 | **`slurm`** | 3.0.0 | HPC | Job submission and management | `clio-kit mcp-server slurm` |
 | **`spack`** | 2.1.0 | Package Management | Structured package discovery, installation, and location | `clio-kit mcp-server spack` |
 | **`terrain`** | 2.2.3 | Geospatial | Analyze DEMs and terrain point clouds | `clio-kit mcp-server terrain` |
-| **`web`** | 2.0.0 | Web | Provider-fixed web search plus unified URL, DOI, and document fetching | `clio-kit mcp-server web` |
+| **`web`** | 2.1.0 | Web | Synchronous search plus durable, queryable, cancellable URL, DOI, and document fetch tasks | `clio-kit mcp-server web` |
 
 </div>
 

--- a/clio-kit-mcp-servers/adios/server.json
+++ b/clio-kit-mcp-servers/adios/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.9.0",
+      "version": "2.10.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/arxiv/server.json
+++ b/clio-kit-mcp-servers/arxiv/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.9.0",
+      "version": "2.10.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/chronolog/server.json
+++ b/clio-kit-mcp-servers/chronolog/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.9.0",
+      "version": "2.10.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/compression/server.json
+++ b/clio-kit-mcp-servers/compression/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.9.0",
+      "version": "2.10.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/darshan/server.json
+++ b/clio-kit-mcp-servers/darshan/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.9.0",
+      "version": "2.10.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/geo/server.json
+++ b/clio-kit-mcp-servers/geo/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.9.0",
+      "version": "2.10.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/geojson/server.json
+++ b/clio-kit-mcp-servers/geojson/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.9.0",
+      "version": "2.10.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/hdf5/server.json
+++ b/clio-kit-mcp-servers/hdf5/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.9.0",
+      "version": "2.10.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/jarvis/server.json
+++ b/clio-kit-mcp-servers/jarvis/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.9.0",
+      "version": "2.10.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/lmod/server.json
+++ b/clio-kit-mcp-servers/lmod/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.9.0",
+      "version": "2.10.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/ndp/server.json
+++ b/clio-kit-mcp-servers/ndp/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.9.0",
+      "version": "2.10.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/node-hardware/server.json
+++ b/clio-kit-mcp-servers/node-hardware/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.9.0",
+      "version": "2.10.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/pandas/server.json
+++ b/clio-kit-mcp-servers/pandas/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.9.0",
+      "version": "2.10.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/parallel-sort/server.json
+++ b/clio-kit-mcp-servers/parallel-sort/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.9.0",
+      "version": "2.10.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/paraview/server.json
+++ b/clio-kit-mcp-servers/paraview/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.9.0",
+      "version": "2.10.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/parquet/server.json
+++ b/clio-kit-mcp-servers/parquet/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.9.0",
+      "version": "2.10.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/plot/server.json
+++ b/clio-kit-mcp-servers/plot/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.9.0",
+      "version": "2.10.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/sac/server.json
+++ b/clio-kit-mcp-servers/sac/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.9.0",
+      "version": "2.10.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/scientific-catalog/server.json
+++ b/clio-kit-mcp-servers/scientific-catalog/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.9.0",
+      "version": "2.10.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/seismic/server.json
+++ b/clio-kit-mcp-servers/seismic/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.9.0",
+      "version": "2.10.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/slurm/server.json
+++ b/clio-kit-mcp-servers/slurm/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.9.0",
+      "version": "2.10.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/spack/server.json
+++ b/clio-kit-mcp-servers/spack/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.9.0",
+      "version": "2.10.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/terrain/server.json
+++ b/clio-kit-mcp-servers/terrain/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.9.0",
+      "version": "2.10.0",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/web/.claude-plugin/plugin.json
+++ b/clio-kit-mcp-servers/web/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "clio-web",
   "description": "Provider-fixed web search plus transparent URL, DOI, and document fetching",
-  "version": "2.0.0"
+  "version": "2.1.0"
 }

--- a/clio-kit-mcp-servers/web/README.md
+++ b/clio-kit-mcp-servers/web/README.md
@@ -1,94 +1,58 @@
 # Web MCP Server
 
-The Web MCP exposes two stable agent tools—`search` and `fetch`—while fixing the
-search provider when each MCP installation starts. The agent cannot switch providers per
-call, and it never sees parameters that the selected provider cannot use.
+The Web MCP exposes synchronous `search`, durable task-enabled `fetch`, and
+`fetch_events` for the complete backend conversion log. The selected search
+provider is fixed when the MCP starts; no tool call can silently switch it.
 
-## Installations
+## Install
 
-DuckDuckGo remains the keyless default:
+Connect a local stdio MCP to one unified CLIO Web Search deployment:
+
+```bash
+claude mcp add web -- uvx clio-kit mcp-server web --remote-url http://homelab:8089
+```
+
+`--remote_url` is accepted as an alias for clients or scripts that prefer
+underscores. The remote URL provides SearXNG search, DOI resolution, document
+conversion, task-backend discovery, and per-agent Valkey credentials. If the
+deployment requires authentication, set `WEB_REMOTE_TOKEN` in the MCP process.
+
+For standalone keyless search without remote document conversion:
 
 ```bash
 claude mcp add web -- uvx clio-kit mcp-server web --provider ddg
 ```
 
-Use a private SearXNG deployment (or the optional `clio-search` image) with:
+Legacy `--address` and `--document-address` options remain compatible, but only
+`--remote-url` enables automatic durable Valkey discovery.
 
-```bash
-claude mcp add web -- uvx clio-kit mcp-server web \
-  -- \
-  --provider searxng \
-  --address http://10.0.0.102:8089
-```
+## Task contract
 
-For `searxng`, `--address` is required. When that address is a `clio-search`
-installation, it also enables DOI resolution and structured-document conversion. A standalone
-SearXNG instance still supports search; document enrichment will fail explicitly if requested.
-For a non-SearXNG search provider, document enrichment can be configured separately with
-`--document-address`.
+`fetch(target)` is declared with required MCP task support. It returns a task
+handle immediately at the protocol level. `tasks/get` reports the latest
+download or conversion message, terminal results are returned through the task,
+and `tasks/cancel` cancels any active backend document conversion. There is no
+fixed overall conversion timeout; only individual network requests have bounded
+timeouts.
 
-Brave and Tavily remain optional bring-your-own-key providers. Their keys are read from
-`WEB_BRAVE_API_KEY` and `WEB_TAVILY_API_KEY`; selecting either provider without its key is a
-startup error. No paid provider is required by the default or SearXNG installations.
+`fetch_events(conversion_id, after_sequence=0, limit=100)` returns the ordered,
+persistent backend log when the latest task message is not enough to diagnose a
+conversion. Failures describe the stage, cause, retryability, conversion ID, and
+an actionable remediation without exposing raw third-party exception text.
 
-## `search`
-
-Every installation accepts `query` and `count`. A SearXNG installation additionally exposes:
-
-- `category` (`general`, `science`, or `it`)
-- `engines`
-- `language`
-- `time_range`
-- `pageno` (1 through 3)
-- `safesearch`
-
-Those fields are absent from the MCP schema for DDG, Brave, and Tavily. Results always preserve
-`title`, `url`, `snippet`, and provider provenance. SearXNG results also preserve available
-scholarly metadata such as authors, DOI, publication date, journal, publisher, document type,
-PDF/HTML URLs, tags, citation count, engines, and score. `unresponsive_engines` is diagnostic
-secondary-engine information; a successful result set is still a successful search.
-
-## `fetch`
-
-`fetch(target)` accepts an HTTP(S) URL or DOI. HTML is converted to Markdown locally. Text and
-structured text pass through. Supported PDFs, Office documents, XML, and images are detected from
-headers, URL, and content signatures and sent to the optional document service automatically.
-The returned document includes Markdown, normalized structure, metadata, and—where GROBID detects
-a scholarly paper—bibliographic references and in-text citation contexts.
-
-Long conversions return `reason="document_conversion_pending"`, a durable `conversion_id`, and a
-retry interval. Repeating the same fetch is content-deduplicated by `clio-search`. With
-`to_file=True`, converted documents write a Markdown artifact and a JSON metadata companion.
-Without a document service, existing HTML/text behavior remains available and unsupported binary
-content can still be saved raw.
-
-DOI resolution queries Crossref, falls back to DataCite metadata, and optionally uses Unpaywall
-when the private `clio-search` installation has its own contact email configured. It never bypasses
-access controls or fabricates an open copy.
-
-## Configuration
-
-CLI arguments define the installed search contract:
-
-| Argument | Meaning |
-| --- | --- |
-| `--provider {ddg,searxng,brave,tavily}` | Fixed provider for this installation. |
-| `--address URL` | Required SearXNG root; also used for document enrichment by default. |
-| `--document-address URL` | Optional separate `clio-search` root. |
-
-Runtime limits use `WEB_` environment variables, including `WEB_MAX_BYTES` (5 MiB HTML/text),
-`WEB_MAX_DOCUMENT_BYTES` (50 MiB), `WEB_CONNECT_TIMEOUT_S`, `WEB_READ_TIMEOUT_S`,
-`WEB_CONVERSION_WAIT_S`, `WEB_ARTIFACTS_ROOT`, and `WEB_ALLOW_PRIVATE_HOSTS`.
-
-Discovery is available at `web://capabilities` and describes only this installation's active
-provider and tool parameters; it does not advertise alternative providers to the agent.
+`search(query, count=5)` remains synchronous because ordinary web search is a
+bounded request-response operation. SearXNG installations additionally expose
+`category`, `engines`, `language`, `time_range`, `pageno`, and `safesearch`.
+There is intentionally no `deep_search` tool: multi-step research is agent
+semantics, not a backend tool semantic.
 
 ## Development
 
 ```bash
-uv sync
-uv run ruff check --fix src tests
-uv run ruff format src tests
-uv run mypy src
-WEB_MCP_LIVE=1 WEB_SEARXNG_BASE_URL=http://10.0.0.102:8089 uv run pytest
+uv sync --prerelease allow
+uv run ruff check --fix .
+uv run ruff format .
+uv run pyright src tests
+uv run pytest -m "not integration"
+WEB_MCP_LIVE=1 WEB_REMOTE_URL=http://homelab:8089 uv run pytest -m integration
 ```

--- a/clio-kit-mcp-servers/web/docs/web_tools.md
+++ b/clio-kit-mcp-servers/web/docs/web_tools.md
@@ -1,46 +1,39 @@
-# CLIO Web MCP server — tool reference
+# CLIO Web MCP tool reference
 
-Two curated tools for agentic web access. Runs as a confined fleet child under CLIO's sandbox,
-so all egress is recorded through the network chokepoint.
+## `fetch`
 
-## `fetch(url, *, to_file=False, output_dir=None, max_bytes=None, timeout=None)`
+`fetch(target, to_file=False, output_dir=None, max_bytes=None, timeout=None)`
+retrieves an HTTP(S) URL or DOI as a required MCP task. HTML becomes Markdown;
+plain text is returned directly; supported PDFs, Office documents, XML, and
+images are sent to CLIO Web Search for structured conversion.
 
-Retrieve an HTTP(S) URL. HTML is converted to Markdown (trafilatura → readability → plain-text
-strip; the `extractor` field names which ran, so a quality downgrade is never silent). Returns
-inline `content`, or — with `to_file=True` — writes it under the artifacts root and returns
-`local_path` so raw pages never bloat context.
+Task progress contains the backend conversion ID, stage, percentage, and a
+human-readable message. The task stays alive until completion, explicit
+cancellation, or a descriptive terminal failure. Cancellation is propagated to
+`POST /v1/documents/{conversion_id}/cancel`.
 
-- **Size cap** (default 5 MiB, `WEB_MAX_BYTES`): enforced on `Content-Length` *and* mid-stream.
-- **SSRF guard** (default on; `WEB_ALLOW_PRIVATE_HOSTS=true` to disable): refuses loopback /
-  private / link-local literal hosts (incl. the cloud-metadata address `169.254.169.254`) and
-  `localhost` names, on the initial URL **and every redirect hop** (redirects are followed
-  manually so each hop is checked before connecting). `final_url` reports the resolved URL.
-- **Typed gaps (honest, never junk):** an empty extraction returns
-  `reason="js_render_required_browser_unavailable"` (headless-browser escalation is the
-  follow-on); binary without `to_file` returns `reason="binary_content_not_inlined"`.
-- **`(url, prompt)` extraction** is the agent's job (an MCP server has no model access): use
-  `to_file=True` and pipe the saved file through the agent's own model.
+Downloads enforce size limits and validate every redirect against the SSRF
+policy. Empty HTML extraction reports
+`js_render_required_browser_unavailable`; unsupported binary content reports
+`binary_content_not_inlined` unless `to_file=True`.
 
-## `search(query, *, provider=None, count=5, category=None, engines=None, language=None, time_range=None, pageno=None, safesearch=None)`
+## `fetch_events`
 
-Search via a configurable provider. Keyless **DuckDuckGo** (`ddg`) is the default;
-self-hosted **SearXNG** (`searxng`) uses `WEB_SEARXNG_BASE_URL`; optional **Brave**
-and **Tavily** retain their BYO-key configuration. Selecting an unconfigured provider is a
-typed error — never a silent fallback to `ddg`. `count` is capped at 25. Returns
-`{title, url, snippet}` results.
+`fetch_events(conversion_id, after_sequence=0, limit=100)` retrieves a cursor
+page from the persistent backend conversion log. Use it when the latest
+`tasks/get` status message is insufficient. It is a synchronous read-only tool.
 
-SearXNG accepts native `category` (`general`, `science`, or `it`), exact `engines`,
-`language`, `time_range` (`day`, `month`, or `year`), `pageno` (1 through 3), and
-`safesearch` (0 through 2) selectors. Its response also includes `engines_answered` and
-normalized `unresponsive_engines`. An explicit `engines` list takes precedence over
-`category`, avoiding SearXNG's broader union of both selectors. Passing these selectors to
-another provider is an error.
+## `search`
 
-## Configuration (`WEB_`-prefixed env or a `.env`)
+`search(query, count=5)` is deliberately synchronous. DuckDuckGo is the keyless
+default. SearXNG, Brave, and Tavily are selected at MCP startup. SearXNG exposes
+its bounded native selectors; other providers expose only `query` and `count`.
 
-`WEB_SEARCH_PROVIDER`, `WEB_SEARXNG_BASE_URL`, `WEB_BRAVE_API_KEY`, `WEB_TAVILY_API_KEY`,
-`WEB_MAX_BYTES`, `WEB_CONNECT_TIMEOUT_S`, `WEB_READ_TIMEOUT_S`, `WEB_ARTIFACTS_ROOT`,
-`WEB_ALLOW_PRIVATE_HOSTS`.
+## Unified configuration
 
-For the LAN deployment, set `WEB_SEARCH_PROVIDER=searxng` and
-`WEB_SEARXNG_BASE_URL=http://10.0.0.102:8088`. No paid-provider credential is required.
+`WEB_REMOTE_URL` or `--remote-url` points the local MCP at one CLIO Web Search
+deployment. On startup, the MCP calls `/v1/capabilities` and
+`/v1/task-backend/session`, persists a stable local agent ID and task encryption
+key, and configures Docket with the returned per-agent Valkey queue and
+credentials. `WEB_REMOTE_TOKEN` supplies the deployment bearer token when one
+is configured.

--- a/clio-kit-mcp-servers/web/pyproject.toml
+++ b/clio-kit-mcp-servers/web/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "web-mcp"
-version = "2.0.0"
+version = "2.1.0"
 description = "Provider-fixed web search plus transparent URL, DOI, and document fetching"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 license = "BSD-3-Clause"
 authors = [
     { name = "IoWarp Team - Gnosis Research Center", email = "grc@illinoistech.edu" }
@@ -12,7 +12,7 @@ authors = [
 keywords = ["web", "fetch", "search", "mcp", "llm-integration", "agentic-web"]
 
 dependencies = [
-    "fastmcp>=4.0.0b1",
+    "fastmcp[tasks]>=4.0.0b3,<5",
     "httpx>=0.27.0",
     "trafilatura>=1.12",
     "readability-lxml>=0.8",
@@ -20,6 +20,7 @@ dependencies = [
     "pydantic>=2.5",
     "pydantic-settings>=2.6",
     "python-dotenv>=1.0",
+    "platformdirs>=4.0",
 ]
 
 [project.urls]
@@ -48,14 +49,14 @@ packages = ["src/web_mcp"]
 
 [tool.ruff]
 line-length = 100
-target-version = "py310"
+target-version = "py311"
 
 [tool.ruff.lint]
 select = ["E", "F", "W", "I", "N", "UP", "S", "B", "A", "C4", "ICN", "PIE", "T20", "Q"]
 ignore = ["S101", "S104", "S603", "S607"]
 
 [tool.mypy]
-python_version = "3.10"
+python_version = "3.11"
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = true
@@ -75,3 +76,6 @@ addopts = "--tb=short"
 markers = [
     "integration: marks tests that hit the real network (deselect with '-m \"not integration\"')",
 ]
+
+[tool.uv]
+prerelease = "allow"

--- a/clio-kit-mcp-servers/web/server.json
+++ b/clio-kit-mcp-servers/web/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.iowarp/web-mcp",
   "title": "CLIO Web",
   "description": "Provider-fixed web search plus transparent URL, DOI, and document fetching",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "repository": {
     "url": "https://github.com/iowarp/clio-kit",
     "source": "github"
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.9.0",
+      "version": "2.10.0",
       "transport": {
         "type": "stdio"
       },
@@ -31,7 +31,11 @@
   "tools": [
     {
       "name": "fetch",
-      "description": "Fetch an HTTP(S) URL or DOI. HTML and text are read locally; supported PDFs and structured documents use the optional CLIO Search document service."
+      "description": "Fetch an HTTP(S) URL or DOI as a durable task. HTML and text are read locally; supported documents use CLIO Web Search conversion when configured."
+    },
+    {
+      "name": "fetch_events",
+      "description": "Query the full ordered backend event log for a document fetch conversion."
     },
     {
       "name": "search",
@@ -42,13 +46,13 @@
     {
       "uri": "web://capabilities",
       "name": "capabilities",
-      "description": "Return only the active installation's search and fetch capabilities."
+      "description": "Return the active installation's search, fetch, and task capabilities."
     }
   ],
   "prompts": [
     {
       "name": "research_web",
-      "description": "Guided search then fetch workflow for researching a topic on the web."
+      "description": "Provide a guided search-then-fetch research workflow."
     }
   ],
   "tags": []

--- a/clio-kit-mcp-servers/web/src/web_mcp/__init__.py
+++ b/clio-kit-mcp-servers/web/src/web_mcp/__init__.py
@@ -1,12 +1,12 @@
 """
 Web MCP Server
 
-This package provides an MCP server for agentic web access with two curated
-tools: ``fetch`` (retrieve a URL and convert HTML to Markdown, optionally to a
-local file) and ``search`` (query a configurable web-search provider).
+This package provides an MCP server for agentic web access. ``fetch`` is a
+durable MCP task with progress and cancellation; ``search`` keeps its ordinary
+synchronous contract; and ``fetch_events`` exposes full conversion history.
 
 It is the seed of CLIO's web tooling and the test instrument for the sandbox
 campaign's egress recording.
 """
 
-__version__ = "2.0.0"
+__version__ = "2.1.0"

--- a/clio-kit-mcp-servers/web/src/web_mcp/config.py
+++ b/clio-kit-mcp-servers/web/src/web_mcp/config.py
@@ -1,0 +1,57 @@
+"""Configuration for the Web MCP server."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import model_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    """Runtime configuration loaded from ``WEB_``-prefixed environment variables."""
+
+    model_config = SettingsConfigDict(env_prefix="WEB_", env_file=".env", extra="ignore")
+
+    search_provider: Literal["ddg", "searxng", "brave", "tavily"] = "ddg"
+    searxng_base_url: str | None = None
+    document_service_url: str | None = None
+    remote_url: str | None = None
+    remote_token: str | None = None
+    brave_api_key: str | None = None
+    tavily_api_key: str | None = None
+
+    max_bytes: int = 5 * 1024 * 1024
+    max_document_bytes: int = 50 * 1024 * 1024
+    connect_timeout_s: float = 5.0
+    read_timeout_s: float = 30.0
+    conversion_poll_s: float = 1.0
+    progress_heartbeat_s: float = 5.0
+
+    artifacts_root: str | None = None
+    allow_private_hosts: bool = False
+
+    state_dir: str | None = None
+    task_backend_url: str | None = None
+    task_queue_name: str | None = None
+    task_concurrency: int = 10
+
+    @model_validator(mode="after")
+    def select_unified_remote_provider(self) -> Settings:
+        """Use the remote deployment's SearXNG unless a provider was explicit."""
+
+        if self.remote_url and "search_provider" not in self.model_fields_set:
+            self.search_provider = "searxng"
+        return self
+
+    @property
+    def effective_document_service_url(self) -> str | None:
+        """Return the unified remote URL or legacy document-service URL."""
+
+        return self.remote_url or self.document_service_url
+
+    @property
+    def effective_searxng_url(self) -> str | None:
+        """Return the unified remote URL or legacy SearXNG URL."""
+
+        return self.remote_url or self.searxng_base_url

--- a/clio-kit-mcp-servers/web/src/web_mcp/document_service.py
+++ b/clio-kit-mcp-servers/web/src/web_mcp/document_service.py
@@ -1,15 +1,17 @@
-"""Client for an optional CLIO Search document-enrichment service."""
+"""Typed client for CLIO Web Search DOI and document-conversion APIs."""
 
 from __future__ import annotations
 
 import asyncio
-import time
+from collections.abc import Awaitable, Callable
 from pathlib import Path
 from typing import Any, cast
 from urllib.parse import urlparse
 
 import httpx
 from fastmcp.exceptions import ToolError
+
+ProgressReporter = Callable[[dict[str, Any]], Awaitable[None]]
 
 _CONVERTIBLE_SUFFIXES = {
     ".pdf",
@@ -36,22 +38,22 @@ _CONVERTIBLE_MIMES = {
 
 
 def service_endpoint(value: str | None, path: str) -> str:
-    """Build a validated CLIO Search endpoint URL."""
+    """Build a validated CLIO Web Search endpoint URL."""
 
     base = (value or "").strip()
     parsed = urlparse(base)
     if parsed.scheme not in {"http", "https"} or not parsed.hostname:
         raise ToolError(
-            "Document enrichment requires an absolute CLIO Search address. "
-            "Set --document-address or WEB_DOCUMENT_SERVICE_URL."
+            "Document enrichment requires an absolute CLIO Web Search address. "
+            "Set --remote-url, --document-address, or WEB_REMOTE_URL."
         )
     if parsed.query or parsed.fragment:
-        raise ToolError("The CLIO Search address must not contain a query or fragment.")
+        raise ToolError("The CLIO Web Search address must not contain a query or fragment.")
     return f"{base.rstrip('/')}{path}"
 
 
 def is_convertible_document(body: bytes, content_type: str | None, url: str) -> bool:
-    """Return whether CLIO Search can structure the fetched content."""
+    """Return whether CLIO Web Search can structure the fetched content."""
 
     mime = (content_type or "").split(";", 1)[0].strip().lower()
     suffix = Path(urlparse(url).path).suffix.lower()
@@ -74,20 +76,25 @@ async def resolve_doi(
     *,
     service_url: str | None,
     timeout: httpx.Timeout,
+    token: str | None = None,
 ) -> dict[str, Any]:
-    """Resolve a DOI through the configured CLIO Search installation."""
+    """Resolve a DOI through the configured CLIO Web Search installation."""
 
     endpoint = service_endpoint(service_url, "/v1/doi/resolve")
     try:
-        async with httpx.AsyncClient(timeout=timeout) as client:
+        async with _client(timeout, token) as client:
             response = await client.post(endpoint, json={"doi": doi})
-            response.raise_for_status()
-            payload = response.json()
-    except (httpx.HTTPError, ValueError) as exc:
-        raise ToolError(f"Could not resolve DOI through CLIO Search at {endpoint}: {exc}") from exc
-    if not isinstance(payload, dict) or not isinstance(payload.get("candidates"), list):
-        raise ToolError("CLIO Search returned a malformed DOI-resolution response.")
-    return cast(dict[str, Any], payload)
+            payload = _response_payload(response, stage="DOI resolution")
+    except ToolError:
+        raise
+    except httpx.HTTPError as exc:
+        raise _network_error("DOI resolution", endpoint, exc) from exc
+    if not isinstance(payload.get("candidates"), list):
+        raise ToolError(
+            "CLIO Web Search returned malformed DOI-resolution data. "
+            "Fix: upgrade or repair the remote service before retrying."
+        )
+    return payload
 
 
 async def convert_document(
@@ -99,38 +106,280 @@ async def convert_document(
     doi: str | None,
     service_url: str | None,
     timeout: httpx.Timeout,
-    wait_s: float,
     poll_s: float,
+    on_progress: ProgressReporter,
+    token: str | None = None,
 ) -> dict[str, Any]:
-    """Submit a document and return completion or a durable pending handle."""
+    """Convert a document to terminal state without an overall elapsed timeout."""
 
     submit_url = service_endpoint(service_url, "/v1/documents")
     fields = {"source_url": source_url}
     if doi:
         fields["doi"] = doi
+    conversion_id: str | None = None
     try:
-        async with httpx.AsyncClient(timeout=timeout) as client:
+        async with _client(timeout, token) as client:
             response = await client.post(
                 submit_url,
                 data=fields,
                 files={"file": (filename, body, content_type or "application/octet-stream")},
             )
-            response.raise_for_status()
-            payload = response.json()
-            if not isinstance(payload, dict) or not payload.get("id"):
-                raise ToolError("CLIO Search returned a malformed document submission.")
-            deadline = time.monotonic() + max(wait_s, 0)
-            while payload.get("status") in {"queued", "running"} and time.monotonic() < deadline:
+            payload = _response_payload(response, stage="document submission")
+            conversion_id = _conversion_id(payload)
+            await on_progress(
+                {
+                    "sequence": 0,
+                    "progress": int(payload.get("progress", 0)),
+                    "stage": str(payload.get("stage") or "queued"),
+                    "level": "info",
+                    "message": str(payload.get("message") or "Conversion accepted"),
+                    "conversion_id": conversion_id,
+                }
+            )
+            after_sequence = 0
+            while payload.get("status") in {"queued", "running"}:
                 await asyncio.sleep(max(poll_s, 0.1))
-                response = await client.get(f"{submit_url}/{payload['id']}")
-                response.raise_for_status()
-                payload = response.json()
+                events_response = await client.get(
+                    f"{submit_url}/{conversion_id}/events",
+                    params={"after_sequence": after_sequence, "limit": 100},
+                )
+                events_payload = _response_payload(
+                    events_response,
+                    stage="conversion progress",
+                    conversion_id=conversion_id,
+                )
+                events = events_payload.get("events")
+                emitted = False
+                if isinstance(events, list):
+                    for event in events:
+                        if not isinstance(event, dict):
+                            continue
+                        event["conversion_id"] = conversion_id
+                        await on_progress(cast(dict[str, Any], event))
+                        after_sequence = max(after_sequence, int(event.get("sequence", 0)))
+                        emitted = True
+                state_response = await client.get(f"{submit_url}/{conversion_id}")
+                payload = _response_payload(
+                    state_response,
+                    stage="conversion status",
+                    conversion_id=conversion_id,
+                )
+                if not emitted and payload.get("status") in {"queued", "running"}:
+                    await on_progress(
+                        {
+                            "sequence": after_sequence,
+                            "progress": int(payload.get("progress", 0)),
+                            "stage": str(payload.get("stage") or payload["status"]),
+                            "level": "info",
+                            "message": str(
+                                payload.get("message") or "Document conversion is still running"
+                            ),
+                            "conversion_id": conversion_id,
+                        }
+                    )
+    except asyncio.CancelledError:
+        if conversion_id is not None:
+            await asyncio.shield(
+                cancel_document(
+                    conversion_id,
+                    service_url=service_url,
+                    timeout=timeout,
+                    token=token,
+                )
+            )
+        raise
     except ToolError:
         raise
-    except (httpx.HTTPError, ValueError) as exc:
-        raise ToolError(f"Could not convert document through CLIO Search: {exc}") from exc
+    except httpx.HTTPError as exc:
+        raise _network_error(
+            "document conversion", submit_url, exc, conversion_id=conversion_id
+        ) from exc
     if payload.get("status") == "failed":
-        error = payload.get("error")
-        message = error.get("message") if isinstance(error, dict) else error
-        raise ToolError(f"CLIO Search document conversion failed: {message or 'unknown error'}")
-    return cast(dict[str, Any], payload)
+        raise ToolError(_conversion_failure(payload, conversion_id))
+    if payload.get("status") == "cancelled":
+        raise asyncio.CancelledError
+    if payload.get("status") != "complete":
+        raise ToolError(
+            _agent_message(
+                stage="conversion status",
+                cause=f"the backend returned unexpected state {payload.get('status')!r}",
+                remediation="Query fetch_events, then retry the fetch if the backend is healthy.",
+                retryable=True,
+                conversion_id=conversion_id,
+            )
+        )
+    return payload
+
+
+async def fetch_events(
+    conversion_id: str,
+    *,
+    service_url: str | None,
+    timeout: httpx.Timeout,
+    after_sequence: int = 0,
+    limit: int = 100,
+    token: str | None = None,
+) -> dict[str, Any]:
+    """Return one ordered page of persistent backend conversion events."""
+
+    endpoint = service_endpoint(service_url, f"/v1/documents/{conversion_id}/events")
+    try:
+        async with _client(timeout, token) as client:
+            response = await client.get(
+                endpoint,
+                params={"after_sequence": after_sequence, "limit": limit},
+            )
+            return _response_payload(
+                response, stage="conversion event lookup", conversion_id=conversion_id
+            )
+    except ToolError:
+        raise
+    except httpx.HTTPError as exc:
+        raise _network_error(
+            "conversion event lookup", endpoint, exc, conversion_id=conversion_id
+        ) from exc
+
+
+async def cancel_document(
+    conversion_id: str,
+    *,
+    service_url: str | None,
+    timeout: httpx.Timeout,
+    token: str | None = None,
+) -> dict[str, Any]:
+    """Cancel a backend conversion and return its durable state."""
+
+    endpoint = service_endpoint(service_url, f"/v1/documents/{conversion_id}/cancel")
+    try:
+        async with _client(timeout, token) as client:
+            response = await client.post(endpoint)
+            return _response_payload(
+                response, stage="conversion cancellation", conversion_id=conversion_id
+            )
+    except ToolError:
+        raise
+    except httpx.HTTPError as exc:
+        raise _network_error(
+            "conversion cancellation", endpoint, exc, conversion_id=conversion_id
+        ) from exc
+
+
+def _client(timeout: httpx.Timeout, token: str | None) -> httpx.AsyncClient:
+    headers = {"Authorization": f"Bearer {token}"} if token else None
+    return httpx.AsyncClient(timeout=timeout, headers=headers)
+
+
+def _response_payload(
+    response: httpx.Response,
+    *,
+    stage: str,
+    conversion_id: str | None = None,
+) -> dict[str, Any]:
+    try:
+        payload = response.json()
+    except ValueError as exc:
+        raise ToolError(
+            _agent_message(
+                stage=stage,
+                cause=f"the service returned non-JSON HTTP {response.status_code}",
+                remediation="Check that --remote-url points to CLIO Web Search 0.3.0 or newer.",
+                retryable=False,
+                conversion_id=conversion_id,
+            )
+        ) from exc
+    if not isinstance(payload, dict):
+        raise ToolError(
+            _agent_message(
+                stage=stage,
+                cause="the service returned a malformed response object",
+                remediation="Upgrade or repair the CLIO Web Search service.",
+                retryable=False,
+                conversion_id=conversion_id,
+            )
+        )
+    typed = cast(dict[str, Any], payload)
+    if response.is_error:
+        raise ToolError(_service_failure(typed, response.status_code, stage, conversion_id))
+    return typed
+
+
+def _service_failure(
+    payload: dict[str, Any],
+    status_code: int,
+    stage: str,
+    conversion_id: str | None,
+) -> str:
+    message = payload.get("message")
+    remediation = payload.get("remediation")
+    retryable = bool(payload.get("retryable"))
+    return _agent_message(
+        stage=str(payload.get("stage") or stage),
+        cause=str(message or f"the service returned HTTP {status_code}"),
+        remediation=str(remediation or "Check service readiness and retry."),
+        retryable=retryable,
+        conversion_id=str(payload.get("conversion_id") or conversion_id or "") or None,
+    )
+
+
+def _conversion_failure(payload: dict[str, Any], conversion_id: str | None) -> str:
+    error = payload.get("error")
+    if not isinstance(error, dict):
+        return _agent_message(
+            stage=str(payload.get("stage") or "conversion"),
+            cause="the document pipeline failed without structured diagnostics",
+            remediation="Query fetch_events and inspect the service log before retrying.",
+            retryable=True,
+            conversion_id=conversion_id,
+        )
+    return _agent_message(
+        stage=str(error.get("stage") or payload.get("stage") or "conversion"),
+        cause=str(error.get("message") or "the document pipeline failed"),
+        remediation=str(error.get("remediation") or "Query fetch_events before retrying."),
+        retryable=bool(error.get("retryable")),
+        conversion_id=str(error.get("conversion_id") or conversion_id or "") or None,
+    )
+
+
+def _network_error(
+    stage: str,
+    endpoint: str,
+    exc: httpx.HTTPError,
+    *,
+    conversion_id: str | None = None,
+) -> ToolError:
+    return ToolError(
+        _agent_message(
+            stage=stage,
+            cause=f"{type(exc).__name__} while contacting {urlparse(endpoint).netloc}",
+            remediation="Verify network access and service readiness, then retry.",
+            retryable=True,
+            conversion_id=conversion_id,
+        )
+    )
+
+
+def _agent_message(
+    *,
+    stage: str,
+    cause: str,
+    remediation: str,
+    retryable: bool,
+    conversion_id: str | None,
+) -> str:
+    identity = f" Conversion ID: {conversion_id}." if conversion_id else ""
+    normalized_cause = cause.strip()
+    cause_suffix = "" if normalized_cause.endswith((".", "!", "?")) else "."
+    return (
+        f"Fetch failed during {stage}. Cause: {normalized_cause}{cause_suffix}{identity} "
+        f"Retryable: {'yes' if retryable else 'no'}. Fix: {remediation}"
+    )
+
+
+def _conversion_id(payload: dict[str, Any]) -> str:
+    value = payload.get("id")
+    if not isinstance(value, str) or not value:
+        raise ToolError(
+            "CLIO Web Search accepted a document without returning a conversion ID. "
+            "Fix: upgrade or repair the remote service before retrying."
+        )
+    return value

--- a/clio-kit-mcp-servers/web/src/web_mcp/fetch.py
+++ b/clio-kit-mcp-servers/web/src/web_mcp/fetch.py
@@ -1,0 +1,309 @@
+"""Fetch orchestration for URLs, DOI resolution, and document conversion."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+import httpx
+from fastmcp.exceptions import ToolError
+from fastmcp.server.context import Context
+
+from web_mcp.config import Settings
+from web_mcp.document_service import (
+    convert_document,
+    is_convertible_document,
+    resolve_doi,
+)
+from web_mcp.document_service import (
+    fetch_events as fetch_conversion_events,
+)
+from web_mcp.fetch_utils import (
+    assert_allowed_url,
+    decode,
+    derive_filename,
+    download,
+    extract_title,
+    html_to_markdown,
+    is_html,
+    is_text,
+    looks_like_text,
+    split_content_type,
+    validate_output_path,
+)
+
+REASON_JS_RENDER_REQUIRED = "js_render_required_browser_unavailable"
+REASON_BINARY_NOT_INLINED = "binary_content_not_inlined"
+
+
+async def fetch_target(
+    configured: Settings,
+    ctx: Context,
+    target: str,
+    *,
+    to_file: bool = False,
+    output_dir: str | None = None,
+    max_bytes: int | None = None,
+    timeout: float | None = None,
+) -> dict[str, Any]:
+    """Fetch one URL or DOI and return content or a saved artifact."""
+
+    requested_target = (target or "").strip()
+    if not requested_target:
+        raise ToolError("fetch requires a non-empty URL or DOI target.")
+
+    cap = max_bytes if max_bytes and max_bytes > 0 else configured.max_bytes
+    read_timeout = timeout if timeout and timeout > 0 else configured.read_timeout_s
+    timeout_cfg = httpx.Timeout(read_timeout, connect=configured.connect_timeout_s)
+    await ctx.report_progress(1, 100, "Validating the fetch target")
+
+    doi: str | None = None
+    doi_resolution: dict[str, Any] | None = None
+    download_targets: list[str]
+    parsed_target = urlparse(requested_target)
+    is_doi_url = (
+        parsed_target.scheme in {"http", "https"}
+        and (parsed_target.hostname or "").lower() in {"doi.org", "dx.doi.org"}
+        and bool(parsed_target.path.strip("/"))
+    )
+    if is_doi_url or not requested_target.lower().startswith(("http://", "https://")):
+        if "://" in requested_target and not is_doi_url:
+            raise ToolError(
+                f"fetch only supports http(s) URLs or DOI targets; got: {requested_target!r}"
+            )
+        doi = parsed_target.path.strip("/") if is_doi_url else requested_target
+        doi_resolution = await resolve_doi(
+            doi,
+            service_url=configured.effective_document_service_url,
+            timeout=timeout_cfg,
+            token=configured.remote_token,
+        )
+        doi = str(doi_resolution["doi"])
+        download_targets = [
+            str(candidate["url"])
+            for candidate in doi_resolution["candidates"]
+            if isinstance(candidate, dict) and candidate.get("url")
+        ]
+        if not download_targets:
+            raise ToolError(f"CLIO Search found no lawful retrieval candidate for DOI {doi}.")
+    else:
+        download_targets = [requested_target]
+
+    download_target = ""
+    failures: list[str] = []
+    for candidate in download_targets:
+        assert_allowed_url(candidate, allow_private_hosts=configured.allow_private_hosts)
+        try:
+            await ctx.report_progress(5, 100, f"Downloading {candidate}")
+            body, raw_content_type, status, final_url = await download(
+                candidate,
+                max_bytes=cap,
+                max_document_bytes=configured.max_document_bytes,
+                timeout=timeout_cfg,
+                allow_private_hosts=configured.allow_private_hosts,
+            )
+            download_target = candidate
+            break
+        except (ToolError, httpx.HTTPError) as exc:
+            failures.append(f"{candidate}: {exc}")
+    else:
+        raise ToolError(f"Could not fetch {requested_target}: {'; '.join(failures)}")
+
+    size_bytes = len(body)
+    mime, charset = split_content_type(raw_content_type)
+    is_html_content = is_html(mime)
+    is_text_content = is_text(mime) or is_html_content or (mime == "" and looks_like_text(body))
+    is_binary = not is_text_content
+    result: dict[str, Any] = {
+        "ok": True,
+        "target": requested_target,
+        "url": download_target,
+        "size_bytes": size_bytes,
+        "content_type": raw_content_type,
+        "status": status,
+        "title": None,
+        "method": "http",
+    }
+    if doi_resolution is not None:
+        result["doi"] = doi
+        result["doi_resolution"] = doi_resolution
+    if final_url and final_url != download_target:
+        result["final_url"] = final_url
+
+    content: str | None
+    if is_html_content:
+        html = decode(body, charset)
+        result["title"] = extract_title(html)
+        content, extractor = html_to_markdown(html)
+        result["extractor"] = extractor
+        if content is None:
+            result["content"] = None
+            result["reason"] = REASON_JS_RENDER_REQUIRED
+            result["note"] = (
+                "HTML extraction yielded no content; the page likely requires a "
+                "JavaScript-capable headless browser, which is not available in v1."
+            )
+            return result
+    elif (
+        is_binary
+        and configured.effective_document_service_url
+        and is_convertible_document(body, raw_content_type, final_url)
+    ):
+        return await _convert_result(
+            configured,
+            ctx,
+            result,
+            body=body,
+            raw_content_type=raw_content_type,
+            final_url=final_url,
+            doi=doi,
+            timeout_cfg=timeout_cfg,
+            to_file=to_file,
+            output_dir=output_dir,
+        )
+    elif is_binary:
+        if not to_file:
+            result["content"] = None
+            result["reason"] = REASON_BINARY_NOT_INLINED
+            result["note"] = (
+                "Binary content is not inlined. Re-call fetch with to_file=True to "
+                "save it to a local file."
+            )
+            return result
+        content = None
+    else:
+        content = decode(body, charset)
+
+    if to_file:
+        filename = derive_filename(final_url, is_html=is_html_content, is_binary=is_binary)
+        output_path = _output_path(
+            configured,
+            filename,
+            default_name="page",
+            output_dir=output_dir,
+        )
+        if is_binary:
+            output_path.write_bytes(body)
+        else:
+            output_path.write_text(content or "", encoding="utf-8")
+        result["local_path"] = str(output_path)
+    else:
+        result["content"] = content
+    return result
+
+
+async def fetch_event_log(
+    configured: Settings,
+    conversion_id: str,
+    *,
+    after_sequence: int = 0,
+    limit: int = 100,
+) -> dict[str, Any]:
+    """Return one ordered page from a backend conversion's durable event log."""
+
+    timeout_cfg = httpx.Timeout(configured.read_timeout_s, connect=configured.connect_timeout_s)
+    return await fetch_conversion_events(
+        conversion_id,
+        service_url=configured.effective_document_service_url,
+        timeout=timeout_cfg,
+        after_sequence=after_sequence,
+        limit=limit,
+        token=configured.remote_token,
+    )
+
+
+async def _convert_result(
+    configured: Settings,
+    ctx: Context,
+    result: dict[str, Any],
+    *,
+    body: bytes,
+    raw_content_type: str | None,
+    final_url: str,
+    doi: str | None,
+    timeout_cfg: httpx.Timeout,
+    to_file: bool,
+    output_dir: str | None,
+) -> dict[str, Any]:
+    filename = derive_filename(final_url, is_html=False, is_binary=True)
+
+    async def report_conversion(event: dict[str, Any]) -> None:
+        conversion_id = str(event.get("conversion_id") or "pending")
+        stage = str(event.get("stage") or "conversion")
+        message = str(event.get("message") or "Document conversion is running")
+        await ctx.report_progress(
+            float(event.get("progress", 0)),
+            100,
+            f"Conversion {conversion_id} [{stage}]: {message}",
+        )
+
+    conversion = await convert_document(
+        body,
+        filename=filename,
+        content_type=raw_content_type,
+        source_url=final_url,
+        doi=doi,
+        service_url=configured.effective_document_service_url,
+        timeout=timeout_cfg,
+        poll_s=configured.conversion_poll_s,
+        on_progress=report_conversion,
+        token=configured.remote_token,
+    )
+    converted = conversion.get("result")
+    if not isinstance(converted, dict):
+        raise ToolError("CLIO Search completed conversion without a result payload.")
+    content = str(converted.get("markdown") or "")
+    result["method"] = "clio-search"
+    result["extractor"] = "document-service"
+    document = converted.get("document")
+    if isinstance(document, dict):
+        inline_document = dict(document)
+        structure = inline_document.pop("structure", None)
+        if structure is not None:
+            inline_document["structure_available"] = True
+            if isinstance(structure, dict):
+                inline_document["structure_summary"] = {
+                    key: len(value)
+                    for key, value in structure.items()
+                    if isinstance(value, (dict, list))
+                }
+        result["document"] = inline_document
+    else:
+        result["document"] = document
+    result["conversion_id"] = conversion.get("id")
+    if to_file:
+        output_path = _output_path(
+            configured,
+            f"{Path(filename).stem}.md",
+            default_name="document.md",
+            output_dir=output_dir,
+        )
+        output_path.write_text(content, encoding="utf-8")
+        metadata_path = output_path.with_suffix(".json")
+        metadata_path.write_text(
+            json.dumps(document, ensure_ascii=False, indent=2), encoding="utf-8"
+        )
+        result["local_path"] = str(output_path)
+        result["metadata_path"] = str(metadata_path)
+        if isinstance(document, dict) and "structure" in document:
+            result["structure_saved_to"] = str(metadata_path)
+        return result
+    result["content"] = content
+    return result
+
+
+def _output_path(
+    configured: Settings,
+    candidate: str | Path,
+    *,
+    default_name: str,
+    output_dir: str | Path | None,
+) -> Path:
+    return validate_output_path(
+        candidate,
+        default_name=default_name,
+        output_dir=output_dir,
+        configured_root=configured.artifacts_root,
+    )

--- a/clio-kit-mcp-servers/web/src/web_mcp/search.py
+++ b/clio-kit-mcp-servers/web/src/web_mcp/search.py
@@ -1,0 +1,152 @@
+"""Provider-specific search adapters behind the stable Web MCP contract."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Literal
+
+import httpx
+from fastmcp.exceptions import ToolError
+
+from web_mcp.config import Settings
+from web_mcp.searxng import search_searxng
+
+_BRAVE_ENDPOINT = "https://api.search.brave.com/res/v1/web/search"
+_TAVILY_ENDPOINT = "https://api.tavily.com/search"
+_MAX_SEARCH_COUNT = 25
+
+
+async def search_common(configured: Settings, query: str, count: int = 5) -> dict[str, Any]:
+    """Search the configured DDG, Brave, or Tavily provider."""
+
+    text = (query or "").strip()
+    if not text:
+        raise ToolError("A non-empty query is required.")
+    effective_count = min(count if count and count > 0 else 5, _MAX_SEARCH_COUNT)
+    if configured.search_provider == "ddg":
+        results = await _search_ddg(text, effective_count)
+    elif configured.search_provider == "brave":
+        results = await _search_brave(configured, text, effective_count)
+    elif configured.search_provider == "tavily":
+        results = await _search_tavily(configured, text, effective_count)
+    else:
+        raise ToolError("The active search provider requires the SearXNG search schema.")
+    return {
+        "ok": True,
+        "provider": configured.search_provider,
+        "query": text,
+        "results": results,
+        "count": len(results),
+    }
+
+
+async def search_searxng_provider(
+    configured: Settings,
+    query: str,
+    count: int = 5,
+    category: Literal["general", "science", "it"] | None = None,
+    engines: list[str] | None = None,
+    language: str | None = None,
+    time_range: Literal["day", "month", "year"] | None = None,
+    pageno: int = 1,
+    safesearch: int | None = None,
+) -> dict[str, Any]:
+    """Search the configured SearXNG provider with native selectors."""
+
+    text = (query or "").strip()
+    if not text:
+        raise ToolError("A non-empty query is required.")
+    effective_count = min(count if count and count > 0 else 5, _MAX_SEARCH_COUNT)
+    results, engines_answered, unresponsive_engines = await search_searxng(
+        text,
+        effective_count,
+        base_url=configured.effective_searxng_url,
+        connect_timeout_s=configured.connect_timeout_s,
+        read_timeout_s=configured.read_timeout_s,
+        category=category,
+        engines=engines,
+        language=language,
+        time_range=time_range,
+        pageno=pageno,
+        safesearch=safesearch,
+    )
+    return {
+        "ok": True,
+        "provider": "searxng",
+        "query": text,
+        "results": results,
+        "count": len(results),
+        "engines_answered": engines_answered,
+        "unresponsive_engines": unresponsive_engines,
+    }
+
+
+async def _search_ddg(query: str, count: int) -> list[dict[str, str]]:
+    return await asyncio.to_thread(_ddgs_search, query, count)
+
+
+def _ddgs_search(query: str, count: int) -> list[dict[str, str]]:
+    from ddgs import DDGS
+
+    results: list[dict[str, str]] = []
+    with DDGS() as ddgs:
+        for item in ddgs.text(query, max_results=count):
+            results.append(
+                {
+                    "title": str(item.get("title") or ""),
+                    "url": str(item.get("href") or item.get("url") or ""),
+                    "snippet": str(item.get("body") or item.get("snippet") or ""),
+                }
+            )
+    return results
+
+
+async def _search_brave(configured: Settings, query: str, count: int) -> list[dict[str, str]]:
+    if not configured.brave_api_key:
+        raise ToolError(
+            "search provider 'brave' requires an API key. Set WEB_BRAVE_API_KEY "
+            "or choose a different provider."
+        )
+    headers = {
+        "X-Subscription-Token": configured.brave_api_key,
+        "Accept": "application/json",
+    }
+    async with httpx.AsyncClient(timeout=httpx.Timeout(configured.read_timeout_s)) as client:
+        response = await client.get(
+            _BRAVE_ENDPOINT, headers=headers, params={"q": query, "count": count}
+        )
+        response.raise_for_status()
+        payload = response.json()
+    return [
+        {
+            "title": str(item.get("title") or ""),
+            "url": str(item.get("url") or ""),
+            "snippet": str(item.get("description") or ""),
+        }
+        for item in ((payload.get("web") or {}).get("results") or [])[:count]
+    ]
+
+
+async def _search_tavily(configured: Settings, query: str, count: int) -> list[dict[str, str]]:
+    if not configured.tavily_api_key:
+        raise ToolError(
+            "search provider 'tavily' requires an API key. Set WEB_TAVILY_API_KEY "
+            "or choose a different provider."
+        )
+    body = {
+        "api_key": configured.tavily_api_key,
+        "query": query,
+        "max_results": count,
+    }
+    async with httpx.AsyncClient(timeout=httpx.Timeout(configured.read_timeout_s)) as client:
+        response = await client.post(_TAVILY_ENDPOINT, json=body)
+        response.raise_for_status()
+        payload = response.json()
+    return [
+        {
+            "title": str(item.get("title") or ""),
+            "url": str(item.get("url") or ""),
+            "snippet": str(item.get("content") or ""),
+        }
+        for item in (payload.get("results") or [])[:count]
+    ]

--- a/clio-kit-mcp-servers/web/src/web_mcp/server.py
+++ b/clio-kit-mcp-servers/web/src/web_mcp/server.py
@@ -1,134 +1,33 @@
-"""Web MCP server: curated ``fetch`` + ``search`` tools for agentic web access.
-
-This is a proper v1 web-tooling surface for CLIO. Two tools are exposed:
-
-* ``fetch`` -- retrieve an HTTP(S) URL with a streamed size cap and timeout,
-  convert HTML to Markdown (trafilatura -> readability -> plain-text strip),
-  and either return the content inline or write it to a local file.
-* ``search`` -- query a configurable web-search provider (keyless DuckDuckGo by
-  default, self-hosted SearXNG, or optional BYO-key Brave / Tavily).
-
-Documented extension points (NOT implemented in v1 -- honest, typed gaps, never
-a silent fallback):
-
-* Headless-browser escalation (Playwright) for JS-rendered / Anubis-walled
-  pages. When HTML extraction yields nothing, ``fetch`` returns a typed note
-  ``reason="js_render_required_browser_unavailable"`` instead of silently
-  handing back junk.
-* ``(url, prompt)`` small-model extraction. An MCP server has no model access,
-  so page-specific extraction stays the agent's job: use ``to_file=True`` and
-  let the agent pipe the saved file through its own model.
-"""
+"""FastMCP registration and CLI for the CLIO Web MCP server."""
 
 from __future__ import annotations
 
-import asyncio
-import json
 import os
-from pathlib import Path
+from datetime import timedelta
 from typing import Annotated, Any, Literal
 from urllib.parse import urlparse
 
-import httpx
 from dotenv import load_dotenv
 from fastmcp import FastMCP
-from fastmcp.exceptions import ToolError
 from fastmcp.prompts import Message
+from fastmcp.server.context import Context
+from fastmcp.utilities.tasks import TaskConfig
 from pydantic import Field
-from pydantic_settings import BaseSettings, SettingsConfigDict
 
-from web_mcp.document_service import (
-    convert_document,
-    is_convertible_document,
-    resolve_doi,
+from web_mcp.config import Settings
+from web_mcp.fetch import (
+    REASON_BINARY_NOT_INLINED as REASON_BINARY_NOT_INLINED,
 )
+from web_mcp.fetch import (
+    REASON_JS_RENDER_REQUIRED as REASON_JS_RENDER_REQUIRED,
+)
+from web_mcp.fetch import fetch_event_log, fetch_target
 from web_mcp.fetch_utils import REASON_BLOCKED_HOST as REASON_BLOCKED_HOST
-from web_mcp.fetch_utils import (
-    assert_allowed_url,
-    decode,
-    derive_filename,
-    download,
-    extract_title,
-    html_to_markdown,
-    is_html,
-    is_text,
-    looks_like_text,
-    split_content_type,
-    validate_output_path,
-)
-from web_mcp.searxng import search_searxng
+from web_mcp.search import search_common, search_searxng_provider
+from web_mcp.task_runtime import build_tasks_extension
 
-# Environment setup
 load_dotenv()
-
-
-# ---------------------------------------------------------------------------
-# Configuration (single source of truth; tests vary CONFIG, not ambient env)
-# ---------------------------------------------------------------------------
-
-
-class Settings(BaseSettings):
-    """Runtime configuration for the web MCP server.
-
-    All fields are overridable via ``WEB_``-prefixed environment variables
-    (e.g. ``WEB_SEARCH_PROVIDER``, ``WEB_BRAVE_API_KEY``, ``WEB_MAX_BYTES``) or
-    a ``.env`` file, but tests should construct ``Settings(...)`` directly so
-    behavior is driven by config rather than the ambient environment.
-    """
-
-    model_config = SettingsConfigDict(env_prefix="WEB_", env_file=".env", extra="ignore")
-
-    # Search provider selection. Keyless "ddg" is the default so search works
-    # out of the box; self-hosted "searxng" requires its deployment URL, while
-    # "brave"/"tavily" are opt-in and require their own key.
-    search_provider: Literal["ddg", "searxng", "brave", "tavily"] = "ddg"
-    searxng_base_url: str | None = None
-    document_service_url: str | None = None
-    brave_api_key: str | None = None
-    tavily_api_key: str | None = None
-
-    # Fetch limits.
-    max_bytes: int = 5 * 1024 * 1024
-    max_document_bytes: int = 50 * 1024 * 1024
-    connect_timeout_s: float = 5.0
-    read_timeout_s: float = 30.0
-    conversion_wait_s: float = 25.0
-    conversion_poll_s: float = 1.0
-
-    # Default writable root for ``to_file`` output. ``None`` -> current working
-    # directory, so a caller that launches the server from a chosen directory
-    # controls where artifacts land.
-    artifacts_root: str | None = None
-
-    # SSRF guard: when False (default), fetch refuses URLs whose host is a
-    # loopback / private / link-local / reserved LITERAL IP (or a localhost
-    # name) -- on the initial URL AND every redirect hop -- so the tool is not a
-    # confused deputy reaching the cloud-metadata endpoint (169.254.169.254) or
-    # an internal service on behalf of injected content. Set True for a
-    # deliberately internal fetcher. Deeper DNS-rebinding (a public name that
-    # resolves private) is caught at the sandbox egress layer, not here: the
-    # confined tool routes through a proxy and must NOT resolve DNS itself
-    # (Linux-fence DNS is proxy-only), so the guard is literal-address-based.
-    allow_private_hosts: bool = False
-
-
-# Module-level settings instance. Tests monkeypatch ``server.settings`` with a
-# freshly constructed ``Settings(...)`` to exercise alternate configuration.
 settings = Settings()
-
-
-# Search-provider HTTP endpoints (keyed providers).
-_BRAVE_ENDPOINT = "https://api.search.brave.com/res/v1/web/search"
-_TAVILY_ENDPOINT = "https://api.tavily.com/search"
-
-# Typed extension-point signals (honest gaps, never silent fallbacks).
-REASON_JS_RENDER_REQUIRED = "js_render_required_browser_unavailable"
-REASON_BINARY_NOT_INLINED = "binary_content_not_inlined"
-REASON_CONVERSION_PENDING = "document_conversion_pending"
-
-# Bounds. Redirects are followed manually so each hop is SSRF-checked before the
-# connection; search results are capped so a caller can't request an unbounded page.
-_MAX_SEARCH_COUNT = 25
 
 
 def _new_mcp() -> FastMCP:
@@ -137,50 +36,16 @@ def _new_mcp() -> FastMCP:
     return FastMCP(
         "web",
         instructions=(
-            "Provides agentic web access. Use search to discover candidate sources and fetch "
-            "to read HTTP(S), DOI, HTML, text, PDF, and structured-document targets. The search "
-            "provider is fixed when this MCP installation starts."
+            "Use search to discover sources and fetch to read HTTP(S), DOI, HTML, text, "
+            "PDF, and structured-document targets. Fetch is a durable task; query it for "
+            "progress and cancel it when continued work is no longer useful."
         ),
         list_page_size=10,
     )
 
 
-# ---------------------------------------------------------------------------
-# Tool 1: fetch
-# ---------------------------------------------------------------------------
-
-
-def _validate_output_path(
-    candidate: str | Path, *, default_name: str, output_dir: str | Path | None = None
-) -> Path:
-    """Confine a requested output path to this installation's artifact root."""
-    return validate_output_path(
-        candidate,
-        default_name=default_name,
-        output_dir=output_dir,
-        configured_root=settings.artifacts_root,
-    )
-
-
-def _assert_allowed_url(url: str) -> None:
-    """Apply this installation's private-host policy to a target URL."""
-    assert_allowed_url(url, allow_private_hosts=settings.allow_private_hosts)
-
-
-async def _download(
-    url: str, *, max_bytes: int, max_document_bytes: int, timeout: httpx.Timeout
-) -> tuple[bytes, str | None, int, str]:
-    """Download through the shared redirect, SSRF, and size-limit implementation."""
-    return await download(
-        url,
-        max_bytes=max_bytes,
-        max_document_bytes=max_document_bytes,
-        timeout=timeout,
-        allow_private_hosts=settings.allow_private_hosts,
-    )
-
-
 async def fetch(
+    ctx: Context,
     target: Annotated[
         str,
         Field(description="An http(s) URL or DOI (bare, doi: prefix, or doi.org URL) to fetch."),
@@ -189,310 +54,58 @@ async def fetch(
         bool,
         Field(
             description=(
-                "Write the (converted) content to a local file and return "
-                "local_path instead of inline content. Use for large or binary "
-                "resources so raw pages never bloat context; the agent can then "
-                "pipe the saved file through its own model for (url, prompt) "
-                "extraction."
+                "Write content to a local file and return local_path instead of inline content."
             )
         ),
     ] = False,
     output_dir: Annotated[
         str | None,
-        Field(
-            description=(
-                "Destination directory when to_file=True. Defaults to the "
-                "configured artifacts_root or the current working directory."
-            )
-        ),
+        Field(description="Destination directory when to_file=True."),
     ] = None,
     max_bytes: Annotated[
         int | None,
-        Field(description="Override the size cap in bytes (default from config: 5 MiB)."),
+        Field(description="Override the configured response size cap in bytes."),
     ] = None,
     timeout: Annotated[
         float | None,
-        Field(description="Override the read timeout in seconds (default from config)."),
+        Field(description="Override the configured per-request read timeout in seconds."),
     ] = None,
 ) -> dict[str, Any]:
-    """Fetch a URL or DOI and return Markdown, structure, or a saved artifact.
+    """Fetch a URL or DOI as a queryable, cancellable MCP task."""
 
-    An MCP server has no model access, so page-specific ``(url, prompt)``
-    extraction is intentionally left to the agent: fetch to a file and pipe it
-    through the agent's own model.
-    """
-    requested_target = (target or "").strip()
-    if not requested_target:
-        raise ToolError("fetch requires a non-empty URL or DOI target.")
-
-    cap = max_bytes if max_bytes and max_bytes > 0 else settings.max_bytes
-    read_timeout = timeout if timeout and timeout > 0 else settings.read_timeout_s
-    timeout_cfg = httpx.Timeout(read_timeout, connect=settings.connect_timeout_s)
-
-    doi: str | None = None
-    doi_resolution: dict[str, Any] | None = None
-    download_targets: list[str]
-    parsed_target = urlparse(requested_target)
-    is_doi_url = (
-        parsed_target.scheme in {"http", "https"}
-        and (parsed_target.hostname or "").lower() in {"doi.org", "dx.doi.org"}
-        and bool(parsed_target.path.strip("/"))
+    return await fetch_target(
+        settings,
+        ctx,
+        target,
+        to_file=to_file,
+        output_dir=output_dir,
+        max_bytes=max_bytes,
+        timeout=timeout,
     )
-    if is_doi_url or not requested_target.lower().startswith(("http://", "https://")):
-        if "://" in requested_target and not is_doi_url:
-            raise ToolError(
-                f"fetch only supports http(s) URLs or DOI targets; got: {requested_target!r}"
-            )
-        doi = parsed_target.path.strip("/") if is_doi_url else requested_target
-        doi_resolution = await resolve_doi(
-            doi,
-            service_url=settings.document_service_url,
-            timeout=timeout_cfg,
-        )
-        doi = str(doi_resolution["doi"])
-        download_targets = [
-            str(candidate["url"])
-            for candidate in doi_resolution["candidates"]
-            if isinstance(candidate, dict) and candidate.get("url")
-        ]
-        if not download_targets:
-            raise ToolError(f"CLIO Search found no lawful retrieval candidate for DOI {doi}.")
-    else:
-        download_targets = [requested_target]
-
-    download_target = ""
-    failures: list[str] = []
-    for candidate in download_targets:
-        _assert_allowed_url(candidate)
-        try:
-            body, raw_content_type, status, final_url = await _download(
-                candidate,
-                max_bytes=cap,
-                max_document_bytes=settings.max_document_bytes,
-                timeout=timeout_cfg,
-            )
-            download_target = candidate
-            break
-        except (ToolError, httpx.HTTPError) as exc:
-            failures.append(f"{candidate}: {exc}")
-    else:
-        summary = "; ".join(failures)
-        raise ToolError(f"Could not fetch {requested_target}: {summary}")
-
-    size_bytes = len(body)
-    mime, charset = split_content_type(raw_content_type)
-    is_html_content = is_html(mime)
-    # A response with NO content-type is content-sniffed: decodable-as-UTF-8 text is treated as
-    # text (returned), not withheld as binary. Only genuinely undecodable bytes stay binary.
-    is_text_content = is_text(mime) or is_html_content or (mime == "" and looks_like_text(body))
-    is_binary = not is_text_content
-
-    result: dict[str, Any] = {
-        "ok": True,
-        "target": requested_target,
-        "url": download_target,
-        "size_bytes": size_bytes,
-        "content_type": raw_content_type,
-        "status": status,
-        "title": None,
-        "method": "http",
-    }
-    if doi_resolution is not None:
-        result["doi"] = doi
-        result["doi_resolution"] = doi_resolution
-    if final_url and final_url != download_target:
-        result["final_url"] = final_url  # the resolved URL after redirects (url stays verbatim)
-
-    content: str | None
-    if is_html_content:
-        html = decode(body, charset)
-        result["title"] = extract_title(html)
-        content, extractor = html_to_markdown(html)
-        result["extractor"] = extractor  # which extractor ran (downgrade is visible)
-        if content is None:
-            # Extraction produced nothing usable: almost always a JS-rendered
-            # or challenge-walled page. Signal the headless-browser extension
-            # point instead of returning junk.
-            result["content"] = None
-            result["reason"] = REASON_JS_RENDER_REQUIRED
-            result["note"] = (
-                "HTML extraction yielded no content; the page likely requires a "
-                "JavaScript-capable headless browser, which is not available in v1."
-            )
-            return result
-    elif (
-        is_binary
-        and settings.document_service_url
-        and is_convertible_document(body, raw_content_type, final_url)
-    ):
-        filename = derive_filename(final_url, is_html=False, is_binary=True)
-        conversion = await convert_document(
-            body,
-            filename=filename,
-            content_type=raw_content_type,
-            source_url=final_url,
-            doi=doi,
-            service_url=settings.document_service_url,
-            timeout=timeout_cfg,
-            wait_s=settings.conversion_wait_s,
-            poll_s=settings.conversion_poll_s,
-        )
-        if conversion.get("status") != "complete":
-            result.update(
-                {
-                    "content": None,
-                    "reason": REASON_CONVERSION_PENDING,
-                    "conversion_id": conversion.get("id"),
-                    "retry_after_s": conversion.get("retry_after_s", 2),
-                }
-            )
-            return result
-        converted = conversion.get("result")
-        if not isinstance(converted, dict):
-            raise ToolError("CLIO Search completed conversion without a result payload.")
-        content = str(converted.get("markdown") or "")
-        result["method"] = "clio-search"
-        result["extractor"] = "document-service"
-        document = converted.get("document")
-        if isinstance(document, dict):
-            inline_document = dict(document)
-            structure = inline_document.pop("structure", None)
-            if structure is not None:
-                inline_document["structure_available"] = True
-                if isinstance(structure, dict):
-                    inline_document["structure_summary"] = {
-                        key: len(value)
-                        for key, value in structure.items()
-                        if isinstance(value, (dict, list))
-                    }
-            result["document"] = inline_document
-        else:
-            result["document"] = document
-        result["conversion_id"] = conversion.get("id")
-        if to_file:
-            output_path = _validate_output_path(
-                f"{Path(filename).stem}.md", default_name="document.md", output_dir=output_dir
-            )
-            output_path.write_text(content, encoding="utf-8")
-            metadata_path = output_path.with_suffix(".json")
-            metadata_path.write_text(
-                json.dumps(document, ensure_ascii=False, indent=2),
-                encoding="utf-8",
-            )
-            result["local_path"] = str(output_path)
-            result["metadata_path"] = str(metadata_path)
-            if isinstance(document, dict) and "structure" in document:
-                result["structure_saved_to"] = str(metadata_path)
-            return result
-        result["content"] = content
-        return result
-    elif is_binary:
-        if not to_file:
-            # Never inline a giant binary blob; hand back a typed note.
-            result["content"] = None
-            result["reason"] = REASON_BINARY_NOT_INLINED
-            result["note"] = (
-                "Binary content is not inlined. Re-call fetch with to_file=True to "
-                "save it to a local file."
-            )
-            return result
-        content = None  # binary is written raw below
-    else:
-        content = decode(body, charset)
-
-    if to_file:
-        filename = derive_filename(final_url, is_html=is_html_content, is_binary=is_binary)
-        output_path = _validate_output_path(filename, default_name="page", output_dir=output_dir)
-        if is_binary:
-            output_path.write_bytes(body)
-        else:
-            output_path.write_text(content or "", encoding="utf-8")
-        result["local_path"] = str(output_path)
-    else:
-        result["content"] = content
-
-    return result
 
 
-# ---------------------------------------------------------------------------
-# Tool 2: search (provider abstraction, config-selected)
-# ---------------------------------------------------------------------------
+async def fetch_events(
+    conversion_id: Annotated[
+        str,
+        Field(description="Backend conversion ID reported by fetch task progress."),
+    ],
+    after_sequence: Annotated[
+        int,
+        Field(description="Return events after this sequence cursor.", ge=0),
+    ] = 0,
+    limit: Annotated[
+        int,
+        Field(description="Maximum ordered events to return.", ge=1, le=500),
+    ] = 100,
+) -> dict[str, Any]:
+    """Query the full durable event log for one document conversion."""
 
-
-def _ddgs_search(query: str, count: int) -> list[dict[str, str]]:
-    """Keyless DuckDuckGo search via the ``ddgs`` package (sync)."""
-    from ddgs import DDGS
-
-    results: list[dict[str, str]] = []
-    with DDGS() as ddgs:
-        for item in ddgs.text(query, max_results=count):
-            results.append(
-                {
-                    "title": str(item.get("title") or ""),
-                    "url": str(item.get("href") or item.get("url") or ""),
-                    "snippet": str(item.get("body") or item.get("snippet") or ""),
-                }
-            )
-    return results
-
-
-async def _search_ddg(query: str, count: int) -> list[dict[str, str]]:
-    """Run the synchronous DDG search off the event loop."""
-    return await asyncio.to_thread(_ddgs_search, query, count)
-
-
-async def _search_brave(query: str, count: int) -> list[dict[str, str]]:
-    """BYO-key Brave Search adapter."""
-    if not settings.brave_api_key:
-        raise ToolError(
-            "search provider 'brave' requires an API key. Set WEB_BRAVE_API_KEY "
-            "(Settings.brave_api_key) or choose a different provider."
-        )
-    headers = {"X-Subscription-Token": settings.brave_api_key, "Accept": "application/json"}
-    params: dict[str, str | int] = {"q": query, "count": count}
-    async with httpx.AsyncClient(timeout=httpx.Timeout(settings.read_timeout_s)) as client:
-        response = await client.get(_BRAVE_ENDPOINT, headers=headers, params=params)
-        response.raise_for_status()
-        payload = response.json()
-    web = payload.get("web") or {}
-    results: list[dict[str, str]] = []
-    for item in (web.get("results") or [])[:count]:
-        results.append(
-            {
-                "title": str(item.get("title") or ""),
-                "url": str(item.get("url") or ""),
-                "snippet": str(item.get("description") or ""),
-            }
-        )
-    return results
-
-
-async def _search_tavily(query: str, count: int) -> list[dict[str, str]]:
-    """BYO-key Tavily Search adapter."""
-    if not settings.tavily_api_key:
-        raise ToolError(
-            "search provider 'tavily' requires an API key. Set WEB_TAVILY_API_KEY "
-            "(Settings.tavily_api_key) or choose a different provider."
-        )
-    body = {
-        "api_key": settings.tavily_api_key,
-        "query": query,
-        "max_results": count,
-    }
-    async with httpx.AsyncClient(timeout=httpx.Timeout(settings.read_timeout_s)) as client:
-        response = await client.post(_TAVILY_ENDPOINT, json=body)
-        response.raise_for_status()
-        payload = response.json()
-    results: list[dict[str, str]] = []
-    for item in (payload.get("results") or [])[:count]:
-        results.append(
-            {
-                "title": str(item.get("title") or ""),
-                "url": str(item.get("url") or ""),
-                "snippet": str(item.get("content") or ""),
-            }
-        )
-    return results
+    return await fetch_event_log(
+        settings,
+        conversion_id,
+        after_sequence=after_sequence,
+        limit=limit,
+    )
 
 
 async def _search_common(
@@ -501,25 +114,7 @@ async def _search_common(
 ) -> dict[str, Any]:
     """Search the fixed DDG, Brave, or Tavily provider."""
 
-    text = (query or "").strip()
-    if not text:
-        raise ToolError("A non-empty query is required.")
-    effective_count = min(count if count and count > 0 else 5, _MAX_SEARCH_COUNT)
-    if settings.search_provider == "ddg":
-        results = await _search_ddg(text, effective_count)
-    elif settings.search_provider == "brave":
-        results = await _search_brave(text, effective_count)
-    elif settings.search_provider == "tavily":
-        results = await _search_tavily(text, effective_count)
-    else:
-        raise ToolError("The active search provider requires the SearXNG search schema.")
-    return {
-        "ok": True,
-        "provider": settings.search_provider,
-        "query": text,
-        "results": results,
-        "count": len(results),
-    }
+    return await search_common(settings, query, count)
 
 
 async def _search_searxng_tool(
@@ -553,46 +148,35 @@ async def _search_searxng_tool(
 ) -> dict[str, Any]:
     """Search the fixed SearXNG provider with its native selectors."""
 
-    text = (query or "").strip()
-    if not text:
-        raise ToolError("A non-empty query is required.")
-    effective_count = min(count if count and count > 0 else 5, _MAX_SEARCH_COUNT)
-    results, engines_answered, unresponsive_engines = await search_searxng(
-        text,
-        effective_count,
-        base_url=settings.searxng_base_url,
-        connect_timeout_s=settings.connect_timeout_s,
-        read_timeout_s=settings.read_timeout_s,
-        category=category,
-        engines=engines,
-        language=language,
-        time_range=time_range,
-        pageno=pageno,
-        safesearch=safesearch,
+    return await search_searxng_provider(
+        settings,
+        query,
+        count,
+        category,
+        engines,
+        language,
+        time_range,
+        pageno,
+        safesearch,
     )
-    return {
-        "ok": True,
-        "provider": "searxng",
-        "query": text,
-        "results": results,
-        "count": len(results),
-        "engines_answered": engines_answered,
-        "unresponsive_engines": unresponsive_engines,
-    }
 
 
 def capabilities() -> dict[str, Any]:
-    """Return only the active installation's search and fetch capabilities."""
+    """Return the active installation's search, fetch, and task capabilities."""
 
     search_parameters = ["query", "count"]
     if settings.search_provider == "searxng":
         search_parameters.extend(
             ["category", "engines", "language", "time_range", "pageno", "safesearch"]
         )
+    durable_backend = bool(settings.remote_url or settings.task_backend_url)
     return {
         "active_provider": settings.search_provider,
         "search_parameters": search_parameters,
-        "document_enrichment": bool((settings.document_service_url or "").strip()),
+        "document_enrichment": bool((settings.effective_document_service_url or "").strip()),
+        "fetch_task_mode": "required",
+        "search_task_mode": "forbidden",
+        "task_backend": "valkey" if durable_backend else "memory",
         "max_bytes": settings.max_bytes,
         "max_document_bytes": settings.max_document_bytes,
         "allow_private_hosts": settings.allow_private_hosts,
@@ -600,12 +184,12 @@ def capabilities() -> dict[str, Any]:
 
 
 def research_web(topic: str) -> list[Message]:
-    """Guided search then fetch workflow for researching a topic on the web."""
+    """Provide a guided search-then-fetch research workflow."""
+
     return [
         Message(
-            f"Research '{topic}' on the web. Use search to find the most relevant pages, "
-            "then fetch the top results (to_file=True for long pages so raw content stays "
-            "out of context) and synthesize the findings, citing each source URL."
+            f"Research '{topic}' on the web. Use search to find relevant pages, then fetch "
+            "the strongest sources and synthesize the findings with source URLs."
         )
     ]
 
@@ -614,7 +198,7 @@ def _validate_startup(configured: Settings) -> None:
     """Reject invalid selected-provider configuration before serving tools."""
 
     if configured.search_provider == "searxng":
-        value = (configured.searxng_base_url or "").strip()
+        value = (configured.effective_searxng_url or "").strip()
         parsed = urlparse(value)
         if parsed.scheme not in {"http", "https"} or not parsed.hostname:
             raise ValueError("provider 'searxng' requires --address with an absolute HTTP(S) URL")
@@ -632,22 +216,31 @@ def create_mcp(configured: Settings | None = None) -> FastMCP:
         settings = configured
     _validate_startup(settings)
     instance = _new_mcp()
+    instance.add_extension(build_tasks_extension(settings))
     instance.tool(
         name="fetch",
         title="Fetch Target",
         description=(
-            "Fetch an HTTP(S) URL or DOI. HTML and text are read locally; supported PDFs and "
-            "structured documents use the optional CLIO Search document service."
+            "Fetch an HTTP(S) URL or DOI as a durable task. HTML and text are read locally; "
+            "supported documents use CLIO Web Search conversion when configured."
         ),
         annotations={"readOnlyHint": True, "destructiveHint": False, "idempotentHint": True},
         tags={"web", "fetch", "http", "documents"},
+        task=TaskConfig(mode="required", poll_interval=timedelta(seconds=1)),
     )(fetch)
+    instance.tool(
+        name="fetch_events",
+        title="Get Fetch Events",
+        description="Query the full ordered backend event log for a document fetch conversion.",
+        annotations={"readOnlyHint": True, "destructiveHint": False, "idempotentHint": True},
+        tags={"web", "fetch", "documents", "progress"},
+        task=TaskConfig(mode="forbidden"),
+    )(fetch_events)
     search_function = (
         _search_searxng_tool if settings.search_provider == "searxng" else _search_common
     )
     search_description = (
-        "Search the configured self-hosted SearXNG deployment with native category, engine, "
-        "language, time-range, page, and safe-search selectors."
+        "Search the configured self-hosted SearXNG deployment with native selectors."
         if settings.search_provider == "searxng"
         else f"Search the web using this installation's fixed {settings.search_provider} provider."
     )
@@ -657,6 +250,7 @@ def create_mcp(configured: Settings | None = None) -> FastMCP:
         description=search_description,
         annotations={"readOnlyHint": True, "destructiveHint": False, "idempotentHint": False},
         tags={"web", "search"},
+        task=TaskConfig(mode="forbidden"),
     )(search_function)
     instance.resource("web://capabilities")(capabilities)
     instance.prompt()(research_web)
@@ -667,7 +261,8 @@ mcp = create_mcp()
 
 
 def main() -> None:
-    """Main entry point for the web MCP server."""
+    """Run the Web MCP over stdio or HTTP."""
+
     import argparse
 
     parser = argparse.ArgumentParser(description="Web MCP Server")
@@ -680,17 +275,23 @@ def main() -> None:
     )
     parser.add_argument(
         "--address",
-        help="SearXNG or CLIO Search root URL; required when --provider searxng.",
+        help="Legacy SearXNG or CLIO Web Search root URL.",
     )
     parser.add_argument(
         "--document-address",
-        help="Optional CLIO Search root URL for DOI and document enrichment.",
+        help="Legacy CLIO Web Search root URL for DOI and document enrichment.",
+    )
+    parser.add_argument(
+        "--remote-url",
+        "--remote_url",
+        dest="remote_url",
+        help="Unified CLIO Web Search URL for search, documents, and task discovery.",
     )
     parser.add_argument("--transport", choices=["stdio", "http"], default=None)
     parser.add_argument("--host", default="0.0.0.0")
     parser.add_argument("--port", type=int, default=8000)
     args = parser.parse_args()
-    selected = args.provider or settings.search_provider
+    selected = args.provider or ("searxng" if args.remote_url else settings.search_provider)
     configured = Settings(
         search_provider=selected,
         searxng_base_url=args.address or settings.searxng_base_url,
@@ -699,16 +300,22 @@ def main() -> None:
             or settings.document_service_url
             or (args.address if selected == "searxng" else None)
         ),
+        remote_url=args.remote_url or settings.remote_url,
+        remote_token=settings.remote_token,
         brave_api_key=settings.brave_api_key,
         tavily_api_key=settings.tavily_api_key,
         max_bytes=settings.max_bytes,
         max_document_bytes=settings.max_document_bytes,
         connect_timeout_s=settings.connect_timeout_s,
         read_timeout_s=settings.read_timeout_s,
-        conversion_wait_s=settings.conversion_wait_s,
         conversion_poll_s=settings.conversion_poll_s,
+        progress_heartbeat_s=settings.progress_heartbeat_s,
         artifacts_root=settings.artifacts_root,
         allow_private_hosts=settings.allow_private_hosts,
+        state_dir=settings.state_dir,
+        task_backend_url=settings.task_backend_url,
+        task_queue_name=settings.task_queue_name,
+        task_concurrency=settings.task_concurrency,
     )
     try:
         server = create_mcp(configured)

--- a/clio-kit-mcp-servers/web/src/web_mcp/task_runtime.py
+++ b/clio-kit-mcp-servers/web/src/web_mcp/task_runtime.py
@@ -1,0 +1,206 @@
+"""Persistent local identity and Docket discovery for FastMCP tasks."""
+
+from __future__ import annotations
+
+import os
+import secrets
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, cast
+from urllib.parse import quote, urlencode
+
+import httpx
+from fastmcp.exceptions import ToolError
+from platformdirs import user_config_path
+from pydantic import SecretStr
+
+from web_mcp.config import Settings
+
+if TYPE_CHECKING:
+    from fastmcp_tasks import TasksExtension
+
+
+@dataclass(frozen=True)
+class TaskRuntime:
+    """Resolved Docket connection and stable local task identity."""
+
+    url: str
+    queue_name: str
+    agent_id: str
+    encryption_key: str
+
+
+def build_tasks_extension(configured: Settings) -> TasksExtension:
+    """Resolve task infrastructure and construct FastMCP's Tasks extension."""
+
+    runtime = resolve_task_runtime(configured)
+    os.environ["FASTMCP_TASKS_ENCRYPTION_KEY"] = runtime.encryption_key
+    from fastmcp_tasks import TasksExtension
+    from fastmcp_tasks.settings import tasks_settings
+
+    tasks_settings.encryption_key = SecretStr(runtime.encryption_key)
+    return TasksExtension(
+        url=runtime.url,
+        name=runtime.queue_name,
+        concurrency=configured.task_concurrency,
+    )
+
+
+def resolve_task_runtime(configured: Settings) -> TaskRuntime:
+    """Resolve local identity, encryption, and the remote Valkey session."""
+
+    state_dir = _state_dir(configured)
+    agent_id = _read_or_create(state_dir / "agent-id", lambda: secrets.token_hex(16))
+    encryption_key = os.getenv("FASTMCP_TASKS_ENCRYPTION_KEY") or _read_or_create(
+        state_dir / "tasks.key", lambda: secrets.token_urlsafe(48)
+    )
+    if configured.task_backend_url:
+        return TaskRuntime(
+            url=configured.task_backend_url,
+            queue_name=configured.task_queue_name or f"clio-web-local-{agent_id[:16]}",
+            agent_id=agent_id,
+            encryption_key=encryption_key,
+        )
+    # ``document_service_url`` is the legacy conversion-only endpoint.  Only the
+    # unified remote deployment contract advertises and provisions Docket.
+    if not configured.remote_url:
+        return TaskRuntime(
+            url="memory://",
+            queue_name=configured.task_queue_name or f"clio-web-local-{agent_id[:16]}",
+            agent_id=agent_id,
+            encryption_key=encryption_key,
+        )
+    session = _discover(configured, agent_id)
+    return TaskRuntime(
+        url=_docket_url(session, state_dir),
+        queue_name=_required_string(session, "queue_name"),
+        agent_id=agent_id,
+        encryption_key=encryption_key,
+    )
+
+
+def _discover(configured: Settings, agent_id: str) -> dict[str, Any]:
+    base = str(configured.effective_document_service_url).rstrip("/")
+    timeout = httpx.Timeout(configured.read_timeout_s, connect=configured.connect_timeout_s)
+    headers: dict[str, str] = {}
+    if configured.remote_token:
+        headers["Authorization"] = f"Bearer {configured.remote_token}"
+    try:
+        with httpx.Client(timeout=timeout, headers=headers) as client:
+            capabilities = client.get(f"{base}/v1/capabilities")
+            capabilities.raise_for_status()
+            capability_payload = capabilities.json()
+            backend = capability_payload.get("task_backend")
+            if not isinstance(backend, dict) or not backend.get("enabled"):
+                raise ToolError(
+                    "The configured CLIO Web Search service does not advertise a FastMCP task "
+                    "backend. Upgrade it to 0.3.0 or configure WEB_TASK_BACKEND_URL explicitly."
+                )
+            session_path = str(backend.get("session_path") or "/v1/task-backend/session")
+            response = client.post(f"{base}{session_path}", json={"agent_id": agent_id})
+            if response.is_error:
+                raise ToolError(_http_failure(response, "task-backend discovery"))
+            payload = response.json()
+    except ToolError:
+        raise
+    except (httpx.HTTPError, ValueError) as exc:
+        raise ToolError(
+            "Could not initialize durable fetch tasks from CLIO Web Search. "
+            f"Stage: task-backend discovery. Cause: {type(exc).__name__}. "
+            "Fix: verify --remote-url, service readiness, and network access, then restart the "
+            "Web MCP."
+        ) from exc
+    if not isinstance(payload, dict):
+        raise ToolError(
+            "CLIO Web Search returned malformed task-backend discovery data. Upgrade or repair "
+            "the service before retrying."
+        )
+    return cast(dict[str, Any], payload)
+
+
+def _docket_url(session: dict[str, Any], state_dir: Path) -> str:
+    scheme = _required_string(session, "scheme")
+    host = _required_string(session, "host")
+    port = int(session.get("port", 0))
+    database = int(session.get("database", 0))
+    if scheme not in {"redis", "rediss"} or not (1 <= port <= 65535):
+        raise ToolError(
+            "CLIO Web Search returned an invalid Valkey endpoint. Repair its advertised task "
+            "backend host, port, and scheme."
+        )
+    username = session.get("username")
+    password = session.get("password")
+    userinfo = ""
+    if isinstance(username, str) and isinstance(password, str):
+        userinfo = f"{quote(username, safe='')}:{quote(password, safe='')}@"
+    query: dict[str, str] = {}
+    ca_pem = session.get("ca_pem")
+    if scheme == "rediss":
+        if not isinstance(ca_pem, str) or "BEGIN CERTIFICATE" not in ca_pem:
+            raise ToolError(
+                "Secure task discovery did not include a usable CA certificate. Repair the "
+                "CLIO Web Search TLS configuration."
+            )
+        ca_path = state_dir / "valkey-ca.pem"
+        _write_private(ca_path, ca_pem)
+        query["ssl_ca_certs"] = str(ca_path)
+        query["ssl_cert_reqs"] = "required"
+    suffix = f"?{urlencode(query)}" if query else ""
+    return f"{scheme}://{userinfo}{host}:{port}/{database}{suffix}"
+
+
+def _required_string(payload: dict[str, Any], key: str) -> str:
+    value = payload.get(key)
+    if not isinstance(value, str) or not value:
+        raise ToolError(f"Task-backend discovery omitted required field {key!r}.")
+    return value
+
+
+def _http_failure(response: httpx.Response, stage: str) -> str:
+    try:
+        payload = response.json()
+    except ValueError:
+        payload = {}
+    if isinstance(payload, dict):
+        message = payload.get("message")
+        remediation = payload.get("remediation")
+        if isinstance(message, str):
+            fix = remediation if isinstance(remediation, str) else "Check the service logs."
+            return f"{message} Stage: {stage}. Fix: {fix}"
+    return (
+        f"CLIO Web Search rejected {stage} with HTTP {response.status_code}. "
+        "Fix: verify authentication and service readiness, then retry."
+    )
+
+
+def _state_dir(configured: Settings) -> Path:
+    path = (
+        Path(configured.state_dir).expanduser()
+        if configured.state_dir
+        else user_config_path("clio-kit", "IOWarp") / "web-mcp"
+    )
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _read_or_create(path: Path, factory: Callable[[], str]) -> str:
+    try:
+        value = path.read_text(encoding="utf-8").strip()
+    except FileNotFoundError:
+        value = str(factory())
+        _write_private(path, value)
+    except OSError as exc:
+        raise ToolError(f"Could not read persistent Web MCP state at {path}: {exc}") from exc
+    if not value:
+        raise ToolError(f"Persistent Web MCP state at {path} is empty; remove it and restart.")
+    return value
+
+
+def _write_private(path: Path, value: str) -> None:
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(value, encoding="utf-8")
+        path.chmod(0o600)
+    except OSError as exc:
+        raise ToolError(f"Could not persist private Web MCP state at {path}: {exc}") from exc

--- a/clio-kit-mcp-servers/web/tests/test_document_service.py
+++ b/clio-kit-mcp-servers/web/tests/test_document_service.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Any
 
 import httpx
 import pytest
@@ -20,13 +21,12 @@ _SERVICE = "http://clio-search.test:8080"
 _PDF = b"%PDF-1.7\nstructured test"
 
 
-def _document_mcp(tmp_path: Path, *, wait_s: float = 0) -> FastMCP:
+def _document_mcp(tmp_path: Path) -> FastMCP:
     return create_mcp(
         Settings(
             search_provider="ddg",
             document_service_url=_SERVICE,
             artifacts_root=str(tmp_path),
-            conversion_wait_s=wait_s,
             conversion_poll_s=0.1,
         )
     )
@@ -173,10 +173,10 @@ async def test_fetch_doi_url_uses_same_resolution_contract(
 
 
 @pytest.mark.asyncio
-async def test_fetch_document_returns_durable_pending_handle(
+async def test_fetch_document_waits_for_terminal_backend_state(
     httpx_mock: HTTPXMock, tmp_path: Path
 ) -> None:
-    """A long conversion returns an honest retry handle rather than hiding work."""
+    """A long conversion remains a live MCP task until the backend completes."""
 
     source = "https://papers.test/work.pdf"
     httpx_mock.add_response(url=source, content=_PDF, headers={"content-type": "application/pdf"})
@@ -186,20 +186,43 @@ async def test_fetch_document_returns_durable_pending_handle(
         status_code=202,
         json={"id": "job-pending", "status": "queued", "retry_after_s": 2},
     )
+    httpx_mock.add_response(
+        method="GET",
+        url=(f"{_SERVICE}/v1/documents/job-pending/events?after_sequence=0&limit=100"),
+        json={
+            "events": [
+                {
+                    "sequence": 1,
+                    "progress": 45,
+                    "stage": "layout",
+                    "level": "info",
+                    "message": "Reading page layout",
+                }
+            ]
+        },
+    )
+    httpx_mock.add_response(
+        method="GET",
+        url=f"{_SERVICE}/v1/documents/job-pending",
+        json={
+            "id": "job-pending",
+            "status": "complete",
+            "result": {"markdown": "# Finished", "document": {"profile": "general"}},
+        },
+    )
 
     async with Client(_document_mcp(tmp_path)) as client:
         result = await client.call_tool("fetch", {"target": source})
     data = parse_result(result)
 
-    assert data["reason"] == "document_conversion_pending"
+    assert data["content"] == "# Finished"
     assert data["conversion_id"] == "job-pending"
-    assert data["retry_after_s"] == 2
 
 
 @pytest.mark.parametrize(
     ("address", "message"),
     [
-        ("not-a-url", "absolute CLIO Search address"),
+        ("not-a-url", "absolute CLIO Web Search address"),
         ("https://search.test/?tenant=x", "query or fragment"),
     ],
 )
@@ -219,7 +242,7 @@ async def test_resolve_doi_rejects_malformed_service_payload(httpx_mock: HTTPXMo
         url=f"{_SERVICE}/v1/doi/resolve",
         json={"doi": "10.1234/example", "candidates": "not-a-list"},
     )
-    with pytest.raises(ToolError, match="malformed DOI-resolution response"):
+    with pytest.raises(ToolError, match="malformed DOI-resolution data"):
         await resolve_doi(
             "10.1234/example",
             service_url=_SERVICE,
@@ -236,7 +259,10 @@ async def test_resolve_doi_wraps_service_failure(httpx_mock: HTTPXMock) -> None:
         method="POST",
         url=f"{_SERVICE}/v1/doi/resolve",
     )
-    with pytest.raises(ToolError, match="Could not resolve DOI through CLIO Search"):
+    with pytest.raises(
+        ToolError,
+        match="Fetch failed during DOI resolution.*Retryable: yes.*Fix:",
+    ):
         await resolve_doi(
             "10.1234/example",
             service_url=_SERVICE,
@@ -256,9 +282,29 @@ async def test_convert_document_polls_and_sends_doi(httpx_mock: HTTPXMock) -> No
     )
     httpx_mock.add_response(
         method="GET",
+        url=f"{_SERVICE}/v1/documents/poll-1/events?after_sequence=0&limit=100",
+        json={
+            "events": [
+                {
+                    "sequence": 1,
+                    "progress": 80,
+                    "stage": "serialize",
+                    "level": "info",
+                    "message": "Writing Markdown",
+                }
+            ]
+        },
+    )
+    httpx_mock.add_response(
+        method="GET",
         url=f"{_SERVICE}/v1/documents/poll-1",
         json={"id": "poll-1", "status": "complete", "result": {"markdown": "done"}},
     )
+    progress: list[dict[str, Any]] = []
+
+    async def report(event: dict[str, Any]) -> None:
+        progress.append(event)
+
     payload = await convert_document(
         _PDF,
         filename="paper.pdf",
@@ -267,13 +313,14 @@ async def test_convert_document_polls_and_sends_doi(httpx_mock: HTTPXMock) -> No
         doi="10.1234/example",
         service_url=_SERVICE,
         timeout=httpx.Timeout(2),
-        wait_s=1,
         poll_s=0,
+        on_progress=report,
     )
 
     assert payload["status"] == "complete"
     request_body = httpx_mock.get_requests()[0].content
     assert b"10.1234/example" in request_body
+    assert [event["stage"] for event in progress] == ["queued", "serialize"]
 
 
 @pytest.mark.asyncio
@@ -285,7 +332,11 @@ async def test_convert_document_rejects_malformed_submission(httpx_mock: HTTPXMo
         url=f"{_SERVICE}/v1/documents",
         json={"status": "queued"},
     )
-    with pytest.raises(ToolError, match="malformed document submission"):
+
+    async def report(_event: dict[str, Any]) -> None:
+        return None
+
+    with pytest.raises(ToolError, match="without returning a conversion ID"):
         await convert_document(
             _PDF,
             filename="paper.pdf",
@@ -294,15 +345,18 @@ async def test_convert_document_rejects_malformed_submission(httpx_mock: HTTPXMo
             doi=None,
             service_url=_SERVICE,
             timeout=httpx.Timeout(2),
-            wait_s=0,
             poll_s=0,
+            on_progress=report,
         )
 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("error", "message"),
-    [({"message": "parser unavailable"}, "parser unavailable"), (None, "unknown error")],
+    [
+        ({"message": "parser unavailable."}, "parser unavailable"),
+        (None, "without structured diagnostics"),
+    ],
 )
 async def test_convert_document_surfaces_typed_failure(
     httpx_mock: HTTPXMock, error: object, message: str
@@ -314,7 +368,11 @@ async def test_convert_document_surfaces_typed_failure(
         url=f"{_SERVICE}/v1/documents",
         json={"id": "failed-1", "status": "failed", "error": error},
     )
-    with pytest.raises(ToolError, match=message):
+
+    async def report(_event: dict[str, Any]) -> None:
+        return None
+
+    with pytest.raises(ToolError, match=message) as captured:
         await convert_document(
             _PDF,
             filename="paper.pdf",
@@ -323,6 +381,7 @@ async def test_convert_document_surfaces_typed_failure(
             doi=None,
             service_url=_SERVICE,
             timeout=httpx.Timeout(2),
-            wait_s=0,
             poll_s=0,
+            on_progress=report,
         )
+    assert ".." not in str(captured.value)

--- a/clio-kit-mcp-servers/web/tests/test_init.py
+++ b/clio-kit-mcp-servers/web/tests/test_init.py
@@ -18,7 +18,7 @@ class TestPackageMetadata:
 
     def test_version_value(self) -> None:
         """Test that version has expected value."""
-        assert web_mcp.__version__ == "2.0.0"
+        assert web_mcp.__version__ == "2.1.0"
 
     def test_docstring_exists(self) -> None:
         """Test that package has a docstring."""

--- a/clio-kit-mcp-servers/web/tests/test_main.py
+++ b/clio-kit-mcp-servers/web/tests/test_main.py
@@ -53,6 +53,16 @@ class TestMainFunction:
                     main()
             mock_run.assert_called_once_with(transport="http", host="0.0.0.0", port=8000)
 
+    def test_remote_url_selects_unified_searxng_provider(self) -> None:
+        """One remote URL configures search as well as fetch and tasks."""
+
+        with patch("web_mcp.server.create_mcp") as create:
+            with patch("sys.argv", ["web-mcp", "--remote_url", "http://homelab:8089"]):
+                main()
+        configured = create.call_args.args[0]
+        assert configured.search_provider == "searxng"
+        assert configured.remote_url == "http://homelab:8089"
+
 
 class TestServerInitialization:
     """Test server initialization and module-level setup."""

--- a/clio-kit-mcp-servers/web/tests/test_registration.py
+++ b/clio-kit-mcp-servers/web/tests/test_registration.py
@@ -6,6 +6,7 @@ import json
 
 import pytest
 from fastmcp import Client
+from mcp.types import TextResourceContents
 
 from web_mcp.server import Settings, create_mcp, mcp
 
@@ -25,7 +26,9 @@ async def test_capabilities_resource_reports_only_active_backend() -> None:
     """Discovery describes this installation rather than alternate providers."""
     async with Client(mcp) as client:
         result = await client.read_resource("web://capabilities")
-    payload = json.loads(result[0].text)  # resource contents expose .text (JSON)
+    contents = result[0]
+    assert isinstance(contents, TextResourceContents)
+    payload = json.loads(contents.text)
     assert payload["active_provider"] == "ddg"  # keyless default
     assert payload["search_parameters"] == ["query", "count"]
     assert "available_providers" not in payload
@@ -42,7 +45,9 @@ async def test_capabilities_resource_reports_configured_searxng() -> None:
     )
     async with Client(searxng_mcp) as client:
         result = await client.read_resource("web://capabilities")
-    payload = json.loads(result[0].text)
+    contents = result[0]
+    assert isinstance(contents, TextResourceContents)
+    payload = json.loads(contents.text)
     assert payload["active_provider"] == "searxng"
     assert "pageno" in payload["search_parameters"]
-    assert "10.0.0.102" not in result[0].text
+    assert "10.0.0.102" not in contents.text

--- a/clio-kit-mcp-servers/web/tests/test_settings.py
+++ b/clio-kit-mcp-servers/web/tests/test_settings.py
@@ -33,6 +33,14 @@ class TestSettingsDefaults:
         cfg = Settings()
         assert cfg.artifacts_root is None
 
+    def test_unified_remote_selects_searxng_automatically(self) -> None:
+        cfg = Settings(remote_url="http://homelab:8089")
+        assert cfg.search_provider == "searxng"
+
+    def test_unified_remote_preserves_explicit_provider(self) -> None:
+        cfg = Settings(remote_url="http://homelab:8089", search_provider="ddg")
+        assert cfg.search_provider == "ddg"
+
 
 class TestSettingsOverride:
     """Configuration is driven by explicit values, not ambient env."""

--- a/clio-kit-mcp-servers/web/tests/test_task_runtime.py
+++ b/clio-kit-mcp-servers/web/tests/test_task_runtime.py
@@ -1,0 +1,288 @@
+"""Task-backend discovery, identity, and diagnostic tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import httpx
+import pytest
+from fastmcp.exceptions import ToolError
+from pytest_httpx import HTTPXMock
+
+from web_mcp.config import Settings
+from web_mcp.task_runtime import resolve_task_runtime
+
+_REMOTE = "https://clio-web.test:8089"
+
+
+def _add_discovery_responses(httpx_mock: HTTPXMock, session: object) -> None:
+    """Register the capability and session responses used by discovery tests."""
+
+    httpx_mock.add_response(
+        method="GET",
+        url=f"{_REMOTE}/v1/capabilities",
+        json={"task_backend": {"enabled": True}},
+    )
+    httpx_mock.add_response(
+        method="POST",
+        url=f"{_REMOTE}/v1/task-backend/session",
+        json=session,
+    )
+
+
+def test_remote_runtime_discovers_stable_agent_queue(httpx_mock: HTTPXMock, tmp_path: Path) -> None:
+    """Unified remote configuration discovers per-agent Docket credentials."""
+
+    httpx_mock.add_response(
+        method="GET",
+        url=f"{_REMOTE}/v1/capabilities",
+        json={
+            "task_backend": {
+                "enabled": True,
+                "session_path": "/v1/task-backend/session",
+            }
+        },
+    )
+    httpx_mock.add_response(
+        method="POST",
+        url=f"{_REMOTE}/v1/task-backend/session",
+        json={
+            "scheme": "redis",
+            "host": "homelab",
+            "port": 8090,
+            "database": 0,
+            "username": "agent-a",
+            "password": "secret",
+            "queue_name": "clio-web-prod-agent-a",
+        },
+    )
+
+    configured = Settings(
+        remote_url=_REMOTE,
+        remote_token="deployment-token",  # noqa: S106 - test-only credential
+        state_dir=str(tmp_path),
+    )
+    first = resolve_task_runtime(configured)
+
+    assert first.url == "redis://agent-a:secret@homelab:8090/0"
+    assert first.queue_name == "clio-web-prod-agent-a"
+    request = httpx_mock.get_requests()[1]
+    assert request.headers["Authorization"] == "Bearer deployment-token"
+    assert request.read().decode()
+
+    httpx_mock.reset()
+    httpx_mock.add_response(
+        method="GET",
+        url=f"{_REMOTE}/v1/capabilities",
+        json={"task_backend": {"enabled": True}},
+    )
+    httpx_mock.add_response(
+        method="POST",
+        url=f"{_REMOTE}/v1/task-backend/session",
+        json={
+            "scheme": "redis",
+            "host": "homelab",
+            "port": 8090,
+            "database": 0,
+            "username": "agent-a",
+            "password": "secret",
+            "queue_name": "clio-web-prod-agent-a",
+        },
+    )
+    second = resolve_task_runtime(configured)
+    assert second.agent_id == first.agent_id
+    assert second.encryption_key == first.encryption_key
+
+
+def test_remote_runtime_reports_actionable_discovery_failure(
+    httpx_mock: HTTPXMock, tmp_path: Path
+) -> None:
+    """Startup failures state the stage and corrective action for an agent."""
+
+    httpx_mock.add_response(
+        method="GET",
+        url=f"{_REMOTE}/v1/capabilities",
+        json={"task_backend": {"enabled": False}},
+    )
+    with pytest.raises(ToolError) as error:
+        resolve_task_runtime(Settings(remote_url=_REMOTE, state_dir=str(tmp_path)))
+
+    message = str(error.value)
+    assert "task backend" in message
+    assert "Upgrade" in message or "configure" in message
+
+
+def test_legacy_document_service_does_not_require_valkey_discovery(tmp_path: Path) -> None:
+    """Legacy document-only configuration keeps a local in-memory task runtime."""
+
+    runtime = resolve_task_runtime(
+        Settings(document_service_url="http://legacy.test", state_dir=str(tmp_path))
+    )
+    assert runtime.url == "memory://"
+
+
+def test_explicit_task_backend_skips_remote_discovery(tmp_path: Path) -> None:
+    """An operator-provided Docket URL remains a supported explicit override."""
+
+    runtime = resolve_task_runtime(
+        Settings(
+            task_backend_url="redis://valkey.internal:6379/2",
+            task_queue_name="web-fetches",
+            state_dir=str(tmp_path),
+        )
+    )
+
+    assert runtime.url == "redis://valkey.internal:6379/2"
+    assert runtime.queue_name == "web-fetches"
+
+
+def test_secure_remote_runtime_persists_discovered_ca(
+    httpx_mock: HTTPXMock, tmp_path: Path
+) -> None:
+    """A rediss session persists its CA and requires certificate verification."""
+
+    ca_pem = "-----BEGIN CERTIFICATE-----\ntest-ca\n-----END CERTIFICATE-----"
+    _add_discovery_responses(
+        httpx_mock,
+        {
+            "scheme": "rediss",
+            "host": "valkey.internal",
+            "port": 6380,
+            "database": 3,
+            "username": "agent user",
+            "password": "p@ss word",
+            "queue_name": "secure-fetches",
+            "ca_pem": ca_pem,
+        },
+    )
+
+    runtime = resolve_task_runtime(Settings(remote_url=_REMOTE, state_dir=str(tmp_path)))
+
+    assert runtime.url.startswith("rediss://agent%20user:p%40ss%20word@valkey.internal:6380/3?")
+    assert "ssl_cert_reqs=required" in runtime.url
+    assert (tmp_path / "valkey-ca.pem").read_text(encoding="utf-8") == ca_pem
+
+
+@pytest.mark.parametrize(
+    ("session", "message"),
+    [
+        (
+            {
+                "scheme": "redis",
+                "host": "valkey.internal",
+                "port": 0,
+                "queue_name": "fetches",
+            },
+            "invalid Valkey endpoint",
+        ),
+        (
+            {
+                "scheme": "rediss",
+                "host": "valkey.internal",
+                "port": 6380,
+                "queue_name": "fetches",
+            },
+            "usable CA certificate",
+        ),
+        (
+            {"scheme": "redis", "host": "valkey.internal", "port": 6379},
+            "required field 'queue_name'",
+        ),
+    ],
+)
+def test_remote_runtime_rejects_unsafe_or_incomplete_session(
+    httpx_mock: HTTPXMock,
+    tmp_path: Path,
+    session: dict[str, object],
+    message: str,
+) -> None:
+    """Invalid discovered endpoints fail before Docket can contact the wrong service."""
+
+    _add_discovery_responses(httpx_mock, session)
+
+    with pytest.raises(ToolError, match=message):
+        resolve_task_runtime(Settings(remote_url=_REMOTE, state_dir=str(tmp_path)))
+
+
+def test_remote_runtime_preserves_structured_session_error(
+    httpx_mock: HTTPXMock, tmp_path: Path
+) -> None:
+    """Backend session errors retain both the cause and operator remediation."""
+
+    httpx_mock.add_response(
+        method="GET",
+        url=f"{_REMOTE}/v1/capabilities",
+        json={"task_backend": {"enabled": True}},
+    )
+    httpx_mock.add_response(
+        method="POST",
+        url=f"{_REMOTE}/v1/task-backend/session",
+        status_code=503,
+        json={
+            "message": "Valkey is unavailable.",
+            "remediation": "Check the bundled Valkey process and persistent volume.",
+        },
+    )
+
+    with pytest.raises(ToolError) as error:
+        resolve_task_runtime(Settings(remote_url=_REMOTE, state_dir=str(tmp_path)))
+
+    assert "Valkey is unavailable" in str(error.value)
+    assert "Check the bundled Valkey process" in str(error.value)
+
+
+def test_remote_runtime_explains_non_json_session_error(
+    httpx_mock: HTTPXMock, tmp_path: Path
+) -> None:
+    """A proxy-style non-JSON response still identifies authentication and readiness checks."""
+
+    httpx_mock.add_response(
+        method="GET",
+        url=f"{_REMOTE}/v1/capabilities",
+        json={"task_backend": {"enabled": True}},
+    )
+    httpx_mock.add_response(
+        method="POST",
+        url=f"{_REMOTE}/v1/task-backend/session",
+        status_code=502,
+        text="upstream unavailable",
+    )
+
+    with pytest.raises(ToolError) as error:
+        resolve_task_runtime(Settings(remote_url=_REMOTE, state_dir=str(tmp_path)))
+
+    assert "HTTP 502" in str(error.value)
+    assert "verify authentication and service readiness" in str(error.value)
+
+
+def test_remote_runtime_rejects_malformed_session_payload(
+    httpx_mock: HTTPXMock, tmp_path: Path
+) -> None:
+    """A non-object discovery result yields an actionable compatibility error."""
+
+    _add_discovery_responses(httpx_mock, ["not", "an", "object"])
+
+    with pytest.raises(ToolError, match="malformed task-backend discovery data"):
+        resolve_task_runtime(Settings(remote_url=_REMOTE, state_dir=str(tmp_path)))
+
+
+def test_remote_runtime_wraps_network_failure(httpx_mock: HTTPXMock, tmp_path: Path) -> None:
+    """A capability transport failure names discovery and the corrective checks."""
+
+    httpx_mock.add_exception(
+        httpx.ConnectError("connection closed"),
+        method="GET",
+        url=f"{_REMOTE}/v1/capabilities",
+    )
+
+    with pytest.raises(ToolError, match="task-backend discovery.*Fix:"):
+        resolve_task_runtime(Settings(remote_url=_REMOTE, state_dir=str(tmp_path)))
+
+
+def test_remote_runtime_rejects_empty_persistent_identity(tmp_path: Path) -> None:
+    """Corrupt empty identity state explains the safe operator recovery action."""
+
+    (tmp_path / "agent-id").write_text("", encoding="utf-8")
+
+    with pytest.raises(ToolError, match="is empty; remove it and restart"):
+        resolve_task_runtime(Settings(state_dir=str(tmp_path)))

--- a/clio-kit-mcp-servers/web/tests/test_tasks.py
+++ b/clio-kit-mcp-servers/web/tests/test_tasks.py
@@ -1,0 +1,176 @@
+"""Deterministic wire-level checks for the MCP v2 fetch task lifecycle."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import httpx
+import pytest
+from fastmcp import Client, FastMCP
+from fastmcp.exceptions import ToolError
+from fastmcp_tasks.client import call_tool_task
+from pytest_httpx import HTTPXMock
+
+from web_mcp.server import Settings, create_mcp
+
+from .helpers import parse_result
+
+_SERVICE = "http://clio-search.test:8080"
+_SOURCE = "https://papers.test/task.pdf"
+_PDF = b"%PDF-1.7\ntask protocol test"
+
+
+def _task_mcp(tmp_path: Path) -> FastMCP:
+    """Create an isolated in-memory task server for one protocol test."""
+
+    return create_mcp(
+        Settings(
+            search_provider="ddg",
+            document_service_url=_SERVICE,
+            artifacts_root=str(tmp_path),
+            conversion_poll_s=0.1,
+            state_dir=str(tmp_path / "state"),
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_fetch_task_exposes_live_progress_and_terminal_result(
+    httpx_mock: HTTPXMock, tmp_path: Path
+) -> None:
+    """A client can query working state, see progress, and retrieve the result."""
+
+    events_requested = asyncio.Event()
+    release_events = asyncio.Event()
+    httpx_mock.add_response(
+        method="GET",
+        url=_SOURCE,
+        content=_PDF,
+        headers={"content-type": "application/pdf"},
+    )
+    httpx_mock.add_response(
+        method="POST",
+        url=f"{_SERVICE}/v1/documents",
+        status_code=202,
+        json={"id": "task-1", "status": "queued", "stage": "queued"},
+    )
+
+    async def progress_response(_request: httpx.Request) -> httpx.Response:
+        events_requested.set()
+        await release_events.wait()
+        return httpx.Response(
+            200,
+            json={
+                "events": [
+                    {
+                        "sequence": 1,
+                        "progress": 70,
+                        "stage": "layout",
+                        "level": "info",
+                        "message": "Reading page layout",
+                    }
+                ]
+            },
+        )
+
+    httpx_mock.add_callback(
+        progress_response,
+        method="GET",
+        url=f"{_SERVICE}/v1/documents/task-1/events?after_sequence=0&limit=100",
+    )
+    httpx_mock.add_response(
+        method="GET",
+        url=f"{_SERVICE}/v1/documents/task-1",
+        json={
+            "id": "task-1",
+            "status": "complete",
+            "result": {"markdown": "# Task result", "document": {"profile": "general"}},
+        },
+    )
+
+    async with Client(_task_mcp(tmp_path)) as client:
+        task = await call_tool_task(client, "fetch", {"target": _SOURCE})
+        await asyncio.wait_for(events_requested.wait(), timeout=5)
+        working = await task.status()
+        assert working.status == "working"
+        assert working.status_message is not None
+        assert "task-1" in working.status_message
+
+        release_events.set()
+        terminal = await task.wait(timeout=5)
+        assert terminal.status == "completed"
+        result = parse_result(await task.result())
+
+    assert result["conversion_id"] == "task-1"
+    assert result["content"] == "# Task result"
+
+
+@pytest.mark.asyncio
+async def test_fetch_task_cancellation_reaches_backend(
+    httpx_mock: HTTPXMock, tmp_path: Path
+) -> None:
+    """Native tasks/cancel cooperatively cancels the backend conversion."""
+
+    events_requested = asyncio.Event()
+    never_release = asyncio.Event()
+    cancel_requested = asyncio.Event()
+    httpx_mock.add_response(
+        method="GET",
+        url=_SOURCE,
+        content=_PDF,
+        headers={"content-type": "application/pdf"},
+    )
+    httpx_mock.add_response(
+        method="POST",
+        url=f"{_SERVICE}/v1/documents",
+        status_code=202,
+        json={"id": "task-cancel", "status": "running", "stage": "conversion"},
+    )
+
+    async def blocked_progress(_request: httpx.Request) -> httpx.Response:
+        events_requested.set()
+        await never_release.wait()
+        return httpx.Response(200, json={"events": []})
+
+    async def cancel_response(_request: httpx.Request) -> httpx.Response:
+        cancel_requested.set()
+        return httpx.Response(200, json={"id": "task-cancel", "status": "cancelled"})
+
+    httpx_mock.add_callback(
+        blocked_progress,
+        method="GET",
+        url=(f"{_SERVICE}/v1/documents/task-cancel/events?after_sequence=0&limit=100"),
+    )
+    httpx_mock.add_callback(
+        cancel_response,
+        method="POST",
+        url=f"{_SERVICE}/v1/documents/task-cancel/cancel",
+    )
+
+    async with Client(_task_mcp(tmp_path)) as client:
+        task = await call_tool_task(client, "fetch", {"target": _SOURCE})
+        await asyncio.wait_for(events_requested.wait(), timeout=5)
+        await task.cancel()
+        terminal = await task.wait(timeout=5)
+        assert terminal.status == "cancelled"
+        await asyncio.wait_for(cancel_requested.wait(), timeout=5)
+        with pytest.raises(ToolError, match="was cancelled"):
+            await task.result()
+
+
+@pytest.mark.asyncio
+async def test_search_rejects_task_execution(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Ordinary search preserves its synchronous tool contract."""
+
+    async def deterministic_search(
+        _configured: Settings, query: str, count: int = 5
+    ) -> dict[str, object]:
+        return {"ok": True, "query": query, "count": count, "results": []}
+
+    monkeypatch.setattr("web_mcp.server.search_common", deterministic_search)
+    async with Client(_task_mcp(tmp_path)) as client:
+        with pytest.raises(ToolError, match="did not run as a task"):
+            await call_tool_task(client, "search", {"query": "clio"})

--- a/clio-kit-mcp-servers/web/tests/test_tool_titles.py
+++ b/clio-kit-mcp-servers/web/tests/test_tool_titles.py
@@ -11,7 +11,7 @@ async def test_all_tools_have_compact_titles() -> None:
     async with Client(mcp) as client:
         tools = await client.list_tools()
 
-    assert len(tools) == 2
+    assert {tool.name for tool in tools} == {"search", "fetch", "fetch_events"}
     for tool in tools:
         assert tool.title, f"{tool.name} is missing a title"
         assert len(tool.title) <= 24, f"{tool.name} title too long: {tool.title!r}"

--- a/clio-kit-mcp-servers/web/uv.lock
+++ b/clio-kit-mcp-servers/web/uv.lock
@@ -1,53 +1,35 @@
 version = 1
 revision = 3
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.15'",
-    "python_full_version == '3.14.*' and sys_platform == 'win32'",
-    "python_full_version == '3.14.*' and sys_platform != 'win32'",
-    "python_full_version == '3.13.*' and sys_platform == 'win32'",
-    "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform == 'win32'",
-    "python_full_version < '3.11' and sys_platform == 'win32'",
-    "python_full_version == '3.13.*' and sys_platform != 'win32'",
-    "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform != 'win32'",
-    "python_full_version < '3.11' and sys_platform != 'win32'",
+    "python_full_version == '3.14.*'",
+    "python_full_version == '3.13.*'",
+    "python_full_version < '3.13'",
 ]
 
-[[package]]
-name = "aiofile"
-version = "3.9.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.11' and sys_platform == 'win32'",
-    "python_full_version < '3.11' and sys_platform != 'win32'",
-]
-dependencies = [
-    { name = "caio" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/67/e2/d7cb819de8df6b5c1968a2756c3cb4122d4fa2b8fc768b53b7c9e5edb646/aiofile-3.9.0.tar.gz", hash = "sha256:e5ad718bb148b265b6df1b3752c4d1d83024b93da9bd599df74b9d9ffcf7919b", size = 17943, upload-time = "2024-10-08T10:39:35.846Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/50/25/da1f0b4dd970e52bf5a36c204c107e11a0c6d3ed195eba0bfbc664c312b2/aiofile-3.9.0-py3-none-any.whl", hash = "sha256:ce2f6c1571538cbdfa0143b04e16b208ecb0e9cb4148e528af8a640ed51cc8aa", size = 19539, upload-time = "2024-10-08T10:39:32.955Z" },
-]
+[options]
+prerelease-mode = "allow"
 
 [[package]]
 name = "aiofile"
 version = "3.11.1"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.15'",
-    "python_full_version == '3.14.*' and sys_platform == 'win32'",
-    "python_full_version == '3.14.*' and sys_platform != 'win32'",
-    "python_full_version == '3.13.*' and sys_platform == 'win32'",
-    "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform == 'win32'",
-    "python_full_version == '3.13.*' and sys_platform != 'win32'",
-    "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform != 'win32'",
-]
 dependencies = [
     { name = "caio" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/48/41/2fea7e193e061ce54eacc3b7bc0e6a99e4fcff43c78cf0a76dd781ed8334/aiofile-3.11.1.tar.gz", hash = "sha256:1f91912c6643d2a4e49ca4ae3514f0bf3867ce948a36d99a6411b8f4755f4cf9", size = 19342, upload-time = "2026-05-16T08:18:33.538Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/67/cd/0d76dfc5de72bde52f55f53e925c7d152d9c7906634ec1e0cbc7e8d4ad93/aiofile-3.11.1-py3-none-any.whl", hash = "sha256:ce77d14ac07f77bc2b757834a5c129321f3f705c474593deed5ab209079a52c9", size = 20446, upload-time = "2026-05-16T08:18:32.051Z" },
+]
+
+[[package]]
+name = "annotated-doc"
+version = "0.0.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/8e/38aa427ed5402449e226975b649c5dc73ccadfefeb95e6aecb8f8ea4b6b6/annotated_doc-0.0.5.tar.gz", hash = "sha256:c7e58ce09192557605d8bbd92836d7e1d520ac9580096042c0bfd197efacf1bb", size = 10758, upload-time = "2026-07-28T13:50:58.129Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/30/e900b21425a860e195f32e37657aa1f7c7f2b1bfb26f03ca209b90933c06/annotated_doc-0.0.5-py3-none-any.whl", hash = "sha256:117bac03a25ede5df5440e855b32d556049ca169ead221505badf432fed4b101", size = 5302, upload-time = "2026-07-28T13:50:57.239Z" },
 ]
 
 [[package]]
@@ -64,7 +46,6 @@ name = "anyio"
 version = "4.14.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
     { name = "idna" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
@@ -115,6 +96,15 @@ wheels = [
 ]
 
 [[package]]
+name = "async-timeout"
+version = "5.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a5/ae/136395dfbfe00dfc94da3f3e136d0b13f394cba8f4841120e34226265780/async_timeout-5.0.1.tar.gz", hash = "sha256:d9321a7a3d5a6a5e187e824d2fa0793ce379a202935782d555d6e9d2735677d3", size = 9274, upload-time = "2024-11-06T16:41:39.6Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/ba/e2081de779ca30d473f21f5b30e0e737c438205440784c7dfc81efc2b029/async_timeout-5.0.1-py3-none-any.whl", hash = "sha256:39e3809566ff85354557ec2398b55e096c8364bacac9405a7a1fa429e77fe76c", size = 6233, upload-time = "2024-11-06T16:41:37.9Z" },
+]
+
+[[package]]
 name = "attrs"
 version = "26.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -146,15 +136,6 @@ wheels = [
 ]
 
 [[package]]
-name = "backports-asyncio-runner"
-version = "1.2.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8e/ff/70dca7d7cb1cbc0edb2c6cc0c38b65cba36cccc491eca64cabd5fe7f8670/backports_asyncio_runner-1.2.0.tar.gz", hash = "sha256:a5aa7b2b7d8f8bfcaa2b57313f70792df84e32a2a746f585213373f900b42162", size = 69893, upload-time = "2025-07-02T02:27:15.685Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a0/59/76ab57e3fe74484f48a53f8e337171b4a2349e506eabe136d7e01d059086/backports_asyncio_runner-1.2.0-py3-none-any.whl", hash = "sha256:0da0a936a8aeb554eccb426dc55af3ba63bcdc69fa1a600b5bb305413a4477b5", size = 12313, upload-time = "2025-07-02T02:27:14.263Z" },
-]
-
-[[package]]
 name = "backports-tarfile"
 version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -178,16 +159,6 @@ version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f7/16/c92ca344d646e71a43b8bb353f0a6490d7f6e06210f8554c8f874e454285/brotli-1.2.0.tar.gz", hash = "sha256:e310f77e41941c13340a95976fe66a8a95b01e783d430eeaf7a2f87e0a57dd0a", size = 7388632, upload-time = "2025-11-05T18:39:42.86Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/64/10/a090475284fc4a71aed40a96f32e44a7fe5bda39687353dd977720b211b6/brotli-1.2.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:3b90b767916ac44e93a8e28ce6adf8d551e43affb512f2377c732d486ac6514e", size = 863089, upload-time = "2025-11-05T18:38:01.181Z" },
-    { url = "https://files.pythonhosted.org/packages/03/41/17416630e46c07ac21e378c3464815dd2e120b441e641bc516ac32cc51d2/brotli-1.2.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:6be67c19e0b0c56365c6a76e393b932fb0e78b3b56b711d180dd7013cb1fd984", size = 445442, upload-time = "2025-11-05T18:38:02.434Z" },
-    { url = "https://files.pythonhosted.org/packages/24/31/90cc06584deb5d4fcafc0985e37741fc6b9717926a78674bbb3ce018957e/brotli-1.2.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0bbd5b5ccd157ae7913750476d48099aaf507a79841c0d04a9db4415b14842de", size = 1532658, upload-time = "2025-11-05T18:38:03.588Z" },
-    { url = "https://files.pythonhosted.org/packages/62/17/33bf0c83bcbc96756dfd712201d87342732fad70bb3472c27e833a44a4f9/brotli-1.2.0-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:3f3c908bcc404c90c77d5a073e55271a0a498f4e0756e48127c35d91cf155947", size = 1631241, upload-time = "2025-11-05T18:38:04.582Z" },
-    { url = "https://files.pythonhosted.org/packages/48/10/f47854a1917b62efe29bc98ac18e5d4f71df03f629184575b862ef2e743b/brotli-1.2.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1b557b29782a643420e08d75aea889462a4a8796e9a6cf5621ab05a3f7da8ef2", size = 1424307, upload-time = "2025-11-05T18:38:05.587Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/b7/f88eb461719259c17483484ea8456925ee057897f8e64487d76e24e5e38d/brotli-1.2.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:81da1b229b1889f25adadc929aeb9dbc4e922bd18561b65b08dd9343cfccca84", size = 1488208, upload-time = "2025-11-05T18:38:06.613Z" },
-    { url = "https://files.pythonhosted.org/packages/26/59/41bbcb983a0c48b0b8004203e74706c6b6e99a04f3c7ca6f4f41f364db50/brotli-1.2.0-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:ff09cd8c5eec3b9d02d2408db41be150d8891c5566addce57513bf546e3d6c6d", size = 1597574, upload-time = "2025-11-05T18:38:07.838Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/e6/8c89c3bdabbe802febb4c5c6ca224a395e97913b5df0dff11b54f23c1788/brotli-1.2.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:a1778532b978d2536e79c05dac2d8cd857f6c55cd0c95ace5b03740824e0e2f1", size = 1492109, upload-time = "2025-11-05T18:38:08.816Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/9a/4b19d4310b2dbd545c0c33f176b0528fa68c3cd0754e34b2f2bcf56548ae/brotli-1.2.0-cp310-cp310-win32.whl", hash = "sha256:b232029d100d393ae3c603c8ffd7e3fe6f798c5e28ddca5feabb8e8fdb732997", size = 334461, upload-time = "2025-11-05T18:38:10.729Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/39/70981d9f47705e3c2b95c0847dfa3e7a37aa3b7c6030aedc4873081ed005/brotli-1.2.0-cp310-cp310-win_amd64.whl", hash = "sha256:ef87b8ab2704da227e83a246356a2b179ef826f550f794b2c52cddb4efbd0196", size = 369035, upload-time = "2025-11-05T18:38:11.827Z" },
     { url = "https://files.pythonhosted.org/packages/7a/ef/f285668811a9e1ddb47a18cb0b437d5fc2760d537a2fe8a57875ad6f8448/brotli-1.2.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:15b33fe93cedc4caaff8a0bd1eb7e3dab1c61bb22a0bf5bdfdfd97cd7da79744", size = 863110, upload-time = "2025-11-05T18:38:12.978Z" },
     { url = "https://files.pythonhosted.org/packages/50/62/a3b77593587010c789a9d6eaa527c79e0848b7b860402cc64bc0bc28a86c/brotli-1.2.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:898be2be399c221d2671d29eed26b6b2713a02c2119168ed914e7d00ceadb56f", size = 445438, upload-time = "2025-11-05T18:38:14.208Z" },
     { url = "https://files.pythonhosted.org/packages/cd/e1/7fadd47f40ce5549dc44493877db40292277db373da5053aff181656e16e/brotli-1.2.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:350c8348f0e76fff0a0fd6c26755d2653863279d086d3aa2c290a6a7251135dd", size = 1534420, upload-time = "2025-11-05T18:38:15.111Z" },
@@ -256,6 +227,22 @@ wheels = [
 ]
 
 [[package]]
+name = "burner-redis"
+version = "0.1.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/89/54706febafc135095b2a9d797cfbd4eed2ab1ad7819808b99b587020471b/burner_redis-0.1.7.tar.gz", hash = "sha256:7474ff092669fd11ef765411572cdafcc3d89b8054aef4ca0617be6d6be4c680", size = 638644, upload-time = "2026-05-08T15:01:42.961Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6c/5d/198bd1d22e504b3034353430703afbdb3efe6e25cb90bf52d896e1d266a7/burner_redis-0.1.7-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:f80c866996e0455d584eb3c0f3b067e411c632fb0519eab454e0968edf01e62c", size = 1288888, upload-time = "2026-05-08T15:01:26.103Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/4e/ce5c91b884ac37fcd380756402536f8810964014097950900517ce8bd30c/burner_redis-0.1.7-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:a3d9569a376b690fb5876d454e4904443332dc3ad5c0057e149fc2ad220bf599", size = 1234282, upload-time = "2026-05-08T15:01:28.286Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/c0/31c25cc88143eac2dddcc394151a0db627923d44c94376a83768552c9f13/burner_redis-0.1.7-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:20eba1917e3bca9eea5957d5700ff8defcb5a209e57a7841d005549aa0151f44", size = 1337341, upload-time = "2026-05-08T15:01:30.397Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/32/95cfa1833316ca2b6b2e58150a4900bc1ad256043cdd36198f1887618ccc/burner_redis-0.1.7-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:39111467059b8a28f15ea061d2414ec25c3e57c65759983f90f4d358e7d6a72d", size = 1366800, upload-time = "2026-05-08T15:01:32.891Z" },
+    { url = "https://files.pythonhosted.org/packages/34/ad/93c3916f053f89b7b5760da5bf855cd78b7885d480f9cfcc64f3732c1dc2/burner_redis-0.1.7-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9b5adfe99aeb8407f468078f3769b2a63e9168fea12f7709df5d2a3b152706e4", size = 1538160, upload-time = "2026-05-08T15:01:34.667Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/b9/19bae42cb124932d71168bc8e5bcb1da33aa62b908e5e632b3d298d7cb15/burner_redis-0.1.7-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:591a9d20685f9d6d22bf0c863b50b12dfcf328b06111b3f62c33cd3185d48ce0", size = 1591491, upload-time = "2026-05-08T15:01:36.708Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/30/207f47f406619a5b564355d2946c3171f84231a28b800709b5645b06a5ae/burner_redis-0.1.7-cp310-abi3-win_amd64.whl", hash = "sha256:f6cf4ac666766b32fd63940aad0c120847905fd3102c17e5b6b305f91a21d079", size = 1117564, upload-time = "2026-05-08T15:01:39.221Z" },
+    { url = "https://files.pythonhosted.org/packages/76/6f/e9beaf46c5e9fd10dfcdb889ebf7d3aa85142c650c0ab17ab284194f58e1/burner_redis-0.1.7-cp310-abi3-win_arm64.whl", hash = "sha256:458f88feeddfb40a586cc3fcbd8e9384bbdfd2a4512a695af4900e06052570d4", size = 1040407, upload-time = "2026-05-08T15:01:41.235Z" },
+]
+
+[[package]]
 name = "cachetools"
 version = "7.1.5"
 source = { registry = "https://pypi.org/simple" }
@@ -270,10 +257,6 @@ version = "0.9.25"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/92/88/b8527e1b00c1811db339a1df8bd1ae49d146fcea9d6a5c40e3a80aaeb38d/caio-0.9.25.tar.gz", hash = "sha256:16498e7f81d1d0f5a4c0ad3f2540e65fe25691376e0a5bd367f558067113ed10", size = 26781, upload-time = "2025-12-26T15:21:36.501Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6a/80/ea4ead0c5d52a9828692e7df20f0eafe8d26e671ce4883a0a146bb91049e/caio-0.9.25-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:ca6c8ecda611478b6016cb94d23fd3eb7124852b985bdec7ecaad9f3116b9619", size = 36836, upload-time = "2025-12-26T15:22:04.662Z" },
-    { url = "https://files.pythonhosted.org/packages/17/b9/36715c97c873649d1029001578f901b50250916295e3dddf20c865438865/caio-0.9.25-cp310-cp310-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:db9b5681e4af8176159f0d6598e73b2279bb661e718c7ac23342c550bd78c241", size = 79695, upload-time = "2025-12-26T15:22:18.818Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/ab/07080ecb1adb55a02cbd8ec0126aa8e43af343ffabb6a71125b42670e9a1/caio-0.9.25-cp310-cp310-manylinux_2_34_aarch64.whl", hash = "sha256:bf61d7d0c4fd10ffdd98ca47f7e8db4d7408e74649ffaf4bef40b029ada3c21b", size = 79457, upload-time = "2026-03-04T22:08:16.024Z" },
-    { url = "https://files.pythonhosted.org/packages/88/95/dd55757bb671eb4c376e006c04e83beb413486821f517792ea603ef216e9/caio-0.9.25-cp310-cp310-manylinux_2_34_x86_64.whl", hash = "sha256:ab52e5b643f8bbd64a0605d9412796cd3464cb8ca88593b13e95a0f0b10508ae", size = 77705, upload-time = "2026-03-04T22:08:17.202Z" },
     { url = "https://files.pythonhosted.org/packages/ec/90/543f556fcfcfa270713eef906b6352ab048e1e557afec12925c991dc93c2/caio-0.9.25-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:d6956d9e4a27021c8bd6c9677f3a59eb1d820cc32d0343cea7961a03b1371965", size = 36839, upload-time = "2025-12-26T15:21:40.267Z" },
     { url = "https://files.pythonhosted.org/packages/51/3b/36f3e8ec38dafe8de4831decd2e44c69303d2a3892d16ceda42afed44e1b/caio-0.9.25-cp311-cp311-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:bf84bfa039f25ad91f4f52944452a5f6f405e8afab4d445450978cd6241d1478", size = 80255, upload-time = "2025-12-26T15:22:20.271Z" },
     { url = "https://files.pythonhosted.org/packages/df/ce/65e64867d928e6aff1b4f0e12dba0ef6d5bf412c240dc1df9d421ac10573/caio-0.9.25-cp311-cp311-manylinux_2_34_aarch64.whl", hash = "sha256:ae3d62587332bce600f861a8de6256b1014d6485cfd25d68c15caf1611dd1f7c", size = 80052, upload-time = "2026-03-04T22:08:20.402Z" },
@@ -311,18 +294,6 @@ dependencies = [
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/57/5f/ff100cae70ebe9d8df1c01a00e510e45d9adb5c1fdda84791b199141de97/cffi-2.1.0.tar.gz", hash = "sha256:efc1cdd798b1aaf39b4610bba7aad28c9bea9b910f25c784ccf9ec1fa719d1f9", size = 531036, upload-time = "2026-07-06T21:34:30.382Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c0/e9/6d7724983b3d5a0908dbf74f64038ade77c18646ff6636ec7894fd392ce1/cffi-2.1.0-cp310-cp310-macosx_10_15_x86_64.whl", hash = "sha256:b65f590ef2a44640f9a05dbb548a429b4ade77913ce683ac8b1480777658a6c0", size = 183837, upload-time = "2026-07-06T21:32:09.655Z" },
-    { url = "https://files.pythonhosted.org/packages/69/aa/24580a278de21fd7322635556334d9b535f1cbc00b0a3919447cdf464c65/cffi-2.1.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:164bff1657b2a74f0b6d54e11c9b375bc97b931f2ca9c43fcf875838da1570dd", size = 184226, upload-time = "2026-07-06T21:32:11.196Z" },
-    { url = "https://files.pythonhosted.org/packages/88/a9/02cae418ec4beb282ace11958d9d4737793439d561fadc7e6d56f2e2b354/cffi-2.1.0-cp310-cp310-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:c941bb58d5a6e1c3892d86e42927ed6c180302f07e6d395d08c416e594b98b46", size = 211107, upload-time = "2026-07-06T21:32:12.328Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/30/c806937ed5e4c2c7ac30d9d6b76b5dc57ff8b75d83800d9bb11a8253cf2a/cffi-2.1.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a016194dbe13d14ee9556e734b772d8d67b947092b268d757fd4290e3ba2dfc2", size = 218733, upload-time = "2026-07-06T21:32:13.67Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/cf/398272b8bbfd58aa314fda5a7f1cdbb26d1d78ae324a11211521315dd1f0/cffi-2.1.0-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:03e9810d18c646077e501f661b682fbf5dee4676048527ca3cffe66faa9960dd", size = 205543, upload-time = "2026-07-06T21:32:15.148Z" },
-    { url = "https://files.pythonhosted.org/packages/45/ca/f91641185cdd90c36d317a9dc7f85e88ef8682d8b300977baff5e23c35d8/cffi-2.1.0-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:19c54ac121cad98450b4896fa9a43ee0180d57bc4bc911a33db6cab1efab6cd3", size = 205460, upload-time = "2026-07-06T21:32:16.479Z" },
-    { url = "https://files.pythonhosted.org/packages/38/66/04781a77b411f0bb5b234d62c1814754ab75ebe455ccff1b08e8d7aae98f/cffi-2.1.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d433a51f1870e43a13b6732f92aaf540ff77c2015097c78556f75a2d6c030e0", size = 218760, upload-time = "2026-07-06T21:32:17.98Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/9a/bb1d5ed9c3fcae158e9f6391bf309c95d98c2ac37ed56573228471d0af5e/cffi-2.1.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:3d7f118b5adbfdfead90c25822690b02bc8074fba949bb7858bec4ebd55adb43", size = 221230, upload-time = "2026-07-06T21:32:19.407Z" },
-    { url = "https://files.pythonhosted.org/packages/41/aa/3c1409cdd26094efacd1c36c66e0a6eb9d4296e4fd4f9901b8b2042f4323/cffi-2.1.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:c5f5df567f6eb216de69be06ce55c8b714090fae02b18a3b40da8163b8c5fa9c", size = 213524, upload-time = "2026-07-06T21:32:20.828Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/75/74dfb7c3fc6ebbd408038476bd4c1d7e925c62614e7b9c534ecc34218288/cffi-2.1.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:11b3fb55f4f8ad92274ed26705f65d8f91457de71f5380061eb6d125a768fecd", size = 220341, upload-time = "2026-07-06T21:32:21.9Z" },
-    { url = "https://files.pythonhosted.org/packages/70/b6/9003c33a3e7d2c1306f5962e646457dcfe5a8cd8fce6bbe02d7af25db783/cffi-2.1.0-cp310-cp310-win32.whl", hash = "sha256:9d72af0cf10a76a600a9690078fe31c63b9588c8e86bf9fd353f713c84b5db0f", size = 174578, upload-time = "2026-07-06T21:32:23.073Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/26/710688310447531c7a22f857c7f79d9855ec18b03e04494ced723fb37e2f/cffi-2.1.0-cp310-cp310-win_amd64.whl", hash = "sha256:fb62edb5bb52cca65fab91a63afa7561607120d26090a7e8fda6fb9f064726da", size = 185071, upload-time = "2026-07-06T21:32:24.671Z" },
     { url = "https://files.pythonhosted.org/packages/d3/67/85c89a59ba36a671e79638f44d466749f08179266a57e4f2ffdf92174072/cffi-2.1.0-cp311-cp311-macosx_10_15_x86_64.whl", hash = "sha256:02cb7ff33ded4f1532476731f89ede53e2e488a8e6205515a82144246ffa7dcc", size = 183845, upload-time = "2026-07-06T21:32:26.32Z" },
     { url = "https://files.pythonhosted.org/packages/ea/dd/e3b0baa2d3d6a857ac72b7efbf18e32e487c9cdafcc13049ad765495b15e/cffi-2.1.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f5bce581e6b8c235e566a14768a943b172ada3ed73537bb0c0be1edee312d4e7", size = 184186, upload-time = "2026-07-06T21:32:28.025Z" },
     { url = "https://files.pythonhosted.org/packages/65/68/9f3ef890cf3c6ab97bd531c5677f67613d302165d16f8142b2811782a614/cffi-2.1.0-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:30b65779d598c370374fefabf138d456fd6f3216bfa7bedfab1ba82025b0cd93", size = 211892, upload-time = "2026-07-06T21:32:29.565Z" },
@@ -418,12 +389,6 @@ version = "7.4.3"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/19/b6/9df434a8eeba2e6628c465a1dfa31034228ef79b26f76f46278f4ef7e49d/chardet-7.4.3.tar.gz", hash = "sha256:cc1d4eb92a4ec1c2df3b490836ffa46922e599d34ce0bb75cf41fd2bf6303d56", size = 784800, upload-time = "2026-04-13T21:33:39.803Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6b/1b/7f73766c119a1344eb69e31890ede7c5825ce03d69a9d29292d1bd1cfa1b/chardet-7.4.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:c0c79b13c9908ac7dfe0a74116ebc9a0f28b2319d23c32f3dfcdfbe1279c7eaf", size = 874121, upload-time = "2026-04-13T21:32:47.065Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/02/b677c8203d34dad6c2af48287bb1f8c5dff63db2094636fbe634b555b7fb/chardet-7.4.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:bba8bea1b28d927b3e99e47deafe53658d34497c0a891d95ff1ba8ff6663f01c", size = 856900, upload-time = "2026-04-13T21:32:48.893Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/4b/1361a485a999d97cac4c895e615326f69a639532a52ef365a468bd09bad1/chardet-7.4.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:23163921dccf3103ce59540b0443c106d2c0a0ff2e0503e05196f5e6fdea453f", size = 876634, upload-time = "2026-04-13T21:32:50.238Z" },
-    { url = "https://files.pythonhosted.org/packages/87/23/e31c8ad33aa448f0845fd58af5fc22da1626407616d09df4973b2b34f477/chardet-7.4.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cfb54563fe5f130da17c44c6a4e2e8052ba628e5ab4eab7ef8190f736f0f8f72", size = 886497, upload-time = "2026-04-13T21:32:52.111Z" },
-    { url = "https://files.pythonhosted.org/packages/18/ef/ea4edec8c87f7e6eda02673acc68fe48725e564fc5a1865782efb53d5598/chardet-7.4.3-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3990fffcc6a6045f2234ab72752ad037e3b2d48c72037f244d42738db397eb75", size = 881061, upload-time = "2026-04-13T21:32:53.755Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/11/fc10600da98541777d720ad9e6bc040c0e0af1adb92e27142e35158957cb/chardet-7.4.3-cp310-cp310-win_amd64.whl", hash = "sha256:c7116b0452994734ccff35e154b44240090eb0f4f74b9106292668133557c175", size = 942533, upload-time = "2026-04-13T21:32:55.134Z" },
     { url = "https://files.pythonhosted.org/packages/19/52/505c207f334d51e937cbaa27ff95776e16e2d120e13cbe491cd7b3a70b50/chardet-7.4.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:25a862cddc6a9ac07023e808aedd297115345fbaabc2690479481ddc0f980e09", size = 870747, upload-time = "2026-04-13T21:32:56.916Z" },
     { url = "https://files.pythonhosted.org/packages/14/4b/d3c79495dee4831b8bebca2790e72cb90f0c5849c940570a7c7e5b70b952/chardet-7.4.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7005c88da26fd95d8abb8acbe6281d833e9a9181b03cf49b4546c4555389bd97", size = 853210, upload-time = "2026-04-13T21:32:58.309Z" },
     { url = "https://files.pythonhosted.org/packages/b9/99/f6a822ad1bde25a4c38dc3e770485e78e0893dfd871cd6e18ed3ea3a795e/chardet-7.4.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dc50f28bad067393cce0af9091052c3b8df7a23115afd8ba7b2e0947f0cef1f8", size = 873625, upload-time = "2026-04-13T21:32:59.606Z" },
@@ -461,19 +426,6 @@ version = "3.4.9"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/bd/2a/23f34ec9d04624958e137efdc394888716353190e75f25dd22c7a2c7a8aa/charset_normalizer-3.4.9.tar.gz", hash = "sha256:673611bbd43f0810bec0b0f028ddeaaa501190339cac411f347ac76917c3ae7b", size = 152439, upload-time = "2026-07-07T14:34:58.454Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ad/81/8e983840c6e5b93b33c2ba81aa3d52c2e42f0e9a690ce7607a2e61da4a5c/charset_normalizer-3.4.9-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:cd6280cf040f233bd7d3407b743b4b4c74f70e8e1c4199cb112a62c941c0772a", size = 322240, upload-time = "2026-07-07T14:32:36.236Z" },
-    { url = "https://files.pythonhosted.org/packages/de/d1/b4319dc3229d8272fba305e206fc0a148e2de8d4087917ce62ae6382f359/charset_normalizer-3.4.9-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aa99adc8f081b475a12843953db36831eaf83ec33eb46a90629ca6a5de45a616", size = 216475, upload-time = "2026-07-07T14:32:38.142Z" },
-    { url = "https://files.pythonhosted.org/packages/80/33/6c99c1b3e6b8bf730e1bc809b9a2608f224145069114c479a2e9e1494346/charset_normalizer-3.4.9-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c1225416b463483160e4af85d5fc3a9690ccb53fd4b1865a6437825f5ede3209", size = 238670, upload-time = "2026-07-07T14:32:39.658Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/f4/ffbb83546e1f198ecc70ecd372b65cf2b50f9068b380abd67640f17a8e18/charset_normalizer-3.4.9-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:16d10d789dd9bcca1173c95af82c58433122564b7bc39385124be735a35cbe99", size = 233476, upload-time = "2026-07-07T14:32:41.155Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/5f/b98b8da398637b551e427e7be922bdec19177dc54d6811dcdaa503f23aac/charset_normalizer-3.4.9-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9bb41182d93ea91f60b4bc8fbf4c820c69ef8a12ab2d917f3f1834f1acad07e8", size = 223817, upload-time = "2026-07-07T14:32:42.592Z" },
-    { url = "https://files.pythonhosted.org/packages/36/31/a276bb2e66243072a3fd06fdcab9cbb61a305b02143d70d2bda21d888fa8/charset_normalizer-3.4.9-cp310-cp310-manylinux_2_31_armv7l.whl", hash = "sha256:bcf74c1df76758a395bf0af608c04c82257523f55c9868b334f06270d0f2112b", size = 207974, upload-time = "2026-07-07T14:32:44.258Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/be/7ee4453d7e88dfbc4104ccd34900b9f2c7c17dac22881865fe0e82424a25/charset_normalizer-3.4.9-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b5314963fce9b0b12743891de876e724997864ee22aa496f903f426c7e2fa5b2", size = 221655, upload-time = "2026-07-07T14:32:45.64Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/85/181c652953eb5276d198f375b1dd641047392050098100a3a02d6534f657/charset_normalizer-3.4.9-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:e9701d0049d92c16703a42771b98d560b95248949f23f8cf7b4eddd201814fb9", size = 219229, upload-time = "2026-07-07T14:32:47.376Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/e7/aaf6da33fc9f4691cda8f7efbc9f69179d3d39ec8a4799baf273ee1d8db0/charset_normalizer-3.4.9-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:65a7ff3f705e57d392f7261b6d0550fe137c3019477431f1c355e0db0a7d3e15", size = 209704, upload-time = "2026-07-07T14:32:48.855Z" },
-    { url = "https://files.pythonhosted.org/packages/63/01/f2fb3bd3a73be48b173ee0c6aa8d2497af97d5663a8c4c4b491de4c62f7a/charset_normalizer-3.4.9-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:79580094b00d1789d1f93ea55bc43cb2f611910c72235b7657f3482ddcc1b22d", size = 226243, upload-time = "2026-07-07T14:32:50.239Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/02/c57a22739fe05246b0b5783b3bfb6afaac4eebb46f3ececdfb2f048f780e/charset_normalizer-3.4.9-cp310-cp310-win32.whl", hash = "sha256:432786d3561e69aeeae6c7e8648964ce0ad05736120135601f87ac26b9c83381", size = 150935, upload-time = "2026-07-07T14:32:51.676Z" },
-    { url = "https://files.pythonhosted.org/packages/37/8d/ca39a7559a4797505530d084fd3a49a2c959efbbbff146302fb7be4e3b35/charset_normalizer-3.4.9-cp310-cp310-win_amd64.whl", hash = "sha256:8c041122946b7ba21bb32c45b1aa57b1be35527690aeb3c5c234521085632eee", size = 162314, upload-time = "2026-07-07T14:32:53.193Z" },
-    { url = "https://files.pythonhosted.org/packages/01/da/a44bd7a13d426e69e4894557106cd58669097bfad4a8681123b618fbfc5d/charset_normalizer-3.4.9-cp310-cp310-win_arm64.whl", hash = "sha256:375b83ed0aecfce76c16d198fbc21f3b11b337d68662bea0a995046682a11419", size = 153075, upload-time = "2026-07-07T14:32:54.554Z" },
     { url = "https://files.pythonhosted.org/packages/0b/e3/85ec501f206fb049259288c1f3506e53876937fb00edb47009348e66756b/charset_normalizer-3.4.9-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:0e94703ec9684807f20cfb5eed95c70f67f2a8f21ad620146d7b5a13677b93e5", size = 317075, upload-time = "2026-07-07T14:32:56.021Z" },
     { url = "https://files.pythonhosted.org/packages/c3/69/2a5385192e67175f7d8bd5ce4f57c24bc956439adeae5c13a99aa28a53d1/charset_normalizer-3.4.9-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2a441ea71902098ffe78c5abe6c494f44160b4af614ed16c3d9a3b1d17fd8ee2", size = 213837, upload-time = "2026-07-07T14:32:57.78Z" },
     { url = "https://files.pythonhosted.org/packages/b3/46/03ddc7da576d814fe0a36dd1f0fd3258e95404b4b2e3c026b7923d7e133f/charset_normalizer-3.4.9-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:304b13570067b2547562e308af560b3963857b1fa90bd6afd978130130fe2d6a", size = 235503, upload-time = "2026-07-07T14:32:59.205Z" },
@@ -555,6 +507,15 @@ wheels = [
 ]
 
 [[package]]
+name = "cloudpickle"
+version = "3.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/fb/576f067976d320f5f0114a8d9fa1215425441bb35627b1993e5afd8111e5/cloudpickle-3.1.2.tar.gz", hash = "sha256:7fda9eb655c9c230dab534f1983763de5835249750e85fbcef43aaa30a9a2414", size = 22330, upload-time = "2025-11-03T09:25:26.604Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl", hash = "sha256:9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a", size = 22228, upload-time = "2025-11-03T09:25:25.534Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -583,20 +544,6 @@ version = "7.15.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/76/d0/55fe630f4cf94e3fcba868240fad8c8cdd1f764e2a932f8926347e6ec4cd/coverage-7.15.2.tar.gz", hash = "sha256:3df60dc267f0a2ca23cb7a9ab1109c62b9335ffbf519fcfe167157c28c09b81d", size = 927741, upload-time = "2026-07-15T18:56:19.558Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/10/03/060ce69008ac97bbc01b1411b3e55b61f6f015659400b46749b662107831/coverage-7.15.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9b5bd92ff1ec22e535eab0de75fa6db021992791f461a2aceb7822c625a1187d", size = 221284, upload-time = "2026-07-15T18:53:29.52Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/a3/d936e8b53edd9684100a6aefaf3fcabaa54728fe33324436c8d279c047aa/coverage-7.15.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:44826758cfe73fcd0e6af5deb4ba6d5417cc1d13df3acb35c93484a11160f846", size = 221799, upload-time = "2026-07-15T18:53:31.708Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/a3/ca234b06aec7ee28226f11d39a696b4481fe5eddfce8e03bf39979bb8ffb/coverage-7.15.2-cp310-cp310-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:09f5c6ec5901f667bd97dd140b5b9a2586b10efec66f46fb1e6d8135f8b95bdf", size = 248544, upload-time = "2026-07-15T18:53:33.212Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/89/dda79527bb7573ba91828b2fb91b3105d87378d6a2749ca0c0924ce0addd/coverage-7.15.2-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:1d16e3a7104ea84f03e614611b3edbf6fb6892554b3ab0fe7fbb3f2b2ef04376", size = 250374, upload-time = "2026-07-15T18:53:34.683Z" },
-    { url = "https://files.pythonhosted.org/packages/67/c6/c33755a34572f81f49a8c0cdf6b622f35ccb3238b136e1909daf0cdd4319/coverage-7.15.2-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d46e62cb35d91e6e2589fda6d28074426b0e276422b5d2ebef2c6b11dc60dbfd", size = 252239, upload-time = "2026-07-15T18:53:36.205Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/6f/dc341741b375be53a5baeee5b4bf0f0e525d38caed428f7932d23bb7bcb1/coverage-7.15.2-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:dfd3db045e95960ae3683059571e597fda7cc610106a8916f77c5839048c1deb", size = 254150, upload-time = "2026-07-15T18:53:37.863Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/8d/966a18a5b195cb4e77b14c53f5f3dce22b5da05e6de7fafd1e08f2d2067a/coverage-7.15.2-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:affd532502d34c0472d0cdb181325c89f1d2c44992fef0c17e88e7b1576259a1", size = 249234, upload-time = "2026-07-15T18:53:39.394Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/8b/8b2e367496ab48484d48e79984fec76cdc1b7cb5d3a00ee799a5602e3ec9/coverage-7.15.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:d17d7512151fedfcc64c1821a8977fc9be0dbf495754669afcab7b57abc98ae9", size = 250276, upload-time = "2026-07-15T18:53:41.027Z" },
-    { url = "https://files.pythonhosted.org/packages/63/92/1199318a200eb6c8c6ce0192c892c8710ac791abbe0f35099294620bbfda/coverage-7.15.2-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:e26ff680768b8095e8874aabe0e9d3a47a2a9f176a8340d05f8604c56457c23a", size = 248283, upload-time = "2026-07-15T18:53:42.557Z" },
-    { url = "https://files.pythonhosted.org/packages/56/da/be284a55c5619bda891a89c27dfd59324a2c6a14d755cf6aac6960ceebeb/coverage-7.15.2-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:7e8f27131dc7cd53de2c137dd207b3720919320b3c20d499dc30aa9ee6173287", size = 252093, upload-time = "2026-07-15T18:53:44.271Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/53/ee112da833ddd77b73c6d781a98029b45b584b136615b4900ed0569f887e/coverage-7.15.2-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:728a33676d4c3f0db977990a4bd421dcaa3be3e53b5b6273036fff6666008e89", size = 248552, upload-time = "2026-07-15T18:53:45.7Z" },
-    { url = "https://files.pythonhosted.org/packages/82/6a/802cfc802e9113494c80bf3f284cd4d72faeb1f24e244f61046af364f2ca/coverage-7.15.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:29c052f7c83ccfcc5c577eaae025d2e4a9bb80daf03c0ac31c996e83b000ce88", size = 249154, upload-time = "2026-07-15T18:53:47.256Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/65/529808e91d651147edae408fd9e894abc3b8cad7f3e594bbc36719a3e13a/coverage-7.15.2-cp310-cp310-win32.whl", hash = "sha256:1268ac8fb9ddcd783d3948dbabaf80a5d53bfdaa0575e873e2139a692f797443", size = 223334, upload-time = "2026-07-15T18:53:48.768Z" },
-    { url = "https://files.pythonhosted.org/packages/68/0f/0e1829d7001130876dfbc0b4e1c737ea7c155b809e3e4a98a0aa268e2369/coverage-7.15.2-cp310-cp310-win_amd64.whl", hash = "sha256:9f4432898c4bf2fba0435bbe35dd4437d7264565e5a88a21f5b49d8662a6b629", size = 223959, upload-time = "2026-07-15T18:53:50.429Z" },
     { url = "https://files.pythonhosted.org/packages/7d/3a/54536704f507d4573bf9161c4d0dd3dd59b6d85e48c664e901b6844d8e33/coverage-7.15.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:2f1ec6f304b156669cfde653b4e9a953f5de87e247ea02ac599bce0ab2744036", size = 221414, upload-time = "2026-07-15T18:53:51.941Z" },
     { url = "https://files.pythonhosted.org/packages/b6/d9/8ba925d29743e3577b21e4d8c11a702b76bc93c41e7fdfd1177af63d4b8d/coverage-7.15.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4d3361879d736f469f45723c11ea1a5bbdaf1f6928f0e632c940378b5aa9b660", size = 221913, upload-time = "2026-07-15T18:53:53.682Z" },
     { url = "https://files.pythonhosted.org/packages/09/54/a855f3aa0187f2b431ade4e4791b77b56282cfb5d201c83ec26a31b5b36a/coverage-7.15.2-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:c6a98d698f9e2c8008d0370ec7fc452ebfcc530002ae2d0061170d768b992589", size = 252332, upload-time = "2026-07-15T18:53:55.467Z" },
@@ -681,12 +628,19 @@ toml = [
 ]
 
 [[package]]
+name = "cronsim"
+version = "2.7"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/1a/02f105147f7f2e06ed4f734ff5a6439590bb275a53dd91fc73df6312298a/cronsim-2.7-py3-none-any.whl", hash = "sha256:1e1431fa08c51dc7f72e67e571c7c7a09af26420169b607badd4ca9677ffad1e", size = 14213, upload-time = "2025-10-21T16:38:20.431Z" },
+]
+
+[[package]]
 name = "cryptography"
 version = "50.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/de/41/6cbdcf9142d00fe82836fbb51e503e58088575cf7a0fe1dbff6695bf0840/cryptography-50.0.0.tar.gz", hash = "sha256:eeac2acb5a20ed25e0ad6d1df9891a520b78b404266b6d11778f25d5d691a6c9", size = 880201, upload-time = "2026-07-31T14:25:10.11Z" }
 wheels = [
@@ -755,8 +709,6 @@ dependencies = [
     { name = "docstring-parser" },
     { name = "rich" },
     { name = "rich-rst" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3d/47/32d992e829f63aedea5b93360db23c8882c9bbbde094bcf0fff899ea8a3b/cyclopts-4.22.1.tar.gz", hash = "sha256:49cd3779da7113a96ac5c23b151aa61ac9ae1b4b1fe813594d207ca843c97892", size = 193551, upload-time = "2026-07-20T17:38:59.38Z" }
 wheels = [
@@ -848,19 +800,24 @@ wheels = [
 
 [[package]]
 name = "fastmcp"
-version = "4.0.0b1"
+version = "4.0.0b3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "fastmcp-slim", extra = ["client", "server"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/eb/fd/e513c524bb3e296203f65bd8e9e726e9236bd3b59315e7cbdeb095662c01/fastmcp-4.0.0b1.tar.gz", hash = "sha256:f98d69588a73e1672840558641d5d0f111e207baffe001f3465713a53ebb6b4c", size = 42065171, upload-time = "2026-07-28T21:18:15.312Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/01/be88a40071d7bdce1b207c1acd2522167425393cbad33c40a778ce1f656d/fastmcp-4.0.0b3.tar.gz", hash = "sha256:1edea49ef12f6a47721ec69324bba31302eb0faccff939f2851026992fa62f93", size = 42163497, upload-time = "2026-08-14T17:48:01.224Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/66/41b503ef852eff83f3f0c04f46cd1fc738c5374fd509384fc6b96e45918f/fastmcp-4.0.0b1-py3-none-any.whl", hash = "sha256:d66eb7b0763ffff2ae0fc573778ea25604dcb7e59769e5afaf9851a806eb1129", size = 8064, upload-time = "2026-07-28T21:18:12.688Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/0c/6cb98b816b0836fd8ad120761c5cb76e1c5a3a71dfd3b0549b37a3b52a54/fastmcp-4.0.0b3-py3-none-any.whl", hash = "sha256:4a68fb3877f160ca18ca5be4ee80c0d68c89f922b927734c36e6e99827d814fc", size = 8089, upload-time = "2026-08-14T17:47:58.59Z" },
+]
+
+[package.optional-dependencies]
+tasks = [
+    { name = "fastmcp-tasks" },
 ]
 
 [[package]]
 name = "fastmcp-slim"
-version = "4.0.0b1"
+version = "4.0.0b3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "mcp-types" },
@@ -871,9 +828,9 @@ dependencies = [
     { name = "rich" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bc/33/f207166aac88c6d8be1b2a82c54fecd1e04b075ef12d027aa17b3134fc0f/fastmcp_slim-4.0.0b1.tar.gz", hash = "sha256:158efb25720e0cb301711146b2d05d181de95cd91fe70e87c251ad14b123d665", size = 660081, upload-time = "2026-07-28T21:17:50.171Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c0/35/01d59a0a8c4a7a7125f1f3b01f22b7283fea1942b7e1c5cea171bea624cc/fastmcp_slim-4.0.0b3.tar.gz", hash = "sha256:0647126ce70ebf0890912954ffb5cd162fb63bb9169a81b078ae960c8c09830e", size = 674255, upload-time = "2026-08-14T17:47:36.064Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/90/5d/fbe192d2ab50bb31b284fd0eb6c72d4347df7a57d836bee4f1973ffd1d7d/fastmcp_slim-4.0.0b1-py3-none-any.whl", hash = "sha256:dd907a3db5a2f479ca958c30157e227b4f7b340a56d333eb91de95719254597a", size = 827975, upload-time = "2026-07-28T21:17:48.747Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/fa/63bc5d73f77bcf52ae05c184d18ad2ff9c5b35da0d9b55500e74a5377fef/fastmcp_slim-4.0.0b3-py3-none-any.whl", hash = "sha256:59ea0be9978b45cfe3ab47f3b7413b36a5b4b929dff723d48235899eada8bb42", size = 846345, upload-time = "2026-08-14T17:47:34.541Z" },
 ]
 
 [package.optional-dependencies]
@@ -908,6 +865,20 @@ server = [
     { name = "uvicorn" },
     { name = "watchfiles" },
     { name = "websockets" },
+]
+
+[[package]]
+name = "fastmcp-tasks"
+version = "4.0.0b3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "fastmcp-slim", extra = ["server"] },
+    { name = "pydocket" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/57/a2/fe63f980f5cd79512fb1a7f0e39cf0314cfca52ef834a3ff941ff4abda60/fastmcp_tasks-4.0.0b3.tar.gz", hash = "sha256:92929a6444e5ec99addffade9f953a755a56ada91f9d04c10854736ef117e051", size = 54235, upload-time = "2026-08-14T17:47:57.503Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ad/59/1f81ddabc2fee157532dfcbdd286dae3936f549fc7a95bc45497d8cdeceb/fastmcp_tasks-4.0.0b3-py3-none-any.whl", hash = "sha256:8b595dbd4382bec3a0b8767b04194a961dffecf01ca613ad987aae95f80355bc", size = 65414, upload-time = "2026-08-14T17:47:56.507Z" },
 ]
 
 [[package]]
@@ -1148,8 +1119,7 @@ dependencies = [
     { name = "attrs" },
     { name = "jsonschema-specifications" },
     { name = "referencing" },
-    { name = "rpds-py", version = "0.30.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "rpds-py", version = "2026.6.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "rpds-py" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
 wheels = [
@@ -1219,18 +1189,6 @@ version = "0.13.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/dc/2f/3908645ddddab7120b46295e541ead308109fa48dbec7d67d7a778870d60/librt-0.13.0.tar.gz", hash = "sha256:1d2a610c14ac0d0750ee0a3ab8548e83155258387891caaca04def4bf7289781", size = 211402, upload-time = "2026-07-08T12:26:29.834Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/89/2f/ec5241c38e7fa0fe6c26bfc450e78b9489a6c3c08b394b85d2c10e506975/librt-0.13.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:34e47058fcc69a313293d6dee94216a4f30c929ae6f2476e58c5ba635aa639d5", size = 148654, upload-time = "2026-07-08T12:24:30.622Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/1a/d651e18d3ee7aa2879322368c4f278bb7ecaa6b90caadfdec4ebfa8389f3/librt-0.13.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:dbdd5b6509d0c2a8fe72cf494c299a61dbd58142a90a4190664ae159e4a7b547", size = 153537, upload-time = "2026-07-08T12:24:31.773Z" },
-    { url = "https://files.pythonhosted.org/packages/45/18/10bff2122577246009d9619b6569596daf69b7648812f997ca9ca0426f60/librt-0.13.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2e56ea4ee4df77585a6b5c138f6538680886024fa559f5b55bd14b12e98e67b2", size = 494336, upload-time = "2026-07-08T12:24:33.079Z" },
-    { url = "https://files.pythonhosted.org/packages/67/69/87dfee871b852970f137fdeae8e2ca356c5ab38e6f21d2a3299535fc3159/librt-0.13.0-cp310-cp310-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:f1f9cc4d09a46d9cb3c2063ae100629d3f52a6517c3c08c2f4c9828261883929", size = 485393, upload-time = "2026-07-08T12:24:34.324Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/d5/625447a8c0441ff5f15f4ac5e1d323fb9d4d256ebfde7a3c8e003f646057/librt-0.13.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f125f5d46b20f89dc5587a55cc416b4ba2a5b2ffda36d048ee120e17598a653a", size = 515382, upload-time = "2026-07-08T12:24:35.575Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/d8/1c8c49ea04235960426444deece9092a6b3a9587a850a81bae2335317411/librt-0.13.0-cp310-cp310-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:2608d3b39f9e0b4a66a130d9150c615cba40a5090d25eeeaa225e0e46de8c0ac", size = 509483, upload-time = "2026-07-08T12:24:36.923Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/65/f1760fc48050e215201a03506c32b7270159088d01f64557b53e39e74a45/librt-0.13.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:9fd35e95ab5e45c3901d37110263c7db85a961110f5460588fe37f8c131f88a7", size = 532503, upload-time = "2026-07-08T12:24:38.203Z" },
-    { url = "https://files.pythonhosted.org/packages/18/1b/793e281dcf494879eff99f642b63ebc9c7c58694a1c2d1e93362a22c7041/librt-0.13.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:5f31b0aa13c9b04370d4da6be1ab7779776b3a075cceb6747a39a4be85fe1e40", size = 537027, upload-time = "2026-07-08T12:24:39.34Z" },
-    { url = "https://files.pythonhosted.org/packages/69/45/0801bbb40c9eea795d3dd3ce91c4c5f3fe7d42d23ec4be3e8cb283bcc754/librt-0.13.0-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:0b795f5fc70fbbb787ceaf79bb3a0d627bcc33c53de51741755263ec406b775a", size = 517100, upload-time = "2026-07-08T12:24:40.907Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/6c/eb5f514f8e29d4924bc0ff4601dd7b4175557e182e7c0721e84cffa39b8a/librt-0.13.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:36b306a623aaad96fe4b378692b54f9c0789fccd833b9851753d5fbf6138cfde", size = 558653, upload-time = "2026-07-08T12:24:42.359Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/bf/f140100d1b59fe87ff40b5ecbb4e27924335b189a784e230ee465452f6c2/librt-0.13.0-cp310-cp310-win32.whl", hash = "sha256:a3762e75fcac8c9e4dacaaf438bffd9003e2ca2c531b756f3c0035deefa674c8", size = 104402, upload-time = "2026-07-08T12:24:43.668Z" },
-    { url = "https://files.pythonhosted.org/packages/22/7c/57e40fef7cfb61869341cb28bdcefe8a950bebcbecca74a397bae14dce4a/librt-0.13.0-cp310-cp310-win_amd64.whl", hash = "sha256:d63bae12a8aeb51380be3438e4dc4bd27354d0f8e19166b2f44e3e94d6f552dc", size = 125002, upload-time = "2026-07-08T12:24:44.793Z" },
     { url = "https://files.pythonhosted.org/packages/89/25/a6498964cfeec270c468cffdc118f69c29b412593610d55fa1327ca51ff4/librt-0.13.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1b5a7bbff495baedbd9b916c367d66854008f8f3b575908ded477c499dc60082", size = 148029, upload-time = "2026-07-08T12:24:45.961Z" },
     { url = "https://files.pythonhosted.org/packages/78/59/dc86d1bffd8e0c2818bace29d9f7783cfbb8e0673bf3673b5bbd5bbe0420/librt-0.13.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:34bc7938b9fdf14fe32a406c19c71faf894c5cee7e7474bd0be2f17200b82d14", size = 153036, upload-time = "2026-07-08T12:24:47.257Z" },
     { url = "https://files.pythonhosted.org/packages/29/3f/b923826660f02f286186cd9303d52bb05ced0a13708edc104dc8480920e3/librt-0.13.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f40e56b61b41be5f7dec938cfeffd660668cf4b5e72c78e7bd671d66b7bc2c79", size = 493062, upload-time = "2026-07-08T12:24:48.483Z" },
@@ -1306,22 +1264,6 @@ version = "6.1.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/05/3b/aab6728cae887456f409b4d75e8a01856e4f04bd510de38052a47768b680/lxml-6.1.1.tar.gz", hash = "sha256:ba96ae44888e0185281e937633a743ea90d5a196c6000f82565ebb0580012d40", size = 4197430, upload-time = "2026-05-18T19:19:06.424Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/12/da/dbe4dfc01ac226fb0504fad035f4d69f3202f3502e20e68537631daddd96/lxml-6.1.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:09dd5b7075dc2f7709654a46543ba1ea3c2e217b2ed8fbd413a8a945a0f40f60", size = 8541124, upload-time = "2026-05-18T19:17:11.589Z" },
-    { url = "https://files.pythonhosted.org/packages/78/20/f7095ed9fc2c025f9cfe71cc6ec9f1feb05624edc1812423b5f1aecf3d4b/lxml-6.1.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:f6ac4ef4d82dff54670227a69c67782ae0b811b5cf6b17954f1e8f7502fc0d1d", size = 4602783, upload-time = "2026-05-18T19:17:20.888Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/a4/65c63ca98bd129f6cff7b8c2fa48953ab058cc6005b541354e7dd54d8000/lxml-6.1.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:556e94a63c9b04716f8e4de2abb65775061f846e89331b6c5be79183a24f98ea", size = 5002687, upload-time = "2026-05-18T19:17:01.738Z" },
-    { url = "https://files.pythonhosted.org/packages/96/1d/ab7a5c4b5a394d98a94e2d0fc67bab8297597426770dd4978370fbdaf531/lxml-6.1.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5c6bf403fbb3b3e348a561a5f4f0b9961835657981c802a1df03653eef8a9074", size = 5155099, upload-time = "2026-05-18T19:17:05.159Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/b1/07603bfeeb891a2596d5c2a68f7d2f70f7d11c841ebe391412c69c2857b0/lxml-6.1.1-cp310-cp310-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1dde6131244bba38a17c745836ba190bc753fd73c9291666287fd0a3fa3dcf30", size = 5057225, upload-time = "2026-05-18T19:17:08.117Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/16/cb391ee4b90186fa16d9ebcbe3ea96c71b8da3b0686386c8dcbcc3c67d44/lxml-6.1.1-cp310-cp310-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:98fc784c2c1440667aeedf8465bdfe10208acf0ead656a2c68627299f546b315", size = 5287643, upload-time = "2026-05-18T19:17:11.507Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/d6/b619717f918fd76747448fdbaee0e769edbc70e659b5b5d0112b7020b7a3/lxml-6.1.1-cp310-cp310-manylinux_2_28_i686.whl", hash = "sha256:add8cf6ddf9a65116119a28ece0f7886e30af27ba724a7594305f1d1b58a92a1", size = 5412445, upload-time = "2026-05-18T19:17:22.182Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/80/12bc5390ac0a3edeb579d9535e5049a5dda663438728e179d52fb319c33a/lxml-6.1.1-cp310-cp310-manylinux_2_31_armv7l.whl", hash = "sha256:cf9d57306d848218f3601fee7601fab1a327c942d56e2e97610583cb4dd74206", size = 4770864, upload-time = "2026-05-18T19:17:26.851Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/59/6500c09da3137f54f020e908d81cfc5ee3e8888e908fd380207afad7c2e6/lxml-6.1.1-cp310-cp310-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:88136950da4d13c318bde414ce10219931937851327f44328f2df4d2c4614067", size = 5359594, upload-time = "2026-05-18T19:17:32.527Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/9b/f64b4cc6b7ebcf75d95af3cde934d254b5f2f10d4163928d838d86b6eb48/lxml-6.1.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:cecdd5dfdc87b1fd87dbf81d4b037a544f47f4c744200a67013771682d67686a", size = 5107713, upload-time = "2026-05-18T19:17:04.402Z" },
-    { url = "https://files.pythonhosted.org/packages/16/19/c7388ad5d3a72315d2832dc1458cbf4f2af7f2b990b606ff4876efd04511/lxml-6.1.1-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:cd312b9692e831d2ffcad61eab31d91d4b4655a962e61de8fb410472cbcd37aa", size = 4803973, upload-time = "2026-05-18T19:17:06.545Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/22/76197f0bbf165f0b9e75be59be4997e5259cde973f12f098c1b54c7f5d60/lxml-6.1.1-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:5b7328b46d49fc9477d91ae8f6d55340347d827b7734ba3ea33faae0efef1383", size = 5349925, upload-time = "2026-05-18T19:17:09.743Z" },
-    { url = "https://files.pythonhosted.org/packages/24/52/d2a0cfeccb9bcdc47c7ee05cdae5d69b48c9acf20997790a6338bb0d0b3b/lxml-6.1.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:37a58976370f36d9329d118ad0b953c5aeb9119ac9c6a4e258942a225d0573a1", size = 5309825, upload-time = "2026-05-18T19:17:13.831Z" },
-    { url = "https://files.pythonhosted.org/packages/19/4a/b30944266776c2f49749ef2445aa7e78898194134b80ad776386f61b56ae/lxml-6.1.1-cp310-cp310-win32.whl", hash = "sha256:cea3f4c1af79af13cdb2da0c028111d8f8522d4f22a000c82385535f24e5cf3a", size = 3598402, upload-time = "2026-05-18T19:17:08.21Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/97/33691c66a4d7ec1a5a98e7c909a5b83ee45c7f7ba4cf92b1c4cf26e98079/lxml-6.1.1-cp310-cp310-win_amd64.whl", hash = "sha256:3abf332af33a74288675d936fe861fd4344da0dd6622193fbc4f2bfbb35536b5", size = 4021295, upload-time = "2026-05-18T19:17:28.638Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/5f/26a4dd0e12b9456ff7b12a21af5b491eb6629680d1edd73f4140fd386bcf/lxml-6.1.1-cp310-cp310-win_arm64.whl", hash = "sha256:8dadbe5b217ff35b6a8d16610dd710219b59b76d13f0e3f0d9f36786206e4485", size = 3667717, upload-time = "2026-05-19T19:22:44.474Z" },
     { url = "https://files.pythonhosted.org/packages/62/b0/83f481780d1548750b8ce2ec824073deef2f452d9cd1a6faff8507e3d16d/lxml-6.1.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:53b7d2b7a10b1c35c0a5e21e9224accf60c1bbfba523990732e521b2b73adef2", size = 8526461, upload-time = "2026-05-18T19:17:25.862Z" },
     { url = "https://files.pythonhosted.org/packages/b9/d5/30fa0f808002c7329397bfbb24e306789c0b29f04aa5842c07b174b4216f/lxml-6.1.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ff3f333630ab480244a1bff72043e511a91eb22e7595dead8653ee5612dd8f3d", size = 4595375, upload-time = "2026-05-18T19:17:34.555Z" },
     { url = "https://files.pythonhosted.org/packages/4f/d2/edb71cf0e561581a7c5eb2626244320eb04e9f8ce6d563184fd668b45073/lxml-6.1.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a4bbea04c97f6d78a48e3fbc1cb9116d2780b1b39e03a23f6eb9b603fd61f510", size = 4923654, upload-time = "2026-05-18T19:17:42.917Z" },
@@ -1512,18 +1454,10 @@ dependencies = [
     { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
     { name = "mypy-extensions" },
     { name = "pathspec" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/12/af/4e516a05d3ca2eb9283e9ec45b2c02225c1514dd6da49fd3c9eaa6639370/mypy-2.3.0.tar.gz", hash = "sha256:465965d41cd9a2726694e983e8ce7113259327bec798115d1e1dfa2a52fb666e", size = 3988104, upload-time = "2026-07-13T11:34:53.387Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a9/09/f2f5f45dae0c9a0891e4751a73312730e009395102e5d72a22a976cca41f/mypy-2.3.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:1fa8d916ac3b705af733c4c1e6c9ebe38fd0d52beb15b105c3e8355b55e6ecdc", size = 14927774, upload-time = "2026-07-13T11:28:38.224Z" },
-    { url = "https://files.pythonhosted.org/packages/56/b9/345367effd3a6877275a94d481614bfca983f45e028c6290e2cc54603811/mypy-2.3.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:28e1e2af8cd8fff551fd30f2fe4b03fb76764ac8b1ba6c6a1bd00ad32b412db3", size = 14000127, upload-time = "2026-07-13T11:30:19.57Z" },
-    { url = "https://files.pythonhosted.org/packages/99/6c/a10b7a7b9f0a755fb94e27ae834d4cea9ad6c5221f9325eef8f182641feb/mypy-2.3.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3e77244df3843048c3f927182916730e40c124cbaa43905c1fb86cb382aa0805", size = 14229437, upload-time = "2026-07-13T11:28:17.765Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/bd/a26a602acb1bbf849fa4bdac4bc657ee2f11c0c2a764a2cc87a5304e865c/mypy-2.3.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9559ab18a9c9957dfa3004ab57cd4bac5f26a724329a9584e583367f0c2e1117", size = 15171457, upload-time = "2026-07-13T11:29:01.834Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/14/124f462bef69bcbc90b9358088460b6091954a3e004852fcd9948db617a5/mypy-2.3.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:09abd66d8685e73f8f7d17b847c3e104d9a7b164a8706ea87d6c96a3d45816d5", size = 15478281, upload-time = "2026-07-13T11:32:23.413Z" },
-    { url = "https://files.pythonhosted.org/packages/db/a4/8bdca6a8ac8d856d82ed049144af2721245a135c2e8001d3890c93975852/mypy-2.3.0-cp310-cp310-win_amd64.whl", hash = "sha256:5e91adad1ca81742ac7ef9893959911df867752206b37135185e88dfb3c89494", size = 11148008, upload-time = "2026-07-13T11:34:17.332Z" },
-    { url = "https://files.pythonhosted.org/packages/83/41/490eea348e60ba50decec20bc750605444149a5d7a8cc560042f90ba2c75/mypy-2.3.0-cp310-cp310-win_arm64.whl", hash = "sha256:6f99ec626e3c3a2f7c0b22c5b90ddb5dabb1c18729c971e9bdaca1f1766d2cee", size = 10142329, upload-time = "2026-07-13T11:32:52.116Z" },
     { url = "https://files.pythonhosted.org/packages/e6/b9/d75b3082b05f1b3028828aeb18e74ae5ab0a0936051bbf1f32f59f654747/mypy-2.3.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:3419d00717afbc5265b50dd14b1278f29ea4884dd398ab67873489ac093fd329", size = 14838725, upload-time = "2026-07-13T11:32:44.655Z" },
     { url = "https://files.pythonhosted.org/packages/a9/50/79a65c6ea6e115bc73296038a4543b2d5c91f07912b918a2c616a2514bba/mypy-2.3.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:cfca8ee88544090f86b6dcce05ec55d66eb48a762412ac2507810ba4bd793b6f", size = 13911128, upload-time = "2026-07-13T11:32:02.021Z" },
     { url = "https://files.pythonhosted.org/packages/90/48/e11ed7716c26953ca321f726e452e374dbf81a6f2b8b212ec02af29b6b8f/mypy-2.3.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:75cbb4b9ef04a0c84a957f07abc4504fbf64b8dcc145675101f2d3a78a4b1d6a", size = 14146742, upload-time = "2026-07-13T11:33:03.313Z" },
@@ -1680,6 +1614,15 @@ wheels = [
 ]
 
 [[package]]
+name = "prometheus-client"
+version = "0.26.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/73/f1334c29c2af4cd9dba6c7817e61b611bd0215e2eb5565c6064a4de18802/prometheus_client-0.26.0.tar.gz", hash = "sha256:04a91bcf94e2cf74a44a1a874d651a2e853ed354b6e822f3b7487751465d5c2b", size = 92910, upload-time = "2026-07-24T19:36:41.893Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/a3/b69efbf4143b5b9859b977770bbbabcc2796b702fa69dc40271e45cd5a56/prometheus_client-0.26.0-py3-none-any.whl", hash = "sha256:fa93d06737aa02bacd05794768508bb97d2fbee28cb3bca04eaae92f0ca953d6", size = 64494, upload-time = "2026-07-24T19:36:40.854Z" },
+]
+
+[[package]]
 name = "py-key-value-aio"
 version = "0.4.5"
 source = { registry = "https://pypi.org/simple" }
@@ -1694,8 +1637,7 @@ wheels = [
 
 [package.optional-dependencies]
 filetree = [
-    { name = "aiofile", version = "3.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "aiofile", version = "3.11.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "aiofile" },
     { name = "anyio" },
 ]
 keyring = [
@@ -1703,6 +1645,9 @@ keyring = [
 ]
 memory = [
     { name = "cachetools" },
+]
+redis = [
+    { name = "redis" },
 ]
 
 [[package]]
@@ -1743,20 +1688,6 @@ dependencies = [
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464, upload-time = "2026-05-06T13:37:06.98Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e7/08/f1ba952f1c8ae5581c70fa9c6da89f247b83e3dd8c09c035d5d7931fc23d/pydantic_core-2.46.4-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:a396dcc17e5a0b164dbe026896245a4fa9ff402edca1dff0be3d53a517f74de4", size = 2113146, upload-time = "2026-05-06T13:37:36.537Z" },
-    { url = "https://files.pythonhosted.org/packages/56/c6/65f646c7ff09bd257f660434adb45c4dfcbbcebcc030562fecf6f5bf887d/pydantic_core-2.46.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:da4b951fe36dc7c3a1ccb4e3cd1747c3542b8c9ceede8fc86cae054e764485f5", size = 1949769, upload-time = "2026-05-06T13:37:46.365Z" },
-    { url = "https://files.pythonhosted.org/packages/64/ba/bfb1d928fd5b49e1258935ff104ae356e9fd89384a55bf9f847e9193ad40/pydantic_core-2.46.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bb63e0198ca18aad131c089b9204c23079c3afa95487e561f4c522d519e55aba", size = 1974958, upload-time = "2026-05-06T13:37:28.611Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/74/76223bfb117b64af743c9b6670d1364516f5c0604f96b48f3272f6af6cc6/pydantic_core-2.46.4-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f47286a97f0bc9b8859519809077b91b2cefe4ae47fcbf5e466a009c1c5d742b", size = 2042118, upload-time = "2026-05-06T13:36:55.216Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/7b/848732968bc8f48f3187542f08358b9d842db564147b256669426ebb1652/pydantic_core-2.46.4-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:905a0ed8ea6f2d61c1738835f99b699348d7857379083e5fc497fa0c967a407c", size = 2222876, upload-time = "2026-05-06T13:38:25.455Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/2f/e90b63ee2e14bd8d3db8f705a6d75d64e6ee1b7c2c8833747ce706e1e0ce/pydantic_core-2.46.4-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ea793e075b70290d89d8142074262885d3f7da19634845135751bd6344f73b50", size = 2286703, upload-time = "2026-05-06T13:37:53.304Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/1e/acc4d70f88a0a277e4a1fa77ebb985ceabaf900430f875bf9338e11c9420/pydantic_core-2.46.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:395aebd9183f9d112f569aeb5b2214d1a10a33bec8456447f7fbdfa51d38d4cd", size = 2092042, upload-time = "2026-05-06T13:38:46.981Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/da/0a422b57bf8504102bf3c4ccea9c41bab5a5cee6a54650acf8faf67f5a24/pydantic_core-2.46.4-cp310-cp310-manylinux_2_31_riscv64.whl", hash = "sha256:b078afbc25f3a1436c7a1d2cd3e322497ee99615ba97c563566fdf46aff1ee01", size = 2117231, upload-time = "2026-05-06T13:39:23.146Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/2a/2ac13c3af305843e23c5078c53d135656b3f05a2fd78cb7bbbb12e97b473/pydantic_core-2.46.4-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:f747929cf940cddb5b3668a390056ddd5ba2e5010615ea2dcf4f9c4f3ab8791d", size = 2168388, upload-time = "2026-05-06T13:40:08.06Z" },
-    { url = "https://files.pythonhosted.org/packages/72/04/2beacf7e1607e93eefe4aed1b4709f079b905fb77530179d4f7c71745f22/pydantic_core-2.46.4-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:daa27d92c36f24388fe3ad306b174781c747627f134452e4f128ea00ce1fe8c4", size = 2184769, upload-time = "2026-05-06T13:38:13.901Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/29/d2b9fd9f539133548eaf622c06a4ce176cb46ac59f32d0359c4abc0de047/pydantic_core-2.46.4-cp310-cp310-musllinux_1_1_armv7l.whl", hash = "sha256:19e51f073cd3df251856a8a4189fbdf1de4012c3ebacfb1884f94f1eb406079f", size = 2319312, upload-time = "2026-05-06T13:39:08.24Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/af/0f7a5b85fec6075bea96e3ef9187de38fccced0de92c1e7feda8d5cc7bb9/pydantic_core-2.46.4-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:c1747f85cee84c26985853c6f3d9bd3e75da5212912443fa111c113b9c246f39", size = 2361817, upload-time = "2026-05-06T13:38:43.2Z" },
-    { url = "https://files.pythonhosted.org/packages/25/a4/73363fec545fd3ec025490bdda2743c56d0dd5b6266b1a53bbe9e4265375/pydantic_core-2.46.4-cp310-cp310-win32.whl", hash = "sha256:2f84c03c8607173d16b5a854ec68a2f9079ae03237a54fb506d13af47e1d018d", size = 1987085, upload-time = "2026-05-06T13:39:25.497Z" },
-    { url = "https://files.pythonhosted.org/packages/01/aa/62f082da2c91fac1c234bc9ee0066257ce83f0604abd72e4c9d5991f2d84/pydantic_core-2.46.4-cp310-cp310-win_amd64.whl", hash = "sha256:8358a950c8909158e3df31538a7e4edc2d7265a7c54b47f0864d9e5bae9dcebf", size = 2074311, upload-time = "2026-05-06T13:39:59.922Z" },
     { url = "https://files.pythonhosted.org/packages/5c/fa/6d7708d2cfc1a832acb6aeb0cd16e801902df8a0f583bb3b4b527fde022e/pydantic_core-2.46.4-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:0e96592440881c74a213e5ad528e2b24d3d4f940de2766bed9010ab1d9e51594", size = 2111872, upload-time = "2026-05-06T13:40:27.596Z" },
     { url = "https://files.pythonhosted.org/packages/ae/6f/aa064a3e74b5745afbdf250594f38e7ead05e2d651bcb35994b9417a0d4d/pydantic_core-2.46.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e0d65b8c354be7fb5f720c3caa8bc940bc2d20ce749c8e06135f07f8ed95dd7c", size = 1948255, upload-time = "2026-05-06T13:39:12.574Z" },
     { url = "https://files.pythonhosted.org/packages/43/3a/41114a9f7569b84b4d84e7a018c57c56347dac30c0d4a872946ec4e36c46/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7bfb192b3f4b9e8a89b6277b6ce787564f62cfd272055f6e685726b111dc7826", size = 1972827, upload-time = "2026-05-06T13:38:19.841Z" },
@@ -1865,6 +1796,30 @@ wheels = [
 ]
 
 [[package]]
+name = "pydocket"
+version = "0.24.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "burner-redis" },
+    { name = "cloudpickle" },
+    { name = "cronsim" },
+    { name = "opentelemetry-api" },
+    { name = "prometheus-client" },
+    { name = "py-key-value-aio", extra = ["memory", "redis"] },
+    { name = "python-json-logger" },
+    { name = "redis" },
+    { name = "rich" },
+    { name = "typer" },
+    { name = "typing-extensions" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+    { name = "uncalled-for" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b7/6b/a87c6e3fd197807f630af4270aa2ce8f4c1fca4e43bba783f273d298d646/pydocket-0.24.1.tar.gz", hash = "sha256:477d77be1fcfd10ee0c2d0b8aa8c6e97851b9c7f39bb6f2b4e6d42e9b4d6e95a", size = 430759, upload-time = "2026-08-10T19:50:03.368Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/05/4e3b902bc0ca407188aa5fe38af49be634487aec242a77287103242e11b2/pydocket-0.24.1-py3-none-any.whl", hash = "sha256:1faa6c3d566f1f0431e35dfa12db4ccee515d945b913b516ee3e6279afb9e789", size = 130249, upload-time = "2026-08-10T19:50:01.627Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1877,9 +1832,6 @@ wheels = [
 name = "pyjwt"
 version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
-]
 sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
@@ -1905,12 +1857,10 @@ version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
     { name = "iniconfig" },
     { name = "packaging" },
     { name = "pluggy" },
     { name = "pygments" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
@@ -1922,7 +1872,6 @@ name = "pytest-asyncio"
 version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "backports-asyncio-runner", marker = "python_full_version < '3.11'" },
     { name = "pytest" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
@@ -1980,6 +1929,15 @@ wheels = [
 ]
 
 [[package]]
+name = "python-json-logger"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/25/5473e46b179f8e8b4ad3aeeb36773d1701b7770eaf5e5bc2025c7303b598/python_json_logger-4.2.0.tar.gz", hash = "sha256:e371ebe22ec01e289850102091a2b1f6fc9e655c7f1f5f29073936756c290afa", size = 18211, upload-time = "2026-08-15T11:36:38.232Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/55/6467fde553886cb293e41538f3a8b4e4fd4688c6df242cf982162d8367fb/python_json_logger-4.2.0-py3-none-any.whl", hash = "sha256:158a52126fcd6869e09574d2b66272666f3dc8f468c62637ef9a1fa883719cb9", size = 14988, upload-time = "2026-08-15T11:36:36.821Z" },
+]
+
+[[package]]
 name = "python-multipart"
 version = "0.0.32"
 source = { registry = "https://pypi.org/simple" }
@@ -2002,9 +1960,6 @@ name = "pywin32"
 version = "312"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fe/1b/9cfdeac80ee45bebbbcb31f1b7b99a0d81a1c72de48d837be984e0e88b1d/pywin32-312-cp310-cp310-win32.whl", hash = "sha256:772235332b5d1024c696f11cea1ae4be7930f0a8b894bb43db14e3f435f1ff7e", size = 6361387, upload-time = "2026-06-04T07:49:14.329Z" },
-    { url = "https://files.pythonhosted.org/packages/33/b1/7afc96d041d982c27bc2df6f853d43f01fd273e3d39d04be3647ddeb533d/pywin32-312-cp310-cp310-win_amd64.whl", hash = "sha256:5dbc35d2b5320dc07f25fa31269cfb767471002b17de5eb067d03da68c7cb2db", size = 6926780, upload-time = "2026-06-04T07:49:16.881Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/3a/4140da9ad54108e517f4a16b2d83da3033e08662144623e1239587cb7db6/pywin32-312-cp310-cp310-win_arm64.whl", hash = "sha256:3020656e34f1cf7faeb7bccd2b84653a607c6ff0c55ada85e6487d61716deabd", size = 4307203, upload-time = "2026-06-04T07:49:18.993Z" },
     { url = "https://files.pythonhosted.org/packages/1f/f5/10a6e845a00fc5e7afd0a988b744f403d4d57162a28d160a093c4d9322f0/pywin32-312-cp311-cp311-win32.whl", hash = "sha256:17948aeadbdb091f0ced6ef0841620794e68327b94ee415571c1203594b7215c", size = 6362659, upload-time = "2026-06-04T07:49:21.349Z" },
     { url = "https://files.pythonhosted.org/packages/35/c4/dcd2d62b5944b6d5db53413a5899016ccd57ffcb7278f3f81655d25d2027/pywin32-312-cp311-cp311-win_amd64.whl", hash = "sha256:d11417d84412f859b722fad0841b3614459ed0047f7542d8362e77884f6b6e8a", size = 6928825, upload-time = "2026-06-04T07:49:23.934Z" },
     { url = "https://files.pythonhosted.org/packages/b7/56/3cbb433fe4501cdba2eb9040f56a4e1a8243faa4186b25295564d1a7a79d/pywin32-312-cp311-cp311-win_arm64.whl", hash = "sha256:b2200a054ca6d6625c4842fc56a4976a4b47f96b73dbe5538c3f813a80359f47", size = 6721875, upload-time = "2026-06-04T07:49:26.416Z" },
@@ -2037,15 +1992,6 @@ version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f4/a0/39350dd17dd6d6c6507025c0e53aef67a9293a6d37d3511f23ea510d5800/pyyaml-6.0.3-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:214ed4befebe12df36bcc8bc2b64b396ca31be9304b8f59e25c11cf94a4c033b", size = 184227, upload-time = "2025-09-25T21:31:46.04Z" },
-    { url = "https://files.pythonhosted.org/packages/05/14/52d505b5c59ce73244f59c7a50ecf47093ce4765f116cdb98286a71eeca2/pyyaml-6.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:02ea2dfa234451bbb8772601d7b8e426c2bfa197136796224e50e35a78777956", size = 174019, upload-time = "2025-09-25T21:31:47.706Z" },
-    { url = "https://files.pythonhosted.org/packages/43/f7/0e6a5ae5599c838c696adb4e6330a59f463265bfa1e116cfd1fbb0abaaae/pyyaml-6.0.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b30236e45cf30d2b8e7b3e85881719e98507abed1011bf463a8fa23e9c3e98a8", size = 740646, upload-time = "2025-09-25T21:31:49.21Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/3a/61b9db1d28f00f8fd0ae760459a5c4bf1b941baf714e207b6eb0657d2578/pyyaml-6.0.3-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:66291b10affd76d76f54fad28e22e51719ef9ba22b29e1d7d03d6777a9174198", size = 840793, upload-time = "2025-09-25T21:31:50.735Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/1e/7acc4f0e74c4b3d9531e24739e0ab832a5edf40e64fbae1a9c01941cabd7/pyyaml-6.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9c7708761fccb9397fe64bbc0395abcae8c4bf7b0eac081e12b809bf47700d0b", size = 770293, upload-time = "2025-09-25T21:31:51.828Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/ef/abd085f06853af0cd59fa5f913d61a8eab65d7639ff2a658d18a25d6a89d/pyyaml-6.0.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:418cf3f2111bc80e0933b2cd8cd04f286338bb88bdc7bc8e6dd775ebde60b5e0", size = 732872, upload-time = "2025-09-25T21:31:53.282Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/15/2bc9c8faf6450a8b3c9fc5448ed869c599c0a74ba2669772b1f3a0040180/pyyaml-6.0.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:5e0b74767e5f8c593e8c9b5912019159ed0533c70051e9cce3e8b6aa699fcd69", size = 758828, upload-time = "2025-09-25T21:31:54.807Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/00/531e92e88c00f4333ce359e50c19b8d1de9fe8d581b1534e35ccfbc5f393/pyyaml-6.0.3-cp310-cp310-win32.whl", hash = "sha256:28c8d926f98f432f88adc23edf2e6d4921ac26fb084b028c733d01868d19007e", size = 142415, upload-time = "2025-09-25T21:31:55.885Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/fa/926c003379b19fca39dd4634818b00dec6c62d87faf628d1394e137354d4/pyyaml-6.0.3-cp310-cp310-win_amd64.whl", hash = "sha256:bdb2c67c6c1390b63c6ff89f210c8fd09d9a1217a465701eac7316313c915e4c", size = 158561, upload-time = "2025-09-25T21:31:57.406Z" },
     { url = "https://files.pythonhosted.org/packages/6d/16/a95b6757765b7b031c9374925bb718d55e0a9ba8a1b6a12d25962ea44347/pyyaml-6.0.3-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:44edc647873928551a01e7a563d7452ccdebee747728c1080d881d68af7b997e", size = 185826, upload-time = "2025-09-25T21:31:58.655Z" },
     { url = "https://files.pythonhosted.org/packages/16/19/13de8e4377ed53079ee996e1ab0a9c33ec2faf808a4647b7b4c0d46dd239/pyyaml-6.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:652cb6edd41e718550aad172851962662ff2681490a8a711af6a4d288dd96824", size = 175577, upload-time = "2025-09-25T21:32:00.088Z" },
     { url = "https://files.pythonhosted.org/packages/0c/62/d2eb46264d4b157dae1275b573017abec435397aa59cbcdab6fc978a8af4/pyyaml-6.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:10892704fc220243f5305762e276552a0395f7beb4dbf9b14ec8fd43b57f126c", size = 775556, upload-time = "2025-09-25T21:32:01.31Z" },
@@ -2103,11 +2049,22 @@ dependencies = [
     { name = "chardet" },
     { name = "cssselect" },
     { name = "lxml", extra = ["html-clean"] },
-    { name = "lxml-html-clean", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/55/3e/dc87d97532ddad58af786ec89c7036182e352574c1cba37bf2bf783d2b15/readability_lxml-0.8.4.1.tar.gz", hash = "sha256:9d2924f5942dd7f37fb4da353263b22a3e877ccf922d0e45e348e4177b035a53", size = 22874, upload-time = "2025-05-03T21:11:45.493Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/75/2cc58965097e351415af420be81c4665cf80da52a17ef43c01ffbe2caf91/readability_lxml-0.8.4.1-py3-none-any.whl", hash = "sha256:874c0cea22c3bf2b78c7f8df831bfaad3c0a89b7301d45a188db581652b4b465", size = 19912, upload-time = "2025-05-03T21:11:43.993Z" },
+]
+
+[[package]]
+name = "redis"
+version = "8.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "async-timeout", marker = "python_full_version < '3.11.3'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a8/99/604f0b666d4c616d891cf77ebb9db6bb21601344c051aebf1b72b9ff915f/redis-8.1.0.tar.gz", hash = "sha256:6e1a19beef9225c83efd689c7e6b7da2d5215b1f42cd13b7fc3714d0a09c7b25", size = 5254356, upload-time = "2026-07-30T08:51:00.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/66/9d/c5731f6e3608663d4d3656fd8d3aecee8b509c3082818f5a13eae925baea/redis-8.1.0-py3-none-any.whl", hash = "sha256:a4fe1aac3d3b3cc791d4b3d5931c5a956045dc951ee74d1c913ee3ac4d2ee9fb", size = 560618, upload-time = "2026-07-30T08:50:58.497Z" },
 ]
 
 [[package]]
@@ -2116,8 +2073,7 @@ version = "0.37.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
-    { name = "rpds-py", version = "0.30.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "rpds-py", version = "2026.6.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "rpds-py" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
@@ -2131,23 +2087,6 @@ version = "2026.7.19"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/20/98/04b13f1ddfb63158025291c02e03eb42fbb7acb51d091d541050eb4e35e8/regex-2026.7.19.tar.gz", hash = "sha256:7e77b324909c1617cbb4c668677e2c6ae13f44d7c1de0d4f15f2e3c10f3315b5", size = 416440, upload-time = "2026-07-19T00:19:48.923Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/24/13/bbf7d9d1887fe4a3693527c6caa232c197ea9da91f1212e9672eff60329d/regex-2026.7.19-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:555497390743af1a65045fa4527782d10ff5b88970359412baa4a1e628fe393b", size = 494009, upload-time = "2026-07-19T00:16:13.602Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/19/783688e75a2bec15d50aec0d5e7e317d363808bc82a6eb6750b897bfcd7b/regex-2026.7.19-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:343a4504e3fb688c47cad451221ca5d4814f42b1e16c0065bde9cbf7f473bd52", size = 295287, upload-time = "2026-07-19T00:16:15.702Z" },
-    { url = "https://files.pythonhosted.org/packages/16/01/cefe4f051302ca298d3f3e79ed6dbd933ac84485b9515acdd6a52d70cef7/regex-2026.7.19-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:5ebee1ee89c39c953baac6924fcde08c5bb427c4057510862f9d7c7bdb3d8665", size = 290633, upload-time = "2026-07-19T00:16:17.182Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/1e/1045ca2cabb12e8ec41ad0d138e9f3ff1eb079d30a6f51ccf7d709b44aad/regex-2026.7.19-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:062f8cb7a9739c4835d22bd96f370c59aba89f257adcfa53be3cc209e08d3ae0", size = 785300, upload-time = "2026-07-19T00:16:18.505Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/4a/20e5bca184e90bf1bd187efdb53363f4a7b7b34f01d54ced5740caf104bd/regex-2026.7.19-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1123ef4211d763ee771d47916a1596e2f4915794f7aabdc1adcb20e4249a6951", size = 854079, upload-time = "2026-07-19T00:16:19.909Z" },
-    { url = "https://files.pythonhosted.org/packages/09/9b/5a2e59678be3b24aa6a42b2c6d66a48daa212593e9f4096fe7ba577fa9b1/regex-2026.7.19-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6e44c0e7c5664be20aee92085153150c0a7967310a73a43c0f832b7cd35d0dd3", size = 899496, upload-time = "2026-07-19T00:16:21.453Z" },
-    { url = "https://files.pythonhosted.org/packages/48/9a/7317f14ed8ed9fd998d1978b4802b07bc4d79216353c435dbcc1ddd1301f/regex-2026.7.19-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:98c6ac18480fcdb33f35439183f1d2e79760ab41930309c6d951cb1f8e46694c", size = 793541, upload-time = "2026-07-19T00:16:22.991Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/53/833c2db3e274d3c191f4c42fe5bfa358e4c8b617d5d7312d31334965fc46/regex-2026.7.19-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4458124d71339f505bf1fb94f69fd1bb8fa9d2481eebfef27c10ef4f2b9e12f6", size = 785515, upload-time = "2026-07-19T00:16:24.654Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/b9/efb2f9fa151d71db09d4015e1fb92fee47416f01c12164836bbd23e2f3c2/regex-2026.7.19-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fbf300e2070bb35038660b3be1be4b91b0024edb41517e6996320b49b92b4175", size = 769556, upload-time = "2026-07-19T00:16:26.207Z" },
-    { url = "https://files.pythonhosted.org/packages/81/4d/45610c263f8eadb84e4a1fabd904d81d5176226faa9104ef498bf8a8b285/regex-2026.7.19-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:b2b506b1788df5fecd270a10d5e70a95fe77b87ea2b370a318043f6f5f817ee6", size = 774130, upload-time = "2026-07-19T00:16:27.786Z" },
-    { url = "https://files.pythonhosted.org/packages/40/95/1b40d87c7a9e5480bec7a87bce9fd67fc3f14b5f106c8ee66d660249072f/regex-2026.7.19-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:52579c60a6078be70a0e49c81d6e56d677f34cd439af281a0083b8c7bc75c095", size = 848694, upload-time = "2026-07-19T00:16:29.412Z" },
-    { url = "https://files.pythonhosted.org/packages/17/8b/bb45968addd5b394ef9cd9184bd9c65ade1a819dbb2b92b71ad52a0c7907/regex-2026.7.19-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:2955907b7157a6660f27079edf7e0229e9c9c5325c77a2ef6a890cba91efa6f0", size = 758505, upload-time = "2026-07-19T00:16:31.006Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/6f/33386c672fbf43e21602135a0f29a97ee251a483f007fe51d10e9b2dbc93/regex-2026.7.19-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:89dfee3319f5ae3f75ebd5c2445a809bb320252ba5529ffdafea4ef25d79cf1a", size = 836985, upload-time = "2026-07-19T00:16:32.459Z" },
-    { url = "https://files.pythonhosted.org/packages/22/f1/9112b86e9bb075619862e8e42b604794389f1958faa68fb69bde505dd90e/regex-2026.7.19-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:3d3143f159261b1ce5b24c261c590e5913370c3200c5e9ebbb92b5aa5e111902", size = 782610, upload-time = "2026-07-19T00:16:33.857Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/f9/13d460d8a385ca0b0be9e6be80a90968b9293b3e30895543ad2d1d1653e4/regex-2026.7.19-cp310-cp310-win32.whl", hash = "sha256:64729333167c2dcaaa56a331d40ee097bd9c5617ffd51dabb09eaddafb1b532e", size = 266772, upload-time = "2026-07-19T00:16:35.194Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/90/29addd7a03e1aea402c1f31467e25c80caabc8c3735b88a23cf73b0aa9c2/regex-2026.7.19-cp310-cp310-win_amd64.whl", hash = "sha256:1c398716054621aa300b3d411f467dda903806c5da0df6945ab73982b8d115db", size = 277967, upload-time = "2026-07-19T00:16:36.847Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/ba/ecfce06fe66c122bc6f77ae284887a9282e4411fe1e6268c5266611ca054/regex-2026.7.19-cp310-cp310-win_arm64.whl", hash = "sha256:064f1760a5a4ade65c5419be23e782f29147528e8a66e0c42dd4cedb8d4e9fc6", size = 276963, upload-time = "2026-07-19T00:16:38.315Z" },
     { url = "https://files.pythonhosted.org/packages/05/e5/cef4de2bac939280b68d32adc659478845238a8274f2f79c465063f590ad/regex-2026.7.19-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:ac777001cdfc28b72477d93c8564bb7583081ea8fb45cdca3d568e0a4f87183c", size = 494012, upload-time = "2026-07-19T00:16:39.927Z" },
     { url = "https://files.pythonhosted.org/packages/ff/87/e86f51eb117457bb7803132ffe5cb6e2841e2b5bea4cc85d397f3c6e257d/regex-2026.7.19-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:59787bd5f8c70aa339084e961d2996b53fbdeab4d5393bba5c1fe1fc32e02bae", size = 295281, upload-time = "2026-07-19T00:16:41.433Z" },
     { url = "https://files.pythonhosted.org/packages/41/2e/2360c41d8080a3d9ec7e5c90fad6eab3b50192869d10e9a5609e48c8177b/regex-2026.7.19-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:90c633e7e8d6bf4e992b8b36ce69e018f834b641dd6de8cea6d78c06ffa119c5", size = 290615, upload-time = "2026-07-19T00:16:43.058Z" },
@@ -2274,143 +2213,8 @@ wheels = [
 
 [[package]]
 name = "rpds-py"
-version = "0.30.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.11' and sys_platform == 'win32'",
-    "python_full_version < '3.11' and sys_platform != 'win32'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/20/af/3f2f423103f1113b36230496629986e0ef7e199d2aa8392452b484b38ced/rpds_py-0.30.0.tar.gz", hash = "sha256:dd8ff7cf90014af0c0f787eea34794ebf6415242ee1d6fa91eaba725cc441e84", size = 69469, upload-time = "2025-11-30T20:24:38.837Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/06/0c/0c411a0ec64ccb6d104dcabe0e713e05e153a9a2c3c2bd2b32ce412166fe/rpds_py-0.30.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:679ae98e00c0e8d68a7fda324e16b90fd5260945b45d3b824c892cec9eea3288", size = 370490, upload-time = "2025-11-30T20:21:33.256Z" },
-    { url = "https://files.pythonhosted.org/packages/19/6a/4ba3d0fb7297ebae71171822554abe48d7cab29c28b8f9f2c04b79988c05/rpds_py-0.30.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:4cc2206b76b4f576934f0ed374b10d7ca5f457858b157ca52064bdfc26b9fc00", size = 359751, upload-time = "2025-11-30T20:21:34.591Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/7c/e4933565ef7f7a0818985d87c15d9d273f1a649afa6a52ea35ad011195ea/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:389a2d49eded1896c3d48b0136ead37c48e221b391c052fba3f4055c367f60a6", size = 389696, upload-time = "2025-11-30T20:21:36.122Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/01/6271a2511ad0815f00f7ed4390cf2567bec1d4b1da39e2c27a41e6e3b4de/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:32c8528634e1bf7121f3de08fa85b138f4e0dc47657866630611b03967f041d7", size = 403136, upload-time = "2025-11-30T20:21:37.728Z" },
-    { url = "https://files.pythonhosted.org/packages/55/64/c857eb7cd7541e9b4eee9d49c196e833128a55b89a9850a9c9ac33ccf897/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f207f69853edd6f6700b86efb84999651baf3789e78a466431df1331608e5324", size = 524699, upload-time = "2025-11-30T20:21:38.92Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/ed/94816543404078af9ab26159c44f9e98e20fe47e2126d5d32c9d9948d10a/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:67b02ec25ba7a9e8fa74c63b6ca44cf5707f2fbfadae3ee8e7494297d56aa9df", size = 412022, upload-time = "2025-11-30T20:21:40.407Z" },
-    { url = "https://files.pythonhosted.org/packages/61/b5/707f6cf0066a6412aacc11d17920ea2e19e5b2f04081c64526eb35b5c6e7/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0c0e95f6819a19965ff420f65578bacb0b00f251fefe2c8b23347c37174271f3", size = 390522, upload-time = "2025-11-30T20:21:42.17Z" },
-    { url = "https://files.pythonhosted.org/packages/13/4e/57a85fda37a229ff4226f8cbcf09f2a455d1ed20e802ce5b2b4a7f5ed053/rpds_py-0.30.0-cp310-cp310-manylinux_2_31_riscv64.whl", hash = "sha256:a452763cc5198f2f98898eb98f7569649fe5da666c2dc6b5ddb10fde5a574221", size = 404579, upload-time = "2025-11-30T20:21:43.769Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/da/c9339293513ec680a721e0e16bf2bac3db6e5d7e922488de471308349bba/rpds_py-0.30.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e0b65193a413ccc930671c55153a03ee57cecb49e6227204b04fae512eb657a7", size = 421305, upload-time = "2025-11-30T20:21:44.994Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/be/522cb84751114f4ad9d822ff5a1aa3c98006341895d5f084779b99596e5c/rpds_py-0.30.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:858738e9c32147f78b3ac24dc0edb6610000e56dc0f700fd5f651d0a0f0eb9ff", size = 572503, upload-time = "2025-11-30T20:21:46.91Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/9b/de879f7e7ceddc973ea6e4629e9b380213a6938a249e94b0cdbcc325bb66/rpds_py-0.30.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:da279aa314f00acbb803da1e76fa18666778e8a8f83484fba94526da5de2cba7", size = 598322, upload-time = "2025-11-30T20:21:48.709Z" },
-    { url = "https://files.pythonhosted.org/packages/48/ac/f01fc22efec3f37d8a914fc1b2fb9bcafd56a299edbe96406f3053edea5a/rpds_py-0.30.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:7c64d38fb49b6cdeda16ab49e35fe0da2e1e9b34bc38bd78386530f218b37139", size = 560792, upload-time = "2025-11-30T20:21:50.024Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/da/4e2b19d0f131f35b6146425f846563d0ce036763e38913d917187307a671/rpds_py-0.30.0-cp310-cp310-win32.whl", hash = "sha256:6de2a32a1665b93233cde140ff8b3467bdb9e2af2b91079f0333a0974d12d464", size = 221901, upload-time = "2025-11-30T20:21:51.32Z" },
-    { url = "https://files.pythonhosted.org/packages/96/cb/156d7a5cf4f78a7cc571465d8aec7a3c447c94f6749c5123f08438bcf7bc/rpds_py-0.30.0-cp310-cp310-win_amd64.whl", hash = "sha256:1726859cd0de969f88dc8673bdd954185b9104e05806be64bcd87badbe313169", size = 235823, upload-time = "2025-11-30T20:21:52.505Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/6e/f964e88b3d2abee2a82c1ac8366da848fce1c6d834dc2132c3fda3970290/rpds_py-0.30.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:a2bffea6a4ca9f01b3f8e548302470306689684e61602aa3d141e34da06cf425", size = 370157, upload-time = "2025-11-30T20:21:53.789Z" },
-    { url = "https://files.pythonhosted.org/packages/94/ba/24e5ebb7c1c82e74c4e4f33b2112a5573ddc703915b13a073737b59b86e0/rpds_py-0.30.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:dc4f992dfe1e2bc3ebc7444f6c7051b4bc13cd8e33e43511e8ffd13bf407010d", size = 359676, upload-time = "2025-11-30T20:21:55.475Z" },
-    { url = "https://files.pythonhosted.org/packages/84/86/04dbba1b087227747d64d80c3b74df946b986c57af0a9f0c98726d4d7a3b/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:422c3cb9856d80b09d30d2eb255d0754b23e090034e1deb4083f8004bd0761e4", size = 389938, upload-time = "2025-11-30T20:21:57.079Z" },
-    { url = "https://files.pythonhosted.org/packages/42/bb/1463f0b1722b7f45431bdd468301991d1328b16cffe0b1c2918eba2c4eee/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:07ae8a593e1c3c6b82ca3292efbe73c30b61332fd612e05abee07c79359f292f", size = 402932, upload-time = "2025-11-30T20:21:58.47Z" },
-    { url = "https://files.pythonhosted.org/packages/99/ee/2520700a5c1f2d76631f948b0736cdf9b0acb25abd0ca8e889b5c62ac2e3/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:12f90dd7557b6bd57f40abe7747e81e0c0b119bef015ea7726e69fe550e394a4", size = 525830, upload-time = "2025-11-30T20:21:59.699Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/ad/bd0331f740f5705cc555a5e17fdf334671262160270962e69a2bdef3bf76/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:99b47d6ad9a6da00bec6aabe5a6279ecd3c06a329d4aa4771034a21e335c3a97", size = 412033, upload-time = "2025-11-30T20:22:00.991Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/1e/372195d326549bb51f0ba0f2ecb9874579906b97e08880e7a65c3bef1a99/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:33f559f3104504506a44bb666b93a33f5d33133765b0c216a5bf2f1e1503af89", size = 390828, upload-time = "2025-11-30T20:22:02.723Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/2b/d88bb33294e3e0c76bc8f351a3721212713629ffca1700fa94979cb3eae8/rpds_py-0.30.0-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:946fe926af6e44f3697abbc305ea168c2c31d3e3ef1058cf68f379bf0335a78d", size = 404683, upload-time = "2025-11-30T20:22:04.367Z" },
-    { url = "https://files.pythonhosted.org/packages/50/32/c759a8d42bcb5289c1fac697cd92f6fe01a018dd937e62ae77e0e7f15702/rpds_py-0.30.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:495aeca4b93d465efde585977365187149e75383ad2684f81519f504f5c13038", size = 421583, upload-time = "2025-11-30T20:22:05.814Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/81/e729761dbd55ddf5d84ec4ff1f47857f4374b0f19bdabfcf929164da3e24/rpds_py-0.30.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d9a0ca5da0386dee0655b4ccdf46119df60e0f10da268d04fe7cc87886872ba7", size = 572496, upload-time = "2025-11-30T20:22:07.713Z" },
-    { url = "https://files.pythonhosted.org/packages/14/f6/69066a924c3557c9c30baa6ec3a0aa07526305684c6f86c696b08860726c/rpds_py-0.30.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:8d6d1cc13664ec13c1b84241204ff3b12f9bb82464b8ad6e7a5d3486975c2eed", size = 598669, upload-time = "2025-11-30T20:22:09.312Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/48/905896b1eb8a05630d20333d1d8ffd162394127b74ce0b0784ae04498d32/rpds_py-0.30.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:3896fa1be39912cf0757753826bc8bdc8ca331a28a7c4ae46b7a21280b06bb85", size = 561011, upload-time = "2025-11-30T20:22:11.309Z" },
-    { url = "https://files.pythonhosted.org/packages/22/16/cd3027c7e279d22e5eb431dd3c0fbc677bed58797fe7581e148f3f68818b/rpds_py-0.30.0-cp311-cp311-win32.whl", hash = "sha256:55f66022632205940f1827effeff17c4fa7ae1953d2b74a8581baaefb7d16f8c", size = 221406, upload-time = "2025-11-30T20:22:13.101Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/5b/e7b7aa136f28462b344e652ee010d4de26ee9fd16f1bfd5811f5153ccf89/rpds_py-0.30.0-cp311-cp311-win_amd64.whl", hash = "sha256:a51033ff701fca756439d641c0ad09a41d9242fa69121c7d8769604a0a629825", size = 236024, upload-time = "2025-11-30T20:22:14.853Z" },
-    { url = "https://files.pythonhosted.org/packages/14/a6/364bba985e4c13658edb156640608f2c9e1d3ea3c81b27aa9d889fff0e31/rpds_py-0.30.0-cp311-cp311-win_arm64.whl", hash = "sha256:47b0ef6231c58f506ef0b74d44e330405caa8428e770fec25329ed2cb971a229", size = 229069, upload-time = "2025-11-30T20:22:16.577Z" },
-    { url = "https://files.pythonhosted.org/packages/03/e7/98a2f4ac921d82f33e03f3835f5bf3a4a40aa1bfdc57975e74a97b2b4bdd/rpds_py-0.30.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a161f20d9a43006833cd7068375a94d035714d73a172b681d8881820600abfad", size = 375086, upload-time = "2025-11-30T20:22:17.93Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/a1/bca7fd3d452b272e13335db8d6b0b3ecde0f90ad6f16f3328c6fb150c889/rpds_py-0.30.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6abc8880d9d036ecaafe709079969f56e876fcf107f7a8e9920ba6d5a3878d05", size = 359053, upload-time = "2025-11-30T20:22:19.297Z" },
-    { url = "https://files.pythonhosted.org/packages/65/1c/ae157e83a6357eceff62ba7e52113e3ec4834a84cfe07fa4b0757a7d105f/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ca28829ae5f5d569bb62a79512c842a03a12576375d5ece7d2cadf8abe96ec28", size = 390763, upload-time = "2025-11-30T20:22:21.661Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/36/eb2eb8515e2ad24c0bd43c3ee9cd74c33f7ca6430755ccdb240fd3144c44/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a1010ed9524c73b94d15919ca4d41d8780980e1765babf85f9a2f90d247153dd", size = 408951, upload-time = "2025-11-30T20:22:23.408Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/65/ad8dc1784a331fabbd740ef6f71ce2198c7ed0890dab595adb9ea2d775a1/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f8d1736cfb49381ba528cd5baa46f82fdc65c06e843dab24dd70b63d09121b3f", size = 514622, upload-time = "2025-11-30T20:22:25.16Z" },
-    { url = "https://files.pythonhosted.org/packages/63/8e/0cfa7ae158e15e143fe03993b5bcd743a59f541f5952e1546b1ac1b5fd45/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d948b135c4693daff7bc2dcfc4ec57237a29bd37e60c2fabf5aff2bbacf3e2f1", size = 414492, upload-time = "2025-11-30T20:22:26.505Z" },
-    { url = "https://files.pythonhosted.org/packages/60/1b/6f8f29f3f995c7ffdde46a626ddccd7c63aefc0efae881dc13b6e5d5bb16/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47f236970bccb2233267d89173d3ad2703cd36a0e2a6e92d0560d333871a3d23", size = 394080, upload-time = "2025-11-30T20:22:27.934Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/d5/a266341051a7a3ca2f4b750a3aa4abc986378431fc2da508c5034d081b70/rpds_py-0.30.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:2e6ecb5a5bcacf59c3f912155044479af1d0b6681280048b338b28e364aca1f6", size = 408680, upload-time = "2025-11-30T20:22:29.341Z" },
-    { url = "https://files.pythonhosted.org/packages/10/3b/71b725851df9ab7a7a4e33cf36d241933da66040d195a84781f49c50490c/rpds_py-0.30.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a8fa71a2e078c527c3e9dc9fc5a98c9db40bcc8a92b4e8858e36d329f8684b51", size = 423589, upload-time = "2025-11-30T20:22:31.469Z" },
-    { url = "https://files.pythonhosted.org/packages/00/2b/e59e58c544dc9bd8bd8384ecdb8ea91f6727f0e37a7131baeff8d6f51661/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:73c67f2db7bc334e518d097c6d1e6fed021bbc9b7d678d6cc433478365d1d5f5", size = 573289, upload-time = "2025-11-30T20:22:32.997Z" },
-    { url = "https://files.pythonhosted.org/packages/da/3e/a18e6f5b460893172a7d6a680e86d3b6bc87a54c1f0b03446a3c8c7b588f/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:5ba103fb455be00f3b1c2076c9d4264bfcb037c976167a6047ed82f23153f02e", size = 599737, upload-time = "2025-11-30T20:22:34.419Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/e2/714694e4b87b85a18e2c243614974413c60aa107fd815b8cbc42b873d1d7/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7cee9c752c0364588353e627da8a7e808a66873672bcb5f52890c33fd965b394", size = 563120, upload-time = "2025-11-30T20:22:35.903Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/ab/d5d5e3bcedb0a77f4f613706b750e50a5a3ba1c15ccd3665ecc636c968fd/rpds_py-0.30.0-cp312-cp312-win32.whl", hash = "sha256:1ab5b83dbcf55acc8b08fc62b796ef672c457b17dbd7820a11d6c52c06839bdf", size = 223782, upload-time = "2025-11-30T20:22:37.271Z" },
-    { url = "https://files.pythonhosted.org/packages/39/3b/f786af9957306fdc38a74cef405b7b93180f481fb48453a114bb6465744a/rpds_py-0.30.0-cp312-cp312-win_amd64.whl", hash = "sha256:a090322ca841abd453d43456ac34db46e8b05fd9b3b4ac0c78bcde8b089f959b", size = 240463, upload-time = "2025-11-30T20:22:39.021Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/d2/b91dc748126c1559042cfe41990deb92c4ee3e2b415f6b5234969ffaf0cc/rpds_py-0.30.0-cp312-cp312-win_arm64.whl", hash = "sha256:669b1805bd639dd2989b281be2cfd951c6121b65e729d9b843e9639ef1fd555e", size = 230868, upload-time = "2025-11-30T20:22:40.493Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/dc/d61221eb88ff410de3c49143407f6f3147acf2538c86f2ab7ce65ae7d5f9/rpds_py-0.30.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:f83424d738204d9770830d35290ff3273fbb02b41f919870479fab14b9d303b2", size = 374887, upload-time = "2025-11-30T20:22:41.812Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/32/55fb50ae104061dbc564ef15cc43c013dc4a9f4527a1f4d99baddf56fe5f/rpds_py-0.30.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e7536cd91353c5273434b4e003cbda89034d67e7710eab8761fd918ec6c69cf8", size = 358904, upload-time = "2025-11-30T20:22:43.479Z" },
-    { url = "https://files.pythonhosted.org/packages/58/70/faed8186300e3b9bdd138d0273109784eea2396c68458ed580f885dfe7ad/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2771c6c15973347f50fece41fc447c054b7ac2ae0502388ce3b6738cd366e3d4", size = 389945, upload-time = "2025-11-30T20:22:44.819Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/a8/073cac3ed2c6387df38f71296d002ab43496a96b92c823e76f46b8af0543/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0a59119fc6e3f460315fe9d08149f8102aa322299deaa5cab5b40092345c2136", size = 407783, upload-time = "2025-11-30T20:22:46.103Z" },
-    { url = "https://files.pythonhosted.org/packages/77/57/5999eb8c58671f1c11eba084115e77a8899d6e694d2a18f69f0ba471ec8b/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:76fec018282b4ead0364022e3c54b60bf368b9d926877957a8624b58419169b7", size = 515021, upload-time = "2025-11-30T20:22:47.458Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/af/5ab4833eadc36c0a8ed2bc5c0de0493c04f6c06de223170bd0798ff98ced/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:692bef75a5525db97318e8cd061542b5a79812d711ea03dbc1f6f8dbb0c5f0d2", size = 414589, upload-time = "2025-11-30T20:22:48.872Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/de/f7192e12b21b9e9a68a6d0f249b4af3fdcdff8418be0767a627564afa1f1/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9027da1ce107104c50c81383cae773ef5c24d296dd11c99e2629dbd7967a20c6", size = 394025, upload-time = "2025-11-30T20:22:50.196Z" },
-    { url = "https://files.pythonhosted.org/packages/91/c4/fc70cd0249496493500e7cc2de87504f5aa6509de1e88623431fec76d4b6/rpds_py-0.30.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:9cf69cdda1f5968a30a359aba2f7f9aa648a9ce4b580d6826437f2b291cfc86e", size = 408895, upload-time = "2025-11-30T20:22:51.87Z" },
-    { url = "https://files.pythonhosted.org/packages/58/95/d9275b05ab96556fefff73a385813eb66032e4c99f411d0795372d9abcea/rpds_py-0.30.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a4796a717bf12b9da9d3ad002519a86063dcac8988b030e405704ef7d74d2d9d", size = 422799, upload-time = "2025-11-30T20:22:53.341Z" },
-    { url = "https://files.pythonhosted.org/packages/06/c1/3088fc04b6624eb12a57eb814f0d4997a44b0d208d6cace713033ff1a6ba/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5d4c2aa7c50ad4728a094ebd5eb46c452e9cb7edbfdb18f9e1221f597a73e1e7", size = 572731, upload-time = "2025-11-30T20:22:54.778Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/42/c612a833183b39774e8ac8fecae81263a68b9583ee343db33ab571a7ce55/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ba81a9203d07805435eb06f536d95a266c21e5b2dfbf6517748ca40c98d19e31", size = 599027, upload-time = "2025-11-30T20:22:56.212Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/60/525a50f45b01d70005403ae0e25f43c0384369ad24ffe46e8d9068b50086/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:945dccface01af02675628334f7cf49c2af4c1c904748efc5cf7bbdf0b579f95", size = 563020, upload-time = "2025-11-30T20:22:58.2Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/5d/47c4655e9bcd5ca907148535c10e7d489044243cc9941c16ed7cd53be91d/rpds_py-0.30.0-cp313-cp313-win32.whl", hash = "sha256:b40fb160a2db369a194cb27943582b38f79fc4887291417685f3ad693c5a1d5d", size = 223139, upload-time = "2025-11-30T20:23:00.209Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/e1/485132437d20aa4d3e1d8b3fb5a5e65aa8139f1e097080c2a8443201742c/rpds_py-0.30.0-cp313-cp313-win_amd64.whl", hash = "sha256:806f36b1b605e2d6a72716f321f20036b9489d29c51c91f4dd29a3e3afb73b15", size = 240224, upload-time = "2025-11-30T20:23:02.008Z" },
-    { url = "https://files.pythonhosted.org/packages/24/95/ffd128ed1146a153d928617b0ef673960130be0009c77d8fbf0abe306713/rpds_py-0.30.0-cp313-cp313-win_arm64.whl", hash = "sha256:d96c2086587c7c30d44f31f42eae4eac89b60dabbac18c7669be3700f13c3ce1", size = 230645, upload-time = "2025-11-30T20:23:03.43Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/1b/b10de890a0def2a319a2626334a7f0ae388215eb60914dbac8a3bae54435/rpds_py-0.30.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:eb0b93f2e5c2189ee831ee43f156ed34e2a89a78a66b98cadad955972548be5a", size = 364443, upload-time = "2025-11-30T20:23:04.878Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/bf/27e39f5971dc4f305a4fb9c672ca06f290f7c4e261c568f3dea16a410d47/rpds_py-0.30.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:922e10f31f303c7c920da8981051ff6d8c1a56207dbdf330d9047f6d30b70e5e", size = 353375, upload-time = "2025-11-30T20:23:06.342Z" },
-    { url = "https://files.pythonhosted.org/packages/40/58/442ada3bba6e8e6615fc00483135c14a7538d2ffac30e2d933ccf6852232/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cdc62c8286ba9bf7f47befdcea13ea0e26bf294bda99758fd90535cbaf408000", size = 383850, upload-time = "2025-11-30T20:23:07.825Z" },
-    { url = "https://files.pythonhosted.org/packages/14/14/f59b0127409a33c6ef6f5c1ebd5ad8e32d7861c9c7adfa9a624fc3889f6c/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:47f9a91efc418b54fb8190a6b4aa7813a23fb79c51f4bb84e418f5476c38b8db", size = 392812, upload-time = "2025-11-30T20:23:09.228Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/66/e0be3e162ac299b3a22527e8913767d869e6cc75c46bd844aa43fb81ab62/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1f3587eb9b17f3789ad50824084fa6f81921bbf9a795826570bda82cb3ed91f2", size = 517841, upload-time = "2025-11-30T20:23:11.186Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/55/fa3b9cf31d0c963ecf1ba777f7cf4b2a2c976795ac430d24a1f43d25a6ba/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:39c02563fc592411c2c61d26b6c5fe1e51eaa44a75aa2c8735ca88b0d9599daa", size = 408149, upload-time = "2025-11-30T20:23:12.864Z" },
-    { url = "https://files.pythonhosted.org/packages/60/ca/780cf3b1a32b18c0f05c441958d3758f02544f1d613abf9488cd78876378/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:51a1234d8febafdfd33a42d97da7a43f5dcb120c1060e352a3fbc0c6d36e2083", size = 383843, upload-time = "2025-11-30T20:23:14.638Z" },
-    { url = "https://files.pythonhosted.org/packages/82/86/d5f2e04f2aa6247c613da0c1dd87fcd08fa17107e858193566048a1e2f0a/rpds_py-0.30.0-cp313-cp313t-manylinux_2_31_riscv64.whl", hash = "sha256:eb2c4071ab598733724c08221091e8d80e89064cd472819285a9ab0f24bcedb9", size = 396507, upload-time = "2025-11-30T20:23:16.105Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/9a/453255d2f769fe44e07ea9785c8347edaf867f7026872e76c1ad9f7bed92/rpds_py-0.30.0-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:6bdfdb946967d816e6adf9a3d8201bfad269c67efe6cefd7093ef959683c8de0", size = 414949, upload-time = "2025-11-30T20:23:17.539Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/31/622a86cdc0c45d6df0e9ccb6becdba5074735e7033c20e401a6d9d0e2ca0/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c77afbd5f5250bf27bf516c7c4a016813eb2d3e116139aed0096940c5982da94", size = 565790, upload-time = "2025-11-30T20:23:19.029Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/5d/15bbf0fb4a3f58a3b1c67855ec1efcc4ceaef4e86644665fff03e1b66d8d/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:61046904275472a76c8c90c9ccee9013d70a6d0f73eecefd38c1ae7c39045a08", size = 590217, upload-time = "2025-11-30T20:23:20.885Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/61/21b8c41f68e60c8cc3b2e25644f0e3681926020f11d06ab0b78e3c6bbff1/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:4c5f36a861bc4b7da6516dbdf302c55313afa09b81931e8280361a4f6c9a2d27", size = 555806, upload-time = "2025-11-30T20:23:22.488Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/39/7e067bb06c31de48de3eb200f9fc7c58982a4d3db44b07e73963e10d3be9/rpds_py-0.30.0-cp313-cp313t-win32.whl", hash = "sha256:3d4a69de7a3e50ffc214ae16d79d8fbb0922972da0356dcf4d0fdca2878559c6", size = 211341, upload-time = "2025-11-30T20:23:24.449Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/4d/222ef0b46443cf4cf46764d9c630f3fe4abaa7245be9417e56e9f52b8f65/rpds_py-0.30.0-cp313-cp313t-win_amd64.whl", hash = "sha256:f14fc5df50a716f7ece6a80b6c78bb35ea2ca47c499e422aa4463455dd96d56d", size = 225768, upload-time = "2025-11-30T20:23:25.908Z" },
-    { url = "https://files.pythonhosted.org/packages/86/81/dad16382ebbd3d0e0328776d8fd7ca94220e4fa0798d1dc5e7da48cb3201/rpds_py-0.30.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:68f19c879420aa08f61203801423f6cd5ac5f0ac4ac82a2368a9fcd6a9a075e0", size = 362099, upload-time = "2025-11-30T20:23:27.316Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/60/19f7884db5d5603edf3c6bce35408f45ad3e97e10007df0e17dd57af18f8/rpds_py-0.30.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ec7c4490c672c1a0389d319b3a9cfcd098dcdc4783991553c332a15acf7249be", size = 353192, upload-time = "2025-11-30T20:23:29.151Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/c4/76eb0e1e72d1a9c4703c69607cec123c29028bff28ce41588792417098ac/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f251c812357a3fed308d684a5079ddfb9d933860fc6de89f2b7ab00da481e65f", size = 384080, upload-time = "2025-11-30T20:23:30.785Z" },
-    { url = "https://files.pythonhosted.org/packages/72/87/87ea665e92f3298d1b26d78814721dc39ed8d2c74b86e83348d6b48a6f31/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ac98b175585ecf4c0348fd7b29c3864bda53b805c773cbf7bfdaffc8070c976f", size = 394841, upload-time = "2025-11-30T20:23:32.209Z" },
-    { url = "https://files.pythonhosted.org/packages/77/ad/7783a89ca0587c15dcbf139b4a8364a872a25f861bdb88ed99f9b0dec985/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3e62880792319dbeb7eb866547f2e35973289e7d5696c6e295476448f5b63c87", size = 516670, upload-time = "2025-11-30T20:23:33.742Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/3c/2882bdac942bd2172f3da574eab16f309ae10a3925644e969536553cb4ee/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4e7fc54e0900ab35d041b0601431b0a0eb495f0851a0639b6ef90f7741b39a18", size = 408005, upload-time = "2025-11-30T20:23:35.253Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/81/9a91c0111ce1758c92516a3e44776920b579d9a7c09b2b06b642d4de3f0f/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47e77dc9822d3ad616c3d5759ea5631a75e5809d5a28707744ef79d7a1bcfcad", size = 382112, upload-time = "2025-11-30T20:23:36.842Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/8e/1da49d4a107027e5fbc64daeab96a0706361a2918da10cb41769244b805d/rpds_py-0.30.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:b4dc1a6ff022ff85ecafef7979a2c6eb423430e05f1165d6688234e62ba99a07", size = 399049, upload-time = "2025-11-30T20:23:38.343Z" },
-    { url = "https://files.pythonhosted.org/packages/df/5a/7ee239b1aa48a127570ec03becbb29c9d5a9eb092febbd1699d567cae859/rpds_py-0.30.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4559c972db3a360808309e06a74628b95eaccbf961c335c8fe0d590cf587456f", size = 415661, upload-time = "2025-11-30T20:23:40.263Z" },
-    { url = "https://files.pythonhosted.org/packages/70/ea/caa143cf6b772f823bc7929a45da1fa83569ee49b11d18d0ada7f5ee6fd6/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:0ed177ed9bded28f8deb6ab40c183cd1192aa0de40c12f38be4d59cd33cb5c65", size = 565606, upload-time = "2025-11-30T20:23:42.186Z" },
-    { url = "https://files.pythonhosted.org/packages/64/91/ac20ba2d69303f961ad8cf55bf7dbdb4763f627291ba3d0d7d67333cced9/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ad1fa8db769b76ea911cb4e10f049d80bf518c104f15b3edb2371cc65375c46f", size = 591126, upload-time = "2025-11-30T20:23:44.086Z" },
-    { url = "https://files.pythonhosted.org/packages/21/20/7ff5f3c8b00c8a95f75985128c26ba44503fb35b8e0259d812766ea966c7/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:46e83c697b1f1c72b50e5ee5adb4353eef7406fb3f2043d64c33f20ad1c2fc53", size = 553371, upload-time = "2025-11-30T20:23:46.004Z" },
-    { url = "https://files.pythonhosted.org/packages/72/c7/81dadd7b27c8ee391c132a6b192111ca58d866577ce2d9b0ca157552cce0/rpds_py-0.30.0-cp314-cp314-win32.whl", hash = "sha256:ee454b2a007d57363c2dfd5b6ca4a5d7e2c518938f8ed3b706e37e5d470801ed", size = 215298, upload-time = "2025-11-30T20:23:47.696Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/d2/1aaac33287e8cfb07aab2e6b8ac1deca62f6f65411344f1433c55e6f3eb8/rpds_py-0.30.0-cp314-cp314-win_amd64.whl", hash = "sha256:95f0802447ac2d10bcc69f6dc28fe95fdf17940367b21d34e34c737870758950", size = 228604, upload-time = "2025-11-30T20:23:49.501Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/95/ab005315818cc519ad074cb7784dae60d939163108bd2b394e60dc7b5461/rpds_py-0.30.0-cp314-cp314-win_arm64.whl", hash = "sha256:613aa4771c99f03346e54c3f038e4cc574ac09a3ddfb0e8878487335e96dead6", size = 222391, upload-time = "2025-11-30T20:23:50.96Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/68/154fe0194d83b973cdedcdcc88947a2752411165930182ae41d983dcefa6/rpds_py-0.30.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:7e6ecfcb62edfd632e56983964e6884851786443739dbfe3582947e87274f7cb", size = 364868, upload-time = "2025-11-30T20:23:52.494Z" },
-    { url = "https://files.pythonhosted.org/packages/83/69/8bbc8b07ec854d92a8b75668c24d2abcb1719ebf890f5604c61c9369a16f/rpds_py-0.30.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a1d0bc22a7cdc173fedebb73ef81e07faef93692b8c1ad3733b67e31e1b6e1b8", size = 353747, upload-time = "2025-11-30T20:23:54.036Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/00/ba2e50183dbd9abcce9497fa5149c62b4ff3e22d338a30d690f9af970561/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0d08f00679177226c4cb8c5265012eea897c8ca3b93f429e546600c971bcbae7", size = 383795, upload-time = "2025-11-30T20:23:55.556Z" },
-    { url = "https://files.pythonhosted.org/packages/05/6f/86f0272b84926bcb0e4c972262f54223e8ecc556b3224d281e6598fc9268/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5965af57d5848192c13534f90f9dd16464f3c37aaf166cc1da1cae1fd5a34898", size = 393330, upload-time = "2025-11-30T20:23:57.033Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/e9/0e02bb2e6dc63d212641da45df2b0bf29699d01715913e0d0f017ee29438/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9a4e86e34e9ab6b667c27f3211ca48f73dba7cd3d90f8d5b11be56e5dbc3fb4e", size = 518194, upload-time = "2025-11-30T20:23:58.637Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/ca/be7bca14cf21513bdf9c0606aba17d1f389ea2b6987035eb4f62bd923f25/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e5d3e6b26f2c785d65cc25ef1e5267ccbe1b069c5c21b8cc724efee290554419", size = 408340, upload-time = "2025-11-30T20:24:00.2Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/c7/736e00ebf39ed81d75544c0da6ef7b0998f8201b369acf842f9a90dc8fce/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:626a7433c34566535b6e56a1b39a7b17ba961e97ce3b80ec62e6f1312c025551", size = 383765, upload-time = "2025-11-30T20:24:01.759Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/3f/da50dfde9956aaf365c4adc9533b100008ed31aea635f2b8d7b627e25b49/rpds_py-0.30.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:acd7eb3f4471577b9b5a41baf02a978e8bdeb08b4b355273994f8b87032000a8", size = 396834, upload-time = "2025-11-30T20:24:03.687Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/00/34bcc2565b6020eab2623349efbdec810676ad571995911f1abdae62a3a0/rpds_py-0.30.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fe5fa731a1fa8a0a56b0977413f8cacac1768dad38d16b3a296712709476fbd5", size = 415470, upload-time = "2025-11-30T20:24:05.232Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/28/882e72b5b3e6f718d5453bd4d0d9cf8df36fddeb4ddbbab17869d5868616/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:74a3243a411126362712ee1524dfc90c650a503502f135d54d1b352bd01f2404", size = 565630, upload-time = "2025-11-30T20:24:06.878Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/97/04a65539c17692de5b85c6e293520fd01317fd878ea1995f0367d4532fb1/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:3e8eeb0544f2eb0d2581774be4c3410356eba189529a6b3e36bbbf9696175856", size = 591148, upload-time = "2025-11-30T20:24:08.445Z" },
-    { url = "https://files.pythonhosted.org/packages/85/70/92482ccffb96f5441aab93e26c4d66489eb599efdcf96fad90c14bbfb976/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:dbd936cde57abfee19ab3213cf9c26be06d60750e60a8e4dd85d1ab12c8b1f40", size = 556030, upload-time = "2025-11-30T20:24:10.956Z" },
-    { url = "https://files.pythonhosted.org/packages/20/53/7c7e784abfa500a2b6b583b147ee4bb5a2b3747a9166bab52fec4b5b5e7d/rpds_py-0.30.0-cp314-cp314t-win32.whl", hash = "sha256:dc824125c72246d924f7f796b4f63c1e9dc810c7d9e2355864b3c3a73d59ade0", size = 211570, upload-time = "2025-11-30T20:24:12.735Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/02/fa464cdfbe6b26e0600b62c528b72d8608f5cc49f96b8d6e38c95d60c676/rpds_py-0.30.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27f4b0e92de5bfbc6f86e43959e6edd1425c33b5e69aab0984a72047f2bcf1e3", size = 226532, upload-time = "2025-11-30T20:24:14.634Z" },
-    { url = "https://files.pythonhosted.org/packages/69/71/3f34339ee70521864411f8b6992e7ab13ac30d8e4e3309e07c7361767d91/rpds_py-0.30.0-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:c2262bdba0ad4fc6fb5545660673925c2d2a5d9e2e0fb603aad545427be0fc58", size = 372292, upload-time = "2025-11-30T20:24:16.537Z" },
-    { url = "https://files.pythonhosted.org/packages/57/09/f183df9b8f2d66720d2ef71075c59f7e1b336bec7ee4c48f0a2b06857653/rpds_py-0.30.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:ee6af14263f25eedc3bb918a3c04245106a42dfd4f5c2285ea6f997b1fc3f89a", size = 362128, upload-time = "2025-11-30T20:24:18.086Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/68/5c2594e937253457342e078f0cc1ded3dd7b2ad59afdbf2d354869110a02/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3adbb8179ce342d235c31ab8ec511e66c73faa27a47e076ccc92421add53e2bb", size = 391542, upload-time = "2025-11-30T20:24:20.092Z" },
-    { url = "https://files.pythonhosted.org/packages/49/5c/31ef1afd70b4b4fbdb2800249f34c57c64beb687495b10aec0365f53dfc4/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:250fa00e9543ac9b97ac258bd37367ff5256666122c2d0f2bc97577c60a1818c", size = 404004, upload-time = "2025-11-30T20:24:22.231Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/63/0cfbea38d05756f3440ce6534d51a491d26176ac045e2707adc99bb6e60a/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9854cf4f488b3d57b9aaeb105f06d78e5529d3145b1e4a41750167e8c213c6d3", size = 527063, upload-time = "2025-11-30T20:24:24.302Z" },
-    { url = "https://files.pythonhosted.org/packages/42/e6/01e1f72a2456678b0f618fc9a1a13f882061690893c192fcad9f2926553a/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:993914b8e560023bc0a8bf742c5f303551992dcb85e247b1e5c7f4a7d145bda5", size = 413099, upload-time = "2025-11-30T20:24:25.916Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/25/8df56677f209003dcbb180765520c544525e3ef21ea72279c98b9aa7c7fb/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58edca431fb9b29950807e301826586e5bbf24163677732429770a697ffe6738", size = 392177, upload-time = "2025-11-30T20:24:27.834Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/b4/0a771378c5f16f8115f796d1f437950158679bcd2a7c68cf251cfb00ed5b/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_31_riscv64.whl", hash = "sha256:dea5b552272a944763b34394d04577cf0f9bd013207bc32323b5a89a53cf9c2f", size = 406015, upload-time = "2025-11-30T20:24:29.457Z" },
-    { url = "https://files.pythonhosted.org/packages/36/d8/456dbba0af75049dc6f63ff295a2f92766b9d521fa00de67a2bd6427d57a/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ba3af48635eb83d03f6c9735dfb21785303e73d22ad03d489e88adae6eab8877", size = 423736, upload-time = "2025-11-30T20:24:31.22Z" },
-    { url = "https://files.pythonhosted.org/packages/13/64/b4d76f227d5c45a7e0b796c674fd81b0a6c4fbd48dc29271857d8219571c/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:dff13836529b921e22f15cb099751209a60009731a68519630a24d61f0b1b30a", size = 573981, upload-time = "2025-11-30T20:24:32.934Z" },
-    { url = "https://files.pythonhosted.org/packages/20/91/092bacadeda3edf92bf743cc96a7be133e13a39cdbfd7b5082e7ab638406/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:1b151685b23929ab7beec71080a8889d4d6d9fa9a983d213f07121205d48e2c4", size = 599782, upload-time = "2025-11-30T20:24:35.169Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/b7/b95708304cd49b7b6f82fdd039f1748b66ec2b21d6a45180910802f1abf1/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:ac37f9f516c51e5753f27dfdef11a88330f04de2d564be3991384b2f3535d02e", size = 562191, upload-time = "2025-11-30T20:24:36.853Z" },
-]
-
-[[package]]
-name = "rpds-py"
 version = "2026.6.3"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.15'",
-    "python_full_version == '3.14.*' and sys_platform == 'win32'",
-    "python_full_version == '3.14.*' and sys_platform != 'win32'",
-    "python_full_version == '3.13.*' and sys_platform == 'win32'",
-    "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform == 'win32'",
-    "python_full_version == '3.13.*' and sys_platform != 'win32'",
-    "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform != 'win32'",
-]
 sdist = { url = "https://files.pythonhosted.org/packages/aa/2a/9618a122aeb2a169a28b03889a2995fe297588964333d4a7d67bdf46e147/rpds_py-2026.6.3.tar.gz", hash = "sha256:1cebd1337c242e4ec2293e541f712b2da849b29f48f0c293684b71c0632625d4", size = 64051, upload-time = "2026-06-30T07:17:53.009Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/94/1f/a2dca5ffdbf1d475ffc4e80e4d5d720ff3a00f691795910116960ee12511/rpds_py-2026.6.3-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:7b689145a1485c335569bd056464f3243a29af7ed3871c7be31ad624ba239bc7", size = 342174, upload-time = "2026-06-30T07:14:54.821Z" },
@@ -2569,6 +2373,15 @@ wheels = [
 ]
 
 [[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2703,6 +2516,21 @@ wheels = [
 ]
 
 [[package]]
+name = "typer"
+version = "0.27.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "rich" },
+    { name = "shellingham" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/40/4a3db7990d1f62a53182aa96eaef57aeb2886a27f90a195bc66713565d31/typer-0.27.1.tar.gz", hash = "sha256:a79bef8469a79c45498e7b814ecf8d603cc7644e9acbd9e19cac0334240b18df", size = 203994, upload-time = "2026-08-03T14:41:03.438Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/89/9518bc0c3929bee36b3a4a8e3daddd6e03f92f9961c66d4983b837160543/typer-0.27.1-py3-none-any.whl", hash = "sha256:53150287edd11baeb4e4722c8e394fcdf8181c0ae89485cba8d25c778d5edd56", size = 122874, upload-time = "2026-08-03T14:41:04.391Z" },
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2746,11 +2574,11 @@ wheels = [
 
 [[package]]
 name = "uncalled-for"
-version = "0.3.2"
+version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b5/82/345cc927f7fbdae6065e7768759932fcc827fc20b29b45dfbafa2f1f7da4/uncalled_for-0.3.2.tar.gz", hash = "sha256:89f5dbcd71e2b8f47c030b1fa302e6cce2ec795d1ac565eeb6525c5fe55cb8a2", size = 50032, upload-time = "2026-05-06T13:38:25.204Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6b/5a/92ce0b3ea5481915f55da994c2c2c5f7a3c09949afde196ee89f8ab961aa/uncalled_for-0.4.0.tar.gz", hash = "sha256:335b95bd2422332ec210d518f314a16e4c640921c39fc8bf2ad095bd3538f4af", size = 56979, upload-time = "2026-08-10T14:51:46.247Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/25/2c87754f3a9e692315f7b811244090e68f362979fc8886b3fbd2985a1d8c/uncalled_for-0.3.2-py3-none-any.whl", hash = "sha256:0ff60b142c7d1f8070bde9d42afaa70aedc77dcc10998c227687e9c15713418e", size = 11444, upload-time = "2026-05-06T13:38:24.025Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/40/97cec87c077eb3291fc7905e6633e08b7ca593c57d30238444bcb6bb3d53/uncalled_for-0.4.0-py3-none-any.whl", hash = "sha256:16c4bb3337532e4bd5569adc192285976f3ad5305402256d34c67a12b5c968bd", size = 15502, upload-time = "2026-08-10T14:51:45.068Z" },
 ]
 
 [[package]]
@@ -2769,7 +2597,6 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "h11" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a2/65/b7c6c443ccc58678c91e1e973bbe2a878591538655d6e1d47f24ba1c51f3/uvicorn-0.51.0.tar.gz", hash = "sha256:f6f4b69b657c312f516dd2d268ab9ae6f254b11e4bac504f37b2ab58b24dd0b0", size = 94412, upload-time = "2026-07-08T10:59:05.962Z" }
 wheels = [
@@ -2785,19 +2612,6 @@ dependencies = [
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cd/41/5e1a4bb12aac5f1493fa1bdc11154eca3b258ca4eba65d39c473fe19d8e9/watchfiles-1.2.0.tar.gz", hash = "sha256:c995fba777f1ea992f090f9236e9284cf7a5d1a0130dd5a3d82c598cacd76838", size = 108252, upload-time = "2026-05-18T04:32:04.251Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0d/5a/2bf22ecb24916983bf1cc0095e7dea2741d14d6553b0d6a2ac8bc96eca93/watchfiles-1.2.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:bb68bf4df85abebe5efddc53cf2075520f243a59868d9b3973278b23e76962a9", size = 400471, upload-time = "2026-05-18T04:31:08.908Z" },
-    { url = "https://files.pythonhosted.org/packages/55/70/dea1f6a0e76607841a60fb51af150e70124864673f61704abb62b90cdcc7/watchfiles-1.2.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c16cb06dd17d43b9d185094268459eac92c9538356f050e55b54e82cf700e1d4", size = 394599, upload-time = "2026-05-18T04:30:19.845Z" },
-    { url = "https://files.pythonhosted.org/packages/18/52/752dcc7dc817baef5e89518732925795ce52e36a683a9a3c9fb68b21504e/watchfiles-1.2.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:77a0feab9af4c021c581f695258c642b3d10c5fd4c676e33a0d8606425d82631", size = 455458, upload-time = "2026-05-18T04:30:29.126Z" },
-    { url = "https://files.pythonhosted.org/packages/12/48/366ebbb22fcc504c2f72b45f0b7e72f40a18795cc01752c16066d597b67a/watchfiles-1.2.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a16ffe19bf5cf9f5edaa1ad1dd830c5a816e8feec430c522302ab55483a4b994", size = 460513, upload-time = "2026-05-18T04:31:40.85Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/44/1f9e1b15e7a729062e0d0c3d0d7225ea4ab98b2267ef87287153be2495fc/watchfiles-1.2.0-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:204f299afcbd65918ab78dbc52626b0ae45e9d8cef403fdbf33ecf9e40eac66e", size = 493616, upload-time = "2026-05-18T04:30:58.47Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/55/8b1086dcc8a1d6a697a62767bd7ea368e74c61c6fd171683cfe24a3fe5d2/watchfiles-1.2.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:11743adfa510bfffebe97659fb280182b5c9b238708f667e866f308c3430dc19", size = 573154, upload-time = "2026-05-18T04:30:37.903Z" },
-    { url = "https://files.pythonhosted.org/packages/14/7a/242f400cc77fafa7b18d53d19d9cb64fc6a6f61f28c55913bae7c674d92a/watchfiles-1.2.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:eb72919d93e3a16fc451d3aa3d4b1698423daca1b382d3d959c9ac51297c12a8", size = 467046, upload-time = "2026-05-18T04:30:41.869Z" },
-    { url = "https://files.pythonhosted.org/packages/02/c8/79eee650c62d2c186598489814468e389b5def0ebe755399ff645b35b1b2/watchfiles-1.2.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b62f042afde2dde21ec1d2c1a74361e804673df86f51e418a999c9acfe671b07", size = 457100, upload-time = "2026-05-18T04:31:13.064Z" },
-    { url = "https://files.pythonhosted.org/packages/81/36/519f6dbb7a95e4fe7c1513ed25b1520295ef9905a27f1f2226a73892bfb7/watchfiles-1.2.0-cp310-cp310-manylinux_2_31_riscv64.whl", hash = "sha256:027ae72bfdfd254862065d8b3e2a815c6ab9b1853ce41e6648ece84afd34a551", size = 467038, upload-time = "2026-05-18T04:30:32.915Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/12/951af6b9f89097e02511122258402cb3578443021930b70cf968d6310dc0/watchfiles-1.2.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:e1cfd51e97e13ff3bd047c140764d277fc9b95b7cb5da59e46a47d167adab310", size = 632563, upload-time = "2026-05-18T04:30:11.539Z" },
-    { url = "https://files.pythonhosted.org/packages/28/cc/0cba1f0a6117b7ec117271bdc3cb3a5a252005959755a2c09a745e0942cc/watchfiles-1.2.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:24b2405c0a46738dd9e1cf7135aa5dbdb9d42d024628651b3b13d5117e99f8df", size = 660851, upload-time = "2026-05-18T04:31:53.186Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/f2/26347558cc8bf6877845e66b315f644d03c173906aa09e233a3f4fd23928/watchfiles-1.2.0-cp310-cp310-win32.whl", hash = "sha256:8c520725602756229f045b032a1ff33d7ef0f7404189d62f6c2438cb6d8ef6a1", size = 277023, upload-time = "2026-05-18T04:30:18.825Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/68/a5e67b6b68e94f4c1511d61c46c55eba0737583620b6febf194c7b9cc23f/watchfiles-1.2.0-cp310-cp310-win_amd64.whl", hash = "sha256:03b14855c6f35539e2d95c442ae9530a75762f1e26567152b9ed05f96534a74d", size = 290107, upload-time = "2026-05-18T04:32:09.677Z" },
     { url = "https://files.pythonhosted.org/packages/fc/3d/8024c801df84d1587740d0359e7fdd80afeae3d159011f3d5376dd82f18e/watchfiles-1.2.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:704fd259e332e01f9b9c178f4bce9e49027e5587cc2600eeeaf8e76e1c846201", size = 400242, upload-time = "2026-05-18T04:31:19.014Z" },
     { url = "https://files.pythonhosted.org/packages/87/5b/f4dfd45323e949984a3a7f9dc31d1cbb049921e7d98253488dda72ccdaa9/watchfiles-1.2.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:6543cf55d170003296d185c0af981f3e1311564907e1f4e08671fc7693a890a5", size = 394562, upload-time = "2026-05-18T04:30:08.46Z" },
     { url = "https://files.pythonhosted.org/packages/98/d8/19483ef075d601c409bce8bcbb5c0f81a10876fff870400568f08ce484a1/watchfiles-1.2.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:89d8c2394a065ca86f5d2910ff263ae67c127e1376ccc4f9fc35c71db879f80a", size = 456611, upload-time = "2026-05-18T04:30:45.723Z" },
@@ -2895,12 +2709,13 @@ wheels = [
 
 [[package]]
 name = "web-mcp"
-version = "2.0.0"
+version = "2.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "ddgs" },
-    { name = "fastmcp" },
+    { name = "fastmcp", extra = ["tasks"] },
     { name = "httpx" },
+    { name = "platformdirs" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "python-dotenv" },
@@ -2921,8 +2736,9 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "ddgs", specifier = ">=6.0" },
-    { name = "fastmcp", specifier = ">=4.0.0b1" },
+    { name = "fastmcp", extras = ["tasks"], specifier = ">=4.0.0b3,<5" },
     { name = "httpx", specifier = ">=0.27.0" },
+    { name = "platformdirs", specifier = ">=4.0" },
     { name = "pydantic", specifier = ">=2.5" },
     { name = "pydantic-settings", specifier = ">=2.6" },
     { name = "python-dotenv", specifier = ">=1.0" },
@@ -2946,23 +2762,6 @@ version = "16.1.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/21/f7/bc3a25c5ec26ce62ce487690becc2f3710bbc7b33338f005ad390db0b986/websockets-16.1.1.tar.gz", hash = "sha256:db234eda965dcce15df96bb9709f587cd87d4d52aaf0e80e2f34ec04c7670c57", size = 182204, upload-time = "2026-07-17T22:51:05.858Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/08/e7/d1671fb984f9dd844e1da5288070c7c23c9eaba3082d3871aae19c3ab8b9/websockets-16.1.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:49ae99bdfcae803a885c926bf14f886196e84925395bb3f568fef5c0f0979d7d", size = 179570, upload-time = "2026-07-17T22:48:24.032Z" },
-    { url = "https://files.pythonhosted.org/packages/99/f5/70df723bf571f5e0b1b845e0a4ff1c966eeb84f667599fc251caa37d15a3/websockets-16.1.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:5bfd1ac19b1b9986a9c95a82d5e23a391ebb09e12c34d7be6094b86efcc35731", size = 177252, upload-time = "2026-07-17T22:48:25.775Z" },
-    { url = "https://files.pythonhosted.org/packages/90/72/2f14b2e167170b8bf1c8bb7f9b0d78000f470d41a2085a91f33e3917b6c9/websockets-16.1.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9246a0d063cfcbcc85f2359dd6876d681213f4790832272aa16641b4ed5d64d4", size = 177530, upload-time = "2026-07-17T22:48:27.337Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/18/a17e2f0cde02dc10154c808deed7e1d8528afff93612f70d3f0a5b19b011/websockets-16.1.1-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:1214e673c404684b9bf7154f5cf43b45025b1a6160fac3a9e438e9c1a97e22cb", size = 186038, upload-time = "2026-07-17T22:48:28.756Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/b0/41de283899cf5929d637b72a508cdbc9aa40dc0f317c6b77613fd1000488/websockets-16.1.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:90001d893bc368e302ef168d82130b4e4fdd27b85fa094682df9b667c2d48838", size = 187278, upload-time = "2026-07-17T22:48:30.328Z" },
-    { url = "https://files.pythonhosted.org/packages/50/61/874aab5257e027f9f61b5004cec65e592babca7942b1bc09f38e72b7f1fd/websockets-16.1.1-cp310-cp310-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:130937b167a52af203c8d58e78d67705874e82759862e3b9671a452fec4abc87", size = 189936, upload-time = "2026-07-17T22:48:31.896Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/1a/42173913ac5519607220849ed417c864d77384e4119f06dbba964a50f096/websockets-16.1.1-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9c9f23004a3d40e89c01a7955d186a6cc83418d93b749701944ce2de3e95a1f3", size = 187796, upload-time = "2026-07-17T22:48:33.344Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/f4/37c1840bd89b529479aec41470b97b7c683b107ca90b6399ac5afb99dedf/websockets-16.1.1-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f55f0b01956a094c8587146d9558c91937e78789c333860ffaf35931a6e5dbc4", size = 186481, upload-time = "2026-07-17T22:48:34.843Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/70/652d9b964adcfbeb056f42e0ca6bece34d108fe75534e74df20643cae199/websockets-16.1.1-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:6aaface73b9c71974c6497366d8b9628357f6c9749e09c4ea3610176c63f2ae3", size = 184351, upload-time = "2026-07-17T22:48:36.307Z" },
-    { url = "https://files.pythonhosted.org/packages/13/f1/af3850e5d48d482921985be72ebcb169c6180b3a77b57bd612deebcee23b/websockets-16.1.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:dc0fad4933f427acd5b1cec210f3ea6dce7089e1724e4b9ec6ef47c6c04d1b3b", size = 186791, upload-time = "2026-07-17T22:48:37.762Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/40/1a4e3ed4969ec378dcad337e5f1472c5e292cb3e733bc392f0dc2e230abd/websockets-16.1.1-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:f2769a0344a09e9ccf5b3cce538bc75a51b53eff3275d3896310c8552049195d", size = 185413, upload-time = "2026-07-17T22:48:39.127Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/3e/4e3fa1afe8f1a6a780434cd9ba8eb422632b044eff3dd73f6af67523c147/websockets-16.1.1-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:f70541f3104339f59f830522d94ebadb1bf47426287381623443d8bb1cdbf33d", size = 187178, upload-time = "2026-07-17T22:48:40.676Z" },
-    { url = "https://files.pythonhosted.org/packages/71/ab/dd742766aa5dda7f349be0de49e4d565b84cf6f7f7fa02e07692f0f2bdd9/websockets-16.1.1-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:dc385593a42e31cd6fb60c19f0ecb015b386603818fc2c6c274fb42bd2bb4165", size = 185051, upload-time = "2026-07-17T22:48:42.098Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/f5/76438c6560f416f1c0a7f587679fb97cc6e99ed336011d43ce2002dd27c1/websockets-16.1.1-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:387e8e4aa5df2f90b198fa3cad3478822a89cf905b6a6d6c97dc3664689640cc", size = 185846, upload-time = "2026-07-17T22:48:43.472Z" },
-    { url = "https://files.pythonhosted.org/packages/62/12/5c0320f2127823d27b2d56d611d31b0b284ad4edcb41364d66bf4c92b537/websockets-16.1.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:fd46fff7eb62c24804d234f0051c7a8ea81285ad63e0337d3dcf33ca82aee58a", size = 186066, upload-time = "2026-07-17T22:48:44.884Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/97/875986b857b955c3f9dd192cb8a1af81254dfb2ea22cc9590f0a1e020b8b/websockets-16.1.1-cp310-cp310-win32.whl", hash = "sha256:7883388947767080f094950b342b30d35a2a06b849cd967c422fa0db72b40ea9", size = 179940, upload-time = "2026-07-17T22:48:46.481Z" },
-    { url = "https://files.pythonhosted.org/packages/54/82/1013a5fe7ddae8e102bc3b4b39db81d8d28fd02100a324ce6ede8cd832b1/websockets-16.1.1-cp310-cp310-win_amd64.whl", hash = "sha256:d57685547e0060cc6fd90ee6a28405d6bd395e525545f13c8d7cd99c78afd79f", size = 180239, upload-time = "2026-07-17T22:48:48.043Z" },
     { url = "https://files.pythonhosted.org/packages/2b/03/47debfe28e9d6d354be5d777b67fd44c359b9eb299a5d103500bd7cc3e37/websockets-16.1.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:d0fcf657e9f13ff4b177960ab2200237b12994232dfb6df16f1cfe1d4339f93c", size = 179566, upload-time = "2026-07-17T22:48:49.596Z" },
     { url = "https://files.pythonhosted.org/packages/72/93/31efa1ed78c17e5cfc229fd449e3966e1b9cc15753204cd585cc8dd01f4a/websockets-16.1.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b852788aa51764e2d8e4cf5493d559326bcae5e38d16ba25ffa322b034df272a", size = 177250, upload-time = "2026-07-17T22:48:50.942Z" },
     { url = "https://files.pythonhosted.org/packages/01/4a/542378ab3972b0c1cf1df3df3eff9591cea0d30c58c3aa3c4ddbc244e787/websockets-16.1.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1427fb4cf0d72f66333e2cacc3ff5f575bf2d7008166ce991a4a470b21d51a22", size = 177528, upload-time = "2026-07-17T22:48:52.59Z" },

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "clio-kit",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "mcpServers": {
     "clio-adios": {
       "command": "clio-kit",

--- a/mcp-server-versions.toml
+++ b/mcp-server-versions.toml
@@ -13,7 +13,7 @@ publish = ["web"]
 # Generated website metadata must not depend on the wall clock. Advance this
 # date intentionally whenever current contract metadata is regenerated.
 [documentation]
-updated = "2026-08-13"
+updated = "2026-08-18"
 
 # MCP Registry server versions describe each agent-facing contract. They are
 # intentionally independent of the clio-kit PyPI distribution version, which
@@ -42,4 +42,4 @@ seismic = "2.2.3"
 slurm = "3.0.0"
 spack = "2.1.0"
 terrain = "2.2.3"
-web = "2.0.0"
+web = "2.1.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "clio-kit"
-version = "2.9.0"
+version = "2.10.0"
 description = "CLIO Kit - MCP Servers, Clients, and Tools for AI Agents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -61,7 +61,7 @@ wheels = [
 
 [[package]]
 name = "clio-kit"
-version = "2.9.0"
+version = "2.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## What changed

- makes `fetch` a required FastMCP/MCP v2 task while keeping `search` synchronous and task-forbidden
- projects backend conversion progress into `tasks/get`, exposes the full ordered log through `fetch_events`, and propagates native task cancellation to the backend
- discovers per-agent Docket/Valkey sessions from one `--remote-url`, with stable local identity and encryption state
- replaces raw transport/conversion exceptions with stage, cause, retryability, conversion ID, and remediation
- splits configuration, task runtime, fetch orchestration, document-service I/O, and search providers into focused modules
- releases clio-kit 2.10.0 and the Web MCP contract 2.1.0 with regenerated manifests

## Why

Document conversion is long-lived work. A fixed request timeout caused first-use model setup to fail and hid useful execution state from agents. MCP tasks let the agent observe progress, retrieve the eventual result, and decide when cancellation is appropriate.

## Validation

- Web MCP: 104 non-integration tests passed; all 3 opt-in live-network tests also passed explicitly with no skips
- clio-kit root suite: 153 passed
- Ruff, Pyright, and mypy passed
- Codecov patch gate passed
- deterministic MCP protocol tests cover working status messages, result retrieval, task-forbidden search, descriptive failures, and backend cancellation propagation
- homelab end-to-end proof observed six distinct progress states, a completed Docling/GROBID conversion, synchronous SearXNG search, and native cancellation with both MCP and backend states `cancelled`