### PR TITLE
fix: avoid blocking launcher cache prune

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "CLIO Kit - MCP Servers for Scientific Computing and HPC",
-    "version": "2.10.0",
+    "version": "2.10.1",
     "pluginRoot": "./clio-kit-mcp-servers"
   },
   "plugins": [

--- a/clio-kit-mcp-servers/adios/server.json
+++ b/clio-kit-mcp-servers/adios/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.10.0",
+      "version": "2.10.1",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/arxiv/server.json
+++ b/clio-kit-mcp-servers/arxiv/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.10.0",
+      "version": "2.10.1",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/chronolog/server.json
+++ b/clio-kit-mcp-servers/chronolog/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.10.0",
+      "version": "2.10.1",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/compression/server.json
+++ b/clio-kit-mcp-servers/compression/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.10.0",
+      "version": "2.10.1",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/darshan/server.json
+++ b/clio-kit-mcp-servers/darshan/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.10.0",
+      "version": "2.10.1",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/geo/server.json
+++ b/clio-kit-mcp-servers/geo/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.10.0",
+      "version": "2.10.1",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/geojson/server.json
+++ b/clio-kit-mcp-servers/geojson/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.10.0",
+      "version": "2.10.1",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/hdf5/server.json
+++ b/clio-kit-mcp-servers/hdf5/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.10.0",
+      "version": "2.10.1",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/jarvis/server.json
+++ b/clio-kit-mcp-servers/jarvis/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.10.0",
+      "version": "2.10.1",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/lmod/server.json
+++ b/clio-kit-mcp-servers/lmod/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.10.0",
+      "version": "2.10.1",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/ndp/server.json
+++ b/clio-kit-mcp-servers/ndp/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.10.0",
+      "version": "2.10.1",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/node-hardware/server.json
+++ b/clio-kit-mcp-servers/node-hardware/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.10.0",
+      "version": "2.10.1",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/pandas/server.json
+++ b/clio-kit-mcp-servers/pandas/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.10.0",
+      "version": "2.10.1",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/parallel-sort/server.json
+++ b/clio-kit-mcp-servers/parallel-sort/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.10.0",
+      "version": "2.10.1",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/paraview/server.json
+++ b/clio-kit-mcp-servers/paraview/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.10.0",
+      "version": "2.10.1",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/parquet/server.json
+++ b/clio-kit-mcp-servers/parquet/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.10.0",
+      "version": "2.10.1",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/plot/server.json
+++ b/clio-kit-mcp-servers/plot/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.10.0",
+      "version": "2.10.1",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/sac/server.json
+++ b/clio-kit-mcp-servers/sac/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.10.0",
+      "version": "2.10.1",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/scientific-catalog/server.json
+++ b/clio-kit-mcp-servers/scientific-catalog/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.10.0",
+      "version": "2.10.1",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/seismic/server.json
+++ b/clio-kit-mcp-servers/seismic/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.10.0",
+      "version": "2.10.1",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/slurm/server.json
+++ b/clio-kit-mcp-servers/slurm/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.10.0",
+      "version": "2.10.1",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/spack/server.json
+++ b/clio-kit-mcp-servers/spack/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.10.0",
+      "version": "2.10.1",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/terrain/server.json
+++ b/clio-kit-mcp-servers/terrain/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.10.0",
+      "version": "2.10.1",
       "transport": {
         "type": "stdio"
       },

--- a/clio-kit-mcp-servers/web/server.json
+++ b/clio-kit-mcp-servers/web/server.json
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "clio-kit",
-      "version": "2.10.0",
+      "version": "2.10.1",
       "transport": {
         "type": "stdio"
       },

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "clio-kit",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "mcpServers": {
     "clio-adios": {
       "command": "clio-kit",

--- a/mcp-server-versions.toml
+++ b/mcp-server-versions.toml
@@ -8,7 +8,7 @@ schema-version = 1
 # change, add it here WITH a real version bump under [servers] in the same
 # PR, then remove it again once published.
 [mcp-registry-release]
-publish = ["web"]
+publish = []
 
 # Generated website metadata must not depend on the wall clock. Advance this
 # date intentionally whenever current contract metadata is regenerated.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "clio-kit"
-version = "2.10.0"
+version = "2.10.1"
 description = "CLIO Kit - MCP Servers, Clients, and Tools for AI Agents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/scripts/check_file_size.py
+++ b/scripts/check_file_size.py
@@ -91,7 +91,6 @@ RATCHET_BASELINE: dict[str, int] = {
     # split this wave.
     "src/clio_kit/__init__.py": 958,
     "src/clio_kit/mcp_contracts.py": 921,
-    "src/clio_kit/env_cache.py": 843,
     "clio-kit-mcp-servers/darshan/src/darshan_mcp/capabilities/darshan_parser.py": 857,
     "clio-kit-mcp-servers/parquet/src/parquet_mcp/capabilities/parquet_handler.py": 839,
     "clio-kit-mcp-servers/node-hardware/src/node_hardware_mcp/mcp_handlers.py": 819,

--- a/src/clio_kit/env_cache.py
+++ b/src/clio_kit/env_cache.py
@@ -34,11 +34,18 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Final
 
+from clio_kit.environment_locks import (
+    ENVIRONMENTS_DIRNAME,
+    LOCKS_DIRNAME,
+    EnvironmentInUseMarker as EnvironmentInUseMarker,
+    environment_in_use as _env_dir_in_use,
+    locks_dir as _locks_dir,
+    other_environment_in_use as _other_environment_in_use,
+)
+
 CACHE_EVENT_SCHEMA: Final = "clio-kit.cache-event.v1"
-ENVIRONMENTS_DIRNAME: Final = "mcp-environments"
 PROJECTS_DIRNAME: Final = "mcp-projects"
 UV_CACHE_DIRNAME: Final = "uv-cache"
-LOCKS_DIRNAME: Final = ".locks"
 _ENV_HASH_PREFIX_LENGTH: Final = 24
 _HEX_DIGITS: Final = frozenset("0123456789abcdef")
 
@@ -50,6 +57,7 @@ EVICTION_ENABLED_ENV: Final = "CLIO_KIT_ENV_EVICTION"
 PRUNE_ENABLED_ENV: Final = "CLIO_KIT_UV_CACHE_PRUNE"
 CACHE_MAX_BYTES_ENV: Final = "CLIO_KIT_CACHE_MAX_BYTES"
 _DEFAULT_KEEP_PER_SERVER: Final = 1
+_UV_PRUNE_TIMEOUT_SECONDS: Final = 10.0
 
 EmitEvent = Callable[[Mapping[str, object]], None]
 
@@ -268,12 +276,47 @@ def prune_uv_cache(
             }
         )
         return report
+    if _other_environment_in_use(cache_root):
+        report = PruneReport(
+            ran=False,
+            ok=True,
+            reason="prune_skipped_in_use",
+            cache_dir=str(cache_dir),
+        )
+        emit(
+            {
+                "event": "uv_cache_prune",
+                "ran": False,
+                "ok": True,
+                "reason": report.reason,
+                "cache_dir": report.cache_dir,
+            }
+        )
+        return report
     try:
         completed = run_command(
             [uv_executable, "cache", "prune", "--cache-dir", str(cache_dir)],
             capture_output=True,
             check=False,
+            timeout=_UV_PRUNE_TIMEOUT_SECONDS,
         )
+    except subprocess.TimeoutExpired:
+        report = PruneReport(
+            ran=True,
+            ok=False,
+            reason=f"prune_timeout_{_UV_PRUNE_TIMEOUT_SECONDS:g}s",
+            cache_dir=str(cache_dir),
+        )
+        emit(
+            {
+                "event": "uv_cache_prune",
+                "ran": True,
+                "ok": False,
+                "reason": report.reason,
+                "cache_dir": report.cache_dir,
+            }
+        )
+        return report
     except OSError as exc:
         report = PruneReport(
             ran=True,
@@ -470,44 +513,6 @@ def discover_servers(cache_root: Path) -> set[str]:
     return servers
 
 
-# --- in-use marker -------------------------------------------------------
-
-
-class EnvironmentInUseMarker:
-    """A per-process lock proving a live launcher holds one environment.
-
-    The marker is a lock file named for the holding process id under a locks
-    registry sibling to the environment tree.  Concurrent launches of the same
-    spec never contend, because each locks only its own pid file; a checker
-    detecting *any* pid file it cannot lock knows a live holder exists, while a
-    crashed holder's file is lockable and reclaimed.  The registry lives outside
-    the environment directory so acquiring it never perturbs environment mtimes
-    or the environment contents uv manages.
-    """
-
-    def __init__(self, cache_root: Path, env_dir_name: str) -> None:
-        self._lock_dir = _locks_dir(cache_root, env_dir_name)
-        self._handle: _FileLock | None = None
-
-    def __enter__(self) -> "EnvironmentInUseMarker":
-        try:
-            self._lock_dir.mkdir(parents=True, exist_ok=True)
-            lock_path = self._lock_dir / f"{os.getpid()}.lock"
-            handle = _FileLock(lock_path)
-            handle.acquire()
-            self._handle = handle
-        except OSError:
-            # Best-effort: an unwritable registry must not block a launch. The
-            # current environment is never a deletion candidate regardless.
-            self._handle = None
-        return self
-
-    def __exit__(self, *_exc: object) -> None:
-        if self._handle is not None:
-            self._handle.release()
-            self._handle = None
-
-
 def _identity_in_use(cache_root: Path, identity: _EnvIdentity) -> bool:
     env_dir_name = (
         identity.env_dir.name
@@ -515,84 +520,6 @@ def _identity_in_use(cache_root: Path, identity: _EnvIdentity) -> bool:
         else f"{identity.server}-{identity.hash_prefix}"
     )
     return _env_dir_in_use(cache_root, env_dir_name)
-
-
-def _env_dir_in_use(cache_root: Path, env_dir_name: str) -> bool:
-    """Return whether any live launcher currently holds this environment."""
-    lock_dir = _locks_dir(cache_root, env_dir_name)
-    if not lock_dir.is_dir():
-        return False
-    in_use = False
-    for lock_path in lock_dir.glob("*.lock"):
-        probe = _FileLock(lock_path)
-        if probe.try_acquire():
-            # No live holder: reclaim the stale marker.
-            probe.release()
-            try:
-                lock_path.unlink()
-            except OSError:
-                pass
-        else:
-            in_use = True
-    return in_use
-
-
-def _locks_dir(cache_root: Path, env_dir_name: str) -> Path:
-    return cache_root / ENVIRONMENTS_DIRNAME / LOCKS_DIRNAME / env_dir_name
-
-
-class _FileLock:
-    """A cross-platform advisory lock on a single sentinel file."""
-
-    def __init__(self, path: Path) -> None:
-        self._path = path
-        self._fd: int | None = None
-
-    def acquire(self) -> None:
-        if not self.try_acquire():
-            raise OSError(f"could not acquire lock: {self._path}")
-
-    def try_acquire(self) -> bool:
-        fd = os.open(self._path, os.O_RDWR | os.O_CREAT, 0o644)
-        try:
-            os.write(fd, b"\0")
-            os.lseek(fd, 0, os.SEEK_SET)
-            _lock_region(fd)
-        except OSError:
-            os.close(fd)
-            return False
-        self._fd = fd
-        return True
-
-    def release(self) -> None:
-        if self._fd is None:
-            return
-        try:
-            _unlock_region(self._fd)
-        except OSError:
-            pass
-        finally:
-            os.close(self._fd)
-            self._fd = None
-
-
-if sys.platform == "win32":
-    import msvcrt
-
-    def _lock_region(fd: int) -> None:
-        msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)
-
-    def _unlock_region(fd: int) -> None:
-        os.lseek(fd, 0, os.SEEK_SET)
-        msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
-else:
-    import fcntl
-
-    def _lock_region(fd: int) -> None:
-        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
-
-    def _unlock_region(fd: int) -> None:
-        fcntl.flock(fd, fcntl.LOCK_UN)
 
 
 # --- internals -----------------------------------------------------------

--- a/src/clio_kit/environment_locks.py
+++ b/src/clio_kit/environment_locks.py
@@ -1,0 +1,150 @@
+"""Cross-platform ownership markers for cached MCP environments.
+
+Each launcher holds a per-process advisory lock outside the environment it is
+using. Cache maintenance can therefore distinguish a live environment from a
+stale marker without touching the environment's contents or modification time.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import Final
+
+ENVIRONMENTS_DIRNAME: Final = "mcp-environments"
+LOCKS_DIRNAME: Final = ".locks"
+
+
+class EnvironmentInUseMarker:
+    """Hold a per-process lock proving a live launcher uses one environment."""
+
+    def __init__(self, cache_root: Path, env_dir_name: str) -> None:
+        self._lock_dir = locks_dir(cache_root, env_dir_name)
+        self._handle: _FileLock | None = None
+
+    def __enter__(self) -> "EnvironmentInUseMarker":
+        try:
+            self._lock_dir.mkdir(parents=True, exist_ok=True)
+            lock_path = self._lock_dir / f"{os.getpid()}.lock"
+            handle = _FileLock(lock_path)
+            handle.acquire()
+            self._handle = handle
+        except OSError:
+            # Best-effort: an unwritable registry must not block a launch. The
+            # current environment is never a deletion candidate regardless.
+            self._handle = None
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        if self._handle is not None:
+            self._handle.release()
+            self._handle = None
+
+
+def environment_in_use(cache_root: Path, env_dir_name: str) -> bool:
+    """Return whether any live launcher currently holds this environment."""
+
+    lock_dir = locks_dir(cache_root, env_dir_name)
+    if not lock_dir.is_dir():
+        return False
+    in_use = False
+    for lock_path in lock_dir.glob("*.lock"):
+        probe = _FileLock(lock_path)
+        if probe.try_acquire():
+            probe.release()
+            _remove_stale_marker(lock_path)
+        else:
+            in_use = True
+    return in_use
+
+
+def other_environment_in_use(cache_root: Path) -> bool:
+    """Return whether another live launcher may hold the shared uv cache."""
+
+    locks_root = cache_root / ENVIRONMENTS_DIRNAME / LOCKS_DIRNAME
+    if not locks_root.is_dir():
+        return False
+    own_marker = f"{os.getpid()}.lock"
+    for lock_path in locks_root.glob("*/*.lock"):
+        if lock_path.name == own_marker:
+            continue
+        probe = _FileLock(lock_path)
+        if not probe.try_acquire():
+            return True
+        probe.release()
+        _remove_stale_marker(lock_path)
+    return False
+
+
+def locks_dir(cache_root: Path, env_dir_name: str) -> Path:
+    """Return the lock-registry directory for one cached environment."""
+
+    return cache_root / ENVIRONMENTS_DIRNAME / LOCKS_DIRNAME / env_dir_name
+
+
+def _remove_stale_marker(lock_path: Path) -> None:
+    try:
+        lock_path.unlink()
+    except OSError:
+        pass
+
+
+class _FileLock:
+    """A cross-platform advisory lock on a single sentinel file."""
+
+    def __init__(self, path: Path) -> None:
+        self._path = path
+        self._fd: int | None = None
+
+    def acquire(self) -> None:
+        """Acquire the lock or raise when another process holds it."""
+
+        if not self.try_acquire():
+            raise OSError(f"could not acquire lock: {self._path}")
+
+    def try_acquire(self) -> bool:
+        """Try to acquire the lock without blocking."""
+
+        fd = os.open(self._path, os.O_RDWR | os.O_CREAT, 0o644)
+        try:
+            os.write(fd, b"\0")
+            os.lseek(fd, 0, os.SEEK_SET)
+            _lock_region(fd)
+        except OSError:
+            os.close(fd)
+            return False
+        self._fd = fd
+        return True
+
+    def release(self) -> None:
+        """Release the lock when held."""
+
+        if self._fd is None:
+            return
+        try:
+            _unlock_region(self._fd)
+        except OSError:
+            pass
+        finally:
+            os.close(self._fd)
+            self._fd = None
+
+
+if sys.platform == "win32":
+    import msvcrt
+
+    def _lock_region(fd: int) -> None:
+        msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)
+
+    def _unlock_region(fd: int) -> None:
+        os.lseek(fd, 0, os.SEEK_SET)
+        msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
+else:
+    import fcntl
+
+    def _lock_region(fd: int) -> None:
+        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+
+    def _unlock_region(fd: int) -> None:
+        fcntl.flock(fd, fcntl.LOCK_UN)

--- a/tests/test_env_cache.py
+++ b/tests/test_env_cache.py
@@ -248,6 +248,55 @@ def test_prune_spawn_failure_is_tolerated(tmp_path: Path) -> None:
     assert "prune_spawn_failed" in report.reason
 
 
+def test_prune_skips_while_another_server_environment_is_live(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A live MCP must not make a second launch wait on uv's cache lock."""
+
+    (tmp_path / "uv-cache").mkdir(parents=True)
+    calls: list[list[str]] = []
+    real_pid = os.getpid()
+
+    def fake_run(cmd: list[str], **_kwargs: Any) -> subprocess.CompletedProcess[bytes]:
+        calls.append(cmd)
+        return subprocess.CompletedProcess(cmd, 0, b"", b"")
+
+    with EnvironmentInUseMarker(tmp_path, "adios-" + _HASHES[0][:24]):
+        monkeypatch.setattr(os, "getpid", lambda: real_pid + 1)
+        report = prune_uv_cache(
+            tmp_path,
+            policy=_policy(),
+            uv_executable="uv",
+            emit=lambda _event: None,
+            run=fake_run,
+        )
+
+    assert report.ran is False
+    assert report.reason == "prune_skipped_in_use"
+    assert calls == []
+
+
+def test_prune_timeout_is_tolerated(tmp_path: Path) -> None:
+    """An unmarked uv cache lock cannot delay an MCP launch indefinitely."""
+
+    (tmp_path / "uv-cache").mkdir(parents=True)
+
+    def timing_out_run(cmd: list[str], **kwargs: Any) -> Any:
+        raise subprocess.TimeoutExpired(cmd, kwargs["timeout"])
+
+    report = prune_uv_cache(
+        tmp_path,
+        policy=_policy(),
+        uv_executable="uv",
+        emit=lambda _event: None,
+        run=timing_out_run,
+    )
+
+    assert report.ran is True
+    assert report.ok is False
+    assert report.reason == "prune_timeout_10s"
+
+
 def test_gc_refuses_when_any_environment_is_in_use(tmp_path: Path) -> None:
     """Bulk gc must refuse entirely while any environment is held, deleting none."""
     events, emit = _events_collector()

--- a/tests/test_generate_server_json_contract.py
+++ b/tests/test_generate_server_json_contract.py
@@ -99,7 +99,7 @@ def test_every_committed_server_has_an_agent_runnable_package_coordinate() -> No
     assert manifests == [project / "server.json" for project in projects]
     assert list(expected_server_versions) == sorted(expected_server_versions)
     assert set(expected_server_versions) == {project.name for project in projects}
-    assert publish_servers == ("web",)
+    assert publish_servers == ()
     assert marketplace["metadata"]["version"] == expected_version
     assert set(marketplace_plugins) == set(expected_server_versions)
     assert gemini_extension["version"] == expected_version

--- a/uv.lock
+++ b/uv.lock
@@ -61,7 +61,7 @@ wheels = [
 
 [[package]]
 name = "clio-kit"
-version = "2.10.0"
+version = "2.10.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- skip best-effort `uv cache prune` while another live MCP environment holds the shared cache
- bound any residual prune invocation to 10 seconds and emit the typed `prune_timeout_10s` outcome instead of blocking server startup
- extract cross-platform environment locks into their own owner module, dropping `env_cache.py` from 843 to 770 lines and removing its size-ratchet exception
- prepare the containing `clio-kit` distribution as 2.10.1 without republishing the unchanged Web 2.1.0 MCP Registry contract

## Reproduction and live proof
With the existing Adios MCP process left running, the 2.10.0 launcher blocked indefinitely inside `uv cache prune` on uv's shared cache lock. This branch launched a freshly built Web environment (112 packages), negotiated MCP, and listed `fetch`, `fetch_events`, and `search` in 29.64 seconds. The launcher emitted `uv_cache_prune` with `ran=false`, `ok=true`, and `reason=prune_skipped_in_use`.

## Verification
- `uv run ruff check` on all changed Python files
- `uv run ruff format --check` on all changed Python files
- `uv run mypy src`
- `uv run pyright src/clio_kit tests/test_env_cache.py`
- `uv run pytest tests -q` — 155 passed, 0 skipped
- `uv run python scripts/check_file_size.py`
- `uv lock --check`
- `uv run python scripts/generate_server_json.py clio-kit-mcp-servers` — all 24 manifests and four user contracts generated successfully
- real source-launch concurrency proof against `http://10.0.0.102:8089` with Adios active